### PR TITLE
Add health check and liveness endpoints

### DIFF
--- a/exemplar/src/main/kotlin/com/squareup/exemplar/ExemplarModule.kt
+++ b/exemplar/src/main/kotlin/com/squareup/exemplar/ExemplarModule.kt
@@ -2,7 +2,9 @@ package com.squareup.exemplar
 
 import com.google.inject.AbstractModule
 import misk.web.WebActionModule
+import misk.web.actions.ReadinessCheckAction
 import misk.web.actions.InternalErrorAction
+import misk.web.actions.LivenessCheckAction
 import misk.web.actions.NotFoundAction
 
 class ExemplarModule : AbstractModule() {
@@ -10,6 +12,8 @@ class ExemplarModule : AbstractModule() {
         install(WebActionModule.create<HelloWebAction>())
         install(WebActionModule.create<HelloWebPostAction>())
         install(WebActionModule.create<InternalErrorAction>())
+        install(WebActionModule.create<ReadinessCheckAction>())
+        install(WebActionModule.create<LivenessCheckAction>())
         install(WebActionModule.create<NotFoundAction>())
     }
 }

--- a/misk/src/main/kotlin/misk/MiskModule.kt
+++ b/misk/src/main/kotlin/misk/MiskModule.kt
@@ -4,10 +4,12 @@ import com.google.common.util.concurrent.Service
 import com.google.common.util.concurrent.ServiceManager
 import com.google.inject.AbstractModule
 import com.google.inject.Provides
+import misk.healthchecks.HealthChecksModule
 import javax.inject.Singleton
 
 class MiskModule : AbstractModule() {
     override fun configure() {
+        install(HealthChecksModule())
     }
 
     @Provides

--- a/misk/src/main/kotlin/misk/healthchecks/HealthCheck.kt
+++ b/misk/src/main/kotlin/misk/healthchecks/HealthCheck.kt
@@ -1,0 +1,26 @@
+package misk.healthchecks
+
+import misk.web.actions.ReadinessCheckAction
+
+/**
+ * Allows users to define custom health checks. An app with a failing HealthCheck will fail the
+ * readiness check in [ReadinessCheckAction], indicating that the app should not accept traffic.
+ */
+interface HealthCheck {
+    /**
+     * Computes whether a component of an application is healthy. For example, an implementing class
+     * can check database connectivity.
+     */
+    fun status(): HealthStatus
+}
+
+data class HealthStatus(
+    val isHealthy: Boolean,
+    val messages: List<String>
+) {
+    companion object {
+        fun healthy() = HealthStatus(true, listOf())
+
+        fun unhealthy(vararg messages: String) = HealthStatus(false, messages.asList())
+    }
+}

--- a/misk/src/main/kotlin/misk/healthchecks/HealthChecksModule.kt
+++ b/misk/src/main/kotlin/misk/healthchecks/HealthChecksModule.kt
@@ -1,0 +1,15 @@
+package misk.healthchecks
+
+import com.google.inject.AbstractModule
+import com.google.inject.multibindings.Multibinder
+
+class HealthChecksModule(
+    private vararg val healthCheckClasses: Class<out HealthCheck>
+) : AbstractModule() {
+    override fun configure() {
+        val setBinder = Multibinder.newSetBinder(binder(), HealthCheck::class.java)
+        for (healthCheckClass in healthCheckClasses) {
+            setBinder.addBinding().to(healthCheckClass)
+        }
+    }
+}

--- a/misk/src/main/kotlin/misk/web/actions/LivenessCheckAction.kt
+++ b/misk/src/main/kotlin/misk/web/actions/LivenessCheckAction.kt
@@ -1,0 +1,27 @@
+package misk.web.actions
+
+import com.google.common.util.concurrent.Service
+import com.google.common.util.concurrent.Service.State
+import misk.web.Get
+import misk.web.PlaintextResponseBody
+import misk.web.Response
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class LivenessCheckAction : WebAction {
+    @Inject private lateinit var services: MutableSet<Service>
+
+    @Get("/_liveness")
+    @PlaintextResponseBody
+    fun livenessCheck(): Response<String> {
+        val isAlive = services.all {
+            it.state() != State.FAILED && it.state() != State.TERMINATED
+        }
+        // TODO(jgulbronson) - Should return an empty body
+        return Response(
+                "",
+                statusCode = if (isAlive) 200 else 503
+        )
+    }
+}

--- a/misk/src/main/kotlin/misk/web/actions/ReadinessCheckAction.kt
+++ b/misk/src/main/kotlin/misk/web/actions/ReadinessCheckAction.kt
@@ -1,0 +1,28 @@
+package misk.web.actions
+
+import com.google.common.util.concurrent.Service
+import misk.healthchecks.HealthCheck
+import misk.web.Get
+import misk.web.JsonResponseBody
+import misk.web.Response
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class ReadinessCheckAction : WebAction {
+    @Inject lateinit var services: MutableSet<Service>
+    @Inject lateinit var healthChecks: MutableSet<HealthCheck>
+
+    @Get("/_readiness")
+    @JsonResponseBody
+    fun readinessCheck(): Response<String> {
+        val isReady = services.all { it.isRunning }
+                && healthChecks.all { it.status().isHealthy }
+
+        // TODO(jgulbronson) - Should return an empty body
+        return Response(
+                "",
+                statusCode = if (isReady) 200 else 503
+        )
+    }
+}

--- a/misk/src/test/kotlin/misk/healthchecks/FakeHealthCheck.kt
+++ b/misk/src/test/kotlin/misk/healthchecks/FakeHealthCheck.kt
@@ -1,0 +1,18 @@
+package misk.healthchecks
+
+import javax.inject.Singleton
+
+@Singleton
+class FakeHealthCheck : HealthCheck {
+    var status = HealthStatus.healthy()
+
+    fun setHealthy() {
+        status = HealthStatus.healthy()
+    }
+
+    fun setUnhealthy(vararg messages: String) {
+        status = HealthStatus.unhealthy(*messages)
+    }
+
+    override fun status(): HealthStatus = status
+}

--- a/misk/src/test/kotlin/misk/healthchecks/FakeHealthCheckModule.kt
+++ b/misk/src/test/kotlin/misk/healthchecks/FakeHealthCheckModule.kt
@@ -1,0 +1,11 @@
+package misk.healthchecks
+
+import com.google.inject.AbstractModule
+import misk.inject.newMultibinder
+import misk.inject.to
+
+class FakeHealthCheckModule : AbstractModule() {
+    override fun configure() {
+        binder().newMultibinder<HealthCheck>().to<FakeHealthCheck>()
+    }
+}

--- a/misk/src/test/kotlin/misk/services/FakeService.kt
+++ b/misk/src/test/kotlin/misk/services/FakeService.kt
@@ -1,0 +1,13 @@
+package misk.services
+
+import com.google.common.util.concurrent.AbstractIdleService
+import javax.inject.Singleton
+
+@Singleton
+class FakeService : AbstractIdleService() {
+    override fun startUp() {
+    }
+
+    override fun shutDown() {
+    }
+}

--- a/misk/src/test/kotlin/misk/services/FakeServiceModule.kt
+++ b/misk/src/test/kotlin/misk/services/FakeServiceModule.kt
@@ -1,0 +1,13 @@
+package misk.services
+
+import com.google.common.util.concurrent.Service
+import com.google.inject.AbstractModule
+import misk.inject.asSingleton
+import misk.inject.newMultibinder
+import misk.inject.to
+
+class FakeServiceModule : AbstractModule() {
+    override fun configure() {
+        binder().newMultibinder<Service>().to<FakeService>()
+    }
+}

--- a/misk/src/test/kotlin/misk/web/actions/LivenessCheckActionTest.kt
+++ b/misk/src/test/kotlin/misk/web/actions/LivenessCheckActionTest.kt
@@ -1,0 +1,32 @@
+package misk.web.actions
+
+import com.google.common.truth.Truth.assertThat
+import com.google.common.util.concurrent.ServiceManager
+import misk.MiskModule
+import misk.services.FakeServiceModule
+import misk.testing.MiskTestRule
+import org.junit.Rule
+import org.junit.Test
+import javax.inject.Inject
+
+class LivenessCheckActionTest {
+    @Rule
+    @JvmField
+    val testRule = MiskTestRule(
+            MiskModule(),
+            FakeServiceModule()
+    )
+
+    @Inject lateinit var livenessCheckAction: LivenessCheckAction
+    @Inject lateinit var serviceManager: ServiceManager
+
+    @Test
+    fun livenessDependsOnServiceState() {
+        serviceManager.startAsync()
+        serviceManager.awaitHealthy()
+        assertThat(livenessCheckAction.livenessCheck().statusCode).isEqualTo(200)
+        serviceManager.stopAsync()
+        serviceManager.awaitStopped()
+        assertThat(livenessCheckAction.livenessCheck().statusCode).isEqualTo(503)
+    }
+}

--- a/misk/src/test/kotlin/misk/web/actions/ReadinessCheckActionTest.kt
+++ b/misk/src/test/kotlin/misk/web/actions/ReadinessCheckActionTest.kt
@@ -1,0 +1,42 @@
+package misk.web.actions
+
+import com.google.common.truth.Truth.assertThat
+import com.google.common.util.concurrent.ServiceManager
+import misk.MiskModule
+import misk.healthchecks.FakeHealthCheck
+import misk.healthchecks.FakeHealthCheckModule
+import misk.services.FakeServiceModule
+import misk.testing.MiskTestRule
+import org.junit.Rule
+import org.junit.Test
+import javax.inject.Inject
+
+class ReadinessCheckActionTest {
+    @Rule
+    @JvmField
+    val testRule = MiskTestRule(
+            MiskModule(),
+            FakeServiceModule(),
+            FakeHealthCheckModule()
+    )
+
+    @Inject lateinit var readinessCheckAction: ReadinessCheckAction
+    @Inject lateinit var serviceManager: ServiceManager
+    @Inject lateinit var healthCheck: FakeHealthCheck
+
+    @Test
+    fun readinessDependsOnServiceStateAndHealthChecksPassing() {
+        serviceManager.startAsync()
+        serviceManager.awaitHealthy()
+        assertThat(readinessCheckAction.readinessCheck().statusCode).isEqualTo(200)
+
+        healthCheck.setUnhealthy()
+        assertThat(readinessCheckAction.readinessCheck().statusCode).isEqualTo(503)
+        healthCheck.setHealthy()
+        assertThat(readinessCheckAction.readinessCheck().statusCode).isEqualTo(200)
+
+        serviceManager.stopAsync()
+        serviceManager.awaitStopped()
+        assertThat(readinessCheckAction.readinessCheck().statusCode).isEqualTo(503)
+    }
+}


### PR DESCRIPTION
This borrows from the Kubernetes notion of [liveness and readiness](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/), to help distinguish between when a service should stop serving traffic vs needs to be restarted.