### PR TITLE
Rename ENV to ENVIRONMENT to keep naming consistent

### DIFF
--- a/misk/src/main/kotlin/misk/environment/EnvironmentModule.kt
+++ b/misk/src/main/kotlin/misk/environment/EnvironmentModule.kt
@@ -11,15 +11,18 @@ class EnvironmentModule(val environment: Environment) : AbstractModule() {
     }
 
     companion object {
+        private val environmentKey = "ENVIRONMENT"
+
         @JvmStatic
         fun fromEnvironmentVariable(): EnvironmentModule {
-            val environmentName = System.getenv("ENV")
+            val environmentName = System.getenv(environmentKey)
             val environment = if (environmentName != null) {
-                Environment.valueOf(environmentName.toUpperCase())
+                Environment.valueOf(environmentName)
             } else {
-                logger.warn("No ENV variable found, running in DEVELOPMENT")
+                logger.warn { "No environment variable with key $environmentKey found, running in DEVELOPMENT" }
                 Environment.DEVELOPMENT
             }
+            logger.info { "Running with environment ${environment.name}" }
             return EnvironmentModule(environment)
         }
     }


### PR DESCRIPTION
Also doesn't upper case the value of the key, to make sure we don't do anything "magical" for the user. The less layers the better.

Followup to #20 