### PR TITLE
Remove slf4j implementation from Misk classpath

### DIFF
--- a/exemplar/build.gradle
+++ b/exemplar/build.gradle
@@ -15,6 +15,7 @@ dependencies {
   compile dep.kotlinStdLib
   compile dep.guava
   compile dep.guice
+  compile dep.loggingImpl
 
   compile project(':misk')
 

--- a/misk/build.gradle
+++ b/misk/build.gradle
@@ -29,7 +29,6 @@ dependencies {
   compile dep.jettyServlet
   compile dep.wireRuntime
   compile dep.loggingApi
-  compile dep.loggingImpl
   compile dep.jacksonDatabind
   compile dep.jacksonDataformatYaml
   compile dep.jacksonKotlin
@@ -38,5 +37,6 @@ dependencies {
 
   testCompile dep.junit
   testCompile dep.truth
+  testCompile dep.loggingImpl
 }
 


### PR DESCRIPTION
The implementation dependency should come from the end-user, not the library, otherwise it defeats the purpose of using a logging facade.