### PR TITLE
Add metrics interceptor for web requests

### DIFF
--- a/misk/src/main/kotlin/misk/Action.kt
+++ b/misk/src/main/kotlin/misk/Action.kt
@@ -4,6 +4,7 @@ import com.google.inject.TypeLiteral
 import kotlin.reflect.KFunction
 
 data class Action(
+    val name: String,
     val function: KFunction<*>,
     val parameterTypes: List<TypeLiteral<*>>,
     val returnType: TypeLiteral<*>

--- a/misk/src/main/kotlin/misk/Actions.kt
+++ b/misk/src/main/kotlin/misk/Actions.kt
@@ -1,13 +1,22 @@
 package misk
 
 import misk.web.typeLiteral
+import kotlin.reflect.KClass
 import kotlin.reflect.KFunction
+import kotlin.reflect.full.instanceParameter
 
 fun KFunction<*>.asAction(): Action {
-    val parameterTypes = this.parameters.drop(1).map {
-        it.type.typeLiteral
-    }
-    val returnType = this.returnType.typeLiteral
+    val instanceParameter = this.instanceParameter
+            ?: throw IllegalArgumentException("only methods may be actions")
 
-    return Action(this, parameterTypes, returnType)
+    val parameterTypes = this.parameters.drop(1).map { it.type.typeLiteral }
+    val returnType = this.returnType.typeLiteral
+    val name = instanceParameter.type.classifier?.let {
+        when (it) {
+            is KClass<*> -> it.simpleName
+            else -> this.name
+        }
+    } ?: this.name
+
+    return Action(name, this, parameterTypes, returnType)
 }

--- a/misk/src/main/kotlin/misk/config/AppName.kt
+++ b/misk/src/main/kotlin/misk/config/AppName.kt
@@ -1,8 +1,8 @@
 package misk.config
 
-import com.google.inject.BindingAnnotation
+import javax.inject.Qualifier
 
-@BindingAnnotation
+@Qualifier
 @Target(
         AnnotationTarget.FIELD,
         AnnotationTarget.PROPERTY,

--- a/misk/src/main/kotlin/misk/web/WebActionsModule.kt
+++ b/misk/src/main/kotlin/misk/web/WebActionsModule.kt
@@ -11,6 +11,7 @@ import misk.web.extractors.PathPatternParameterExtractor
 import misk.web.interceptors.BoxResponseInterceptorFactory
 import misk.web.interceptors.InternalErrorInterceptorFactory
 import misk.web.interceptors.JsonInterceptorFactory
+import misk.web.interceptors.MetricsInterceptor
 import misk.web.interceptors.PlaintextInterceptorFactory
 import misk.web.interceptors.RequestLoggingInterceptor
 
@@ -20,6 +21,7 @@ class WebActionsModule : AbstractModule() {
         binder().newMultibinder<Interceptor.Factory>().to<RequestLoggingInterceptor.Factory>()
         binder().newMultibinder<Interceptor.Factory>().to<JsonInterceptorFactory>()
         binder().newMultibinder<Interceptor.Factory>().toInstance(PlaintextInterceptorFactory)
+        binder().newMultibinder<Interceptor.Factory>().to<MetricsInterceptor.Factory>()
         binder().newMultibinder<Interceptor.Factory>().to<BoxResponseInterceptorFactory>()
         binder().newMultibinder<ParameterExtractor.Factory>().toInstance(PathPatternParameterExtractor)
         binder().newMultibinder<ParameterExtractor.Factory>().to<JsonBodyParameterExtractorFactory>()

--- a/misk/src/main/kotlin/misk/web/interceptors/MetricsInterceptor.kt
+++ b/misk/src/main/kotlin/misk/web/interceptors/MetricsInterceptor.kt
@@ -1,0 +1,30 @@
+package misk.web.interceptors
+
+import misk.Action
+import misk.Chain
+import misk.Interceptor
+import misk.metrics.Metrics
+import misk.metrics.MetricsScope
+import misk.web.Response
+import javax.inject.Inject
+import javax.inject.Singleton
+
+internal class MetricsInterceptor internal constructor(val scope: MetricsScope) : Interceptor {
+
+    @Singleton
+    class Factory @Inject constructor(val m: Metrics) : Interceptor.Factory {
+        override fun create(action: Action): Interceptor? =
+                MetricsInterceptor(m.scope("web.${action.name}"))
+    }
+
+    override fun intercept(chain: Chain): Any? {
+        scope.counter("requests").inc()
+        val result = scope.timer("timing").time { chain.proceed(chain.args) }
+        if (result is Response<*>) {
+            scope.counter("responses.${result.statusCode / 100}xx").inc()
+            scope.counter("responses.${result.statusCode}").inc()
+        }
+
+        return result
+    }
+}

--- a/misk/src/test/kotlin/misk/ActionsTest.kt
+++ b/misk/src/test/kotlin/misk/ActionsTest.kt
@@ -1,0 +1,32 @@
+package misk
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+internal class ActionsTest {
+    @Test
+    fun methodAsAction() {
+        val action = TestAction::myActionMethod.asAction()
+        assertThat(action.name).isEqualTo("TestAction")
+        assertThat(action.parameterTypes).hasSize(1)
+        assertThat(action.parameterTypes[0].type).isEqualTo(Int::class.java)
+        assertThat(action.returnType.type).isEqualTo(String::class.java)
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun methodReferenceNotAllowedAsAction() {
+        val t = TestAction()
+        t::myActionMethod.asAction()
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun freeStandingFunctionNotAllowedAsAction() {
+        ::myActionHandler.asAction()
+    }
+
+    class TestAction {
+        fun myActionMethod(n: Int): String = "foo$n"
+    }
+
+    fun myActionHandler(n: Int): String = "bar$n"
+}

--- a/misk/src/test/kotlin/misk/web/interceptors/MetricsInterceptorTest.kt
+++ b/misk/src/test/kotlin/misk/web/interceptors/MetricsInterceptorTest.kt
@@ -1,0 +1,70 @@
+package misk.web.interceptors
+
+import com.google.common.truth.Truth.assertThat
+import misk.asAction
+import misk.metrics.Metrics
+import misk.metrics.MetricsModule
+import misk.testing.MiskTestRule
+import misk.web.Get
+import misk.web.Response
+import misk.web.actions.WebAction
+import misk.web.actions.asChain
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import javax.inject.Inject
+
+class MetricsInterceptorTest {
+    @get:Rule
+    val miskTestRule = MiskTestRule(MetricsModule())
+
+    @Inject internal lateinit var metricsInterceptorFactory: MetricsInterceptor.Factory
+    @Inject internal lateinit var testAction: TestAction
+    @Inject internal lateinit var metrics: Metrics
+
+    @Before
+    fun sendRequests() {
+        assertThat(invoke(200).statusCode).isEqualTo(200)
+        assertThat(invoke(200).statusCode).isEqualTo(200)
+        assertThat(invoke(202).statusCode).isEqualTo(202)
+        assertThat(invoke(404).statusCode).isEqualTo(404)
+        assertThat(invoke(403).statusCode).isEqualTo(403)
+        assertThat(invoke(403).statusCode).isEqualTo(403)
+    }
+
+    @Test
+    fun requests() {
+        assertThat(metrics.counters["web.TestAction.requests"]!!.count).isEqualTo(6)
+    }
+
+    @Test
+    fun responseCodes() {
+        assertThat(metrics.counters["web.TestAction.responses.2xx"]!!.count).isEqualTo(3)
+        assertThat(metrics.counters["web.TestAction.responses.200"]!!.count).isEqualTo(2)
+        assertThat(metrics.counters["web.TestAction.responses.202"]!!.count).isEqualTo(1)
+        assertThat(metrics.counters["web.TestAction.responses.4xx"]!!.count).isEqualTo(3)
+        assertThat(metrics.counters["web.TestAction.responses.404"]!!.count).isEqualTo(1)
+        assertThat(metrics.counters["web.TestAction.responses.403"]!!.count).isEqualTo(2)
+    }
+
+    @Test
+    fun timing() {
+        assertThat(metrics.timers["web.TestAction.timing"]!!.count).isEqualTo(6)
+    }
+
+    fun invoke(desiredStatusCode: Int): Response<String> {
+        val metricsInterceptor = metricsInterceptorFactory.create(TestAction::call.asAction())!!
+        val chain = testAction.asChain(TestAction::call, listOf(desiredStatusCode),
+                metricsInterceptor)
+
+        @Suppress("UNCHECKED_CAST")
+        return chain.proceed(chain.args) as Response<String>
+    }
+}
+
+internal class TestAction : WebAction {
+    @Get("/call/{result}")
+    fun call(desiredStatusCode: Int): Response<String> {
+        return Response("foo", statusCode = desiredStatusCode)
+    }
+}

--- a/misk/src/test/kotlin/misk/web/interceptors/ProtobufInterceptorFactoryTest.kt
+++ b/misk/src/test/kotlin/misk/web/interceptors/ProtobufInterceptorFactoryTest.kt
@@ -1,9 +1,7 @@
 package misk.web.interceptors
 
-import com.google.common.collect.Lists
 import com.google.common.truth.Truth.assertThat
 import helpers.protos.Dinosaur
-import misk.Interceptor
 import misk.asAction
 import misk.testing.MiskTestRule
 import misk.web.Get
@@ -12,13 +10,11 @@ import misk.web.Response
 import misk.web.ResponseBody
 import misk.web.actions.WebAction
 import misk.web.actions.asChain
-import misk.web.interceptors.ProtobufInterceptorFactory.ProtobufInterceptor
 import okio.Okio
 import okio.Pipe
 import org.junit.Rule
 import org.junit.Test
 import javax.inject.Inject
-import kotlin.reflect.KFunction
 
 class ProtobufInterceptorFactoryTest {
     @get:Rule
@@ -30,16 +26,12 @@ class ProtobufInterceptorFactoryTest {
 
     @Test
     fun test() {
-        val action = protobufAction::hello.asAction()
+        val action = ProtobufAction::hello.asAction()
 
-        val boxResponseInterceptor: Interceptor = boxResponseInterceptorFactory.create(action)!!
-        val protobufInterceptor: ProtobufInterceptor<*> = protobufInterceptorFactory.create(action)!!
-
-        val chain = protobufAction.asChain(
-                ProtobufAction::class.members.first() as KFunction<*>,
-                Lists.newArrayList("T-Rex"),
-                protobufInterceptor, boxResponseInterceptor
-        )
+        val boxResponseInterceptor = boxResponseInterceptorFactory.create(action)!!
+        val protobufInterceptor = protobufInterceptorFactory.create(action)!!
+        val chain = protobufAction.asChain(ProtobufAction::hello, listOf("T-Rex"),
+                protobufInterceptor, boxResponseInterceptor)
 
         @Suppress("UNCHECKED_CAST")
         val result = chain.proceed(chain.args) as Response<ResponseBody>
@@ -58,7 +50,7 @@ internal class ProtobufAction : WebAction {
     @Get("/hello/{dinosaur}")
     @ProtobufResponseBody
     fun hello(
-        dinosaur: String
+            dinosaur: String
     ): Dinosaur {
         return Dinosaur.Builder()
                 .name(dinosaur)


### PR DESCRIPTION
Tracks incoming requests, response codes by family and individual code,
and total application level response times