### PR TITLE
Integrate dropwizard metrics

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,9 @@ ext {
           loggingImpl: 'org.apache.logging.log4j:log4j-slf4j-impl:2.9.1',
           jacksonDatabind: 'com.fasterxml.jackson.core:jackson-databind:2.9.2',
           jacksonDataformatYaml: 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.9.2',
-          jacksonKotlin: 'com.fasterxml.jackson.module:jackson-module-kotlin:2.9.2'
+          jacksonKotlin: 'com.fasterxml.jackson.module:jackson-module-kotlin:2.9.2',
+          metricsParent: 'io.dropwizard.metrics:metrics-parent:3.1.0',
+          metricsCore: 'io.dropwizard.metrics:metrics-core:3.1.0',
   ]
 
   isCi = "true".equals(System.getenv('CI'))

--- a/misk/build.gradle
+++ b/misk/build.gradle
@@ -33,7 +33,10 @@ dependencies {
   compile dep.jacksonDatabind
   compile dep.jacksonDataformatYaml
   compile dep.jacksonKotlin
+  compile dep.metricsCore
+  compile dep.metricsParent
 
   testCompile dep.junit
   testCompile dep.truth
 }
+

--- a/misk/src/main/kotlin/misk/config/AppName.kt
+++ b/misk/src/main/kotlin/misk/config/AppName.kt
@@ -3,5 +3,10 @@ package misk.config
 import com.google.inject.BindingAnnotation
 
 @BindingAnnotation
-@Target(AnnotationTarget.TYPE)
+@Target(
+        AnnotationTarget.FIELD,
+        AnnotationTarget.PROPERTY,
+        AnnotationTarget.FUNCTION,
+        AnnotationTarget.VALUE_PARAMETER
+)
 annotation class AppName

--- a/misk/src/main/kotlin/misk/metrics/Metrics.kt
+++ b/misk/src/main/kotlin/misk/metrics/Metrics.kt
@@ -1,0 +1,26 @@
+package misk.metrics
+
+import com.codahale.metrics.Counter
+import com.codahale.metrics.Gauge
+import com.codahale.metrics.Histogram
+import com.codahale.metrics.MetricRegistry
+import com.codahale.metrics.Timer
+import java.util.SortedMap
+import javax.inject.Inject
+
+class Metrics @Inject internal constructor(
+        metricRegistry: MetricRegistry
+) : MetricsScope("", metricRegistry) {
+    val timers: SortedMap<String, Timer> get() = metricRegistry.timers
+    val counters: SortedMap<String, Counter> get() = metricRegistry.counters
+    val gauges: SortedMap<String, Gauge<Any>> get() = metricRegistry.gauges
+    val histograms: SortedMap<String, Histogram> get() = metricRegistry.histograms
+
+    companion object {
+        /**
+         * @return a version of the name, sanitized to remove elements that are incompatible
+         * with the major metrics collection systems (notably graphite)
+         */
+        fun sanitize(name: String) = name.replace("[\\-\\.\t]", "_")
+    }
+}

--- a/misk/src/main/kotlin/misk/metrics/MetricsModule.kt
+++ b/misk/src/main/kotlin/misk/metrics/MetricsModule.kt
@@ -1,0 +1,12 @@
+package misk.metrics
+
+import com.codahale.metrics.MetricRegistry
+import com.google.inject.AbstractModule
+import com.google.inject.Singleton
+
+class MetricsModule : AbstractModule() {
+    override fun configure() {
+        bind(MetricRegistry::class.java).toInstance(MetricRegistry())
+        bind(Metrics::class.java).`in`(Singleton::class.java)
+    }
+}

--- a/misk/src/main/kotlin/misk/metrics/MetricsScope.kt
+++ b/misk/src/main/kotlin/misk/metrics/MetricsScope.kt
@@ -1,0 +1,53 @@
+package misk.metrics
+
+import com.codahale.metrics.Counter
+import com.codahale.metrics.Gauge
+import com.codahale.metrics.Histogram
+import com.codahale.metrics.MetricRegistry
+import com.codahale.metrics.Timer
+import com.google.common.base.Suppliers
+import misk.metrics.Metrics.Companion.sanitize
+import java.time.Duration
+import java.util.concurrent.TimeUnit
+
+open class MetricsScope internal constructor(
+        internal val root: String,
+        internal val metricRegistry: MetricRegistry
+) {
+    fun counter(name: String): Counter {
+        return metricRegistry.counter(scopedName(name))
+    }
+
+    fun <T> gauge(name: String, f: () -> T): Gauge<T> {
+        return metricRegistry.register(scopedName(name), Gauge<T> { f.invoke() })
+    }
+
+    fun <T> cachedGauge(name: String, duration: Duration, f: () -> T): Gauge<T> {
+        val supplier = Suppliers.memoizeWithExpiration({ f.invoke() }, duration.toMillis(),
+                TimeUnit.MILLISECONDS)
+        return metricRegistry.register(scopedName(name), Gauge<T> { supplier.get() })
+    }
+
+    fun settableGauge(name: String): SettableGauge {
+        return metricRegistry.register(scopedName(name), SettableGauge())
+    }
+
+    fun timer(name: String): Timer {
+        return metricRegistry.timer(scopedName(name))
+    }
+
+    fun histogram(name: String): Histogram {
+        return metricRegistry.histogram(scopedName(name))
+    }
+
+    fun scope(name: String, vararg names: String): MetricsScope {
+        val sanitizedNames = listOf(name, *names)
+                .filter { it.isNotBlank() }
+                .map { sanitize(it) }
+                .toTypedArray()
+
+        return MetricsScope(MetricRegistry.name(root, *sanitizedNames), metricRegistry)
+    }
+
+    fun scopedName(name: String): String = MetricRegistry.name(root, sanitize(name))
+}

--- a/misk/src/main/kotlin/misk/metrics/SettableGauge.kt
+++ b/misk/src/main/kotlin/misk/metrics/SettableGauge.kt
@@ -1,0 +1,10 @@
+package misk.metrics
+
+import com.codahale.metrics.Gauge
+import java.util.concurrent.atomic.AtomicLong
+
+class SettableGauge : Gauge<Long> {
+    val value = AtomicLong()
+
+    override fun getValue(): Long = value.get()
+}

--- a/misk/src/test/kotlin/misk/metrics/MetricsTest.kt
+++ b/misk/src/test/kotlin/misk/metrics/MetricsTest.kt
@@ -1,0 +1,79 @@
+package misk.metrics
+
+import com.google.common.truth.Truth.assertThat
+import com.google.inject.Guice
+import org.junit.Test
+import java.time.Duration
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicLong
+
+class MetricsTest {
+    @Test
+    fun counters() {
+        val metrics = buildMetrics()
+        metrics.counter("my_counter").inc(100)
+        assertThat(metrics.counters).containsKey("my_counter")
+        assertThat(metrics.counters["my_counter"]!!.count).isEqualTo(100)
+        metrics.counter("my_counter").inc(24)
+        assertThat(metrics.counters["my_counter"]!!.count).isEqualTo(124)
+    }
+
+    @Test
+    fun timers() {
+        val metrics = buildMetrics()
+        metrics.timer("my_timer").update(10, TimeUnit.SECONDS)
+        assertThat(metrics.timers).containsKey("my_timer")
+        assertThat(metrics.timers["my_timer"]!!.count).isEqualTo(1)
+        metrics.timer("my_timer").update(23, TimeUnit.SECONDS)
+        assertThat(metrics.timers["my_timer"]!!.count).isEqualTo(2)
+    }
+
+    @Test
+    fun gauges() {
+        val metrics = buildMetrics()
+        val n = AtomicLong()
+
+        metrics.gauge("my_gauge", { n.get() })
+        assertThat(metrics.gauges).containsKey("my_gauge")
+        assertThat(metrics.gauges["my_gauge"]!!.value).isEqualTo(0)
+        n.set(254)
+        assertThat(metrics.gauges["my_gauge"]!!.value).isEqualTo(254)
+    }
+
+    @Test
+    fun settableGauges() {
+        val metrics = buildMetrics()
+        val gauge = metrics.settableGauge("my_gauge")
+
+        assertThat(metrics.gauges).containsKey("my_gauge")
+        assertThat(metrics.gauges["my_gauge"]!!.value).isEqualTo(0)
+        gauge.value.set(254)
+        assertThat(metrics.gauges["my_gauge"]!!.value).isEqualTo(254)
+    }
+
+    @Test
+    fun cacheableGauges() {
+        val metrics = buildMetrics()
+        val n = AtomicLong()
+
+        metrics.cachedGauge("my_gauge", Duration.ofMillis(100), n::get)
+        assertThat(metrics.gauges).containsKey("my_gauge")
+        assertThat(metrics.gauges["my_gauge"]!!.value).isEqualTo(0)
+        n.set(254)
+        assertThat(metrics.gauges["my_gauge"]!!.value).isEqualTo(0)
+        Thread.sleep(120)
+        assertThat(metrics.gauges["my_gauge"]!!.value).isEqualTo(254)
+    }
+
+    @Test
+    fun scoping() {
+        val metrics = buildMetrics()
+        metrics.scope("   \t", "foo_zed", "", "bar_zed").counter("my_counter").inc(100)
+        assertThat(metrics.counters).containsKey("foo_zed.bar_zed.my_counter")
+    }
+
+    fun buildMetrics(): Metrics {
+        val injector = Guice.createInjector(MetricsModule())
+        return injector.getInstance(Metrics::class.java)
+    }
+}


### PR DESCRIPTION
This change simply makes metrics available to services; a subsequent
change will add metrics for tracking action status