### PR TITLE
Add metrics backends

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,8 @@ ext {
           jacksonKotlin: 'com.fasterxml.jackson.module:jackson-module-kotlin:2.9.2',
           metricsParent: 'io.dropwizard.metrics:metrics-parent:3.1.0',
           metricsCore: 'io.dropwizard.metrics:metrics-core:3.1.0',
+          metricsGraphite: 'io.dropwizard.metrics:metrics-graphite:3.1.0',
+          metricsStackDriver: 'com.google.apis:google-api-services-monitoring:v3-rev425-1.23.0',
   ]
 
   isCi = "true".equals(System.getenv('CI'))

--- a/exemplar/src/main/java/com/squareup/exemplar/ExemplarJavaModule.java
+++ b/exemplar/src/main/java/com/squareup/exemplar/ExemplarJavaModule.java
@@ -1,6 +1,7 @@
 package com.squareup.exemplar;
 
 import com.google.inject.AbstractModule;
+import misk.metrics.web.MetricsJsonAction;
 import misk.web.WebActionModule;
 import misk.web.actions.InternalErrorAction;
 import misk.web.actions.NotFoundAction;
@@ -8,6 +9,7 @@ import misk.web.actions.NotFoundAction;
 public class ExemplarJavaModule extends AbstractModule {
   @Override protected void configure() {
     install(WebActionModule.create(HelloJavaAction.class));
+    install(WebActionModule.create(MetricsJsonAction.class));
     install(WebActionModule.create(InternalErrorAction.class));
     install(WebActionModule.create(NotFoundAction.class));
   }

--- a/exemplar/src/main/kotlin/com/squareup/exemplar/ExemplarModule.kt
+++ b/exemplar/src/main/kotlin/com/squareup/exemplar/ExemplarModule.kt
@@ -1,6 +1,7 @@
 package com.squareup.exemplar
 
 import com.google.inject.AbstractModule
+import misk.metrics.web.MetricsJsonAction
 import misk.web.WebActionModule
 import misk.web.actions.ReadinessCheckAction
 import misk.web.actions.InternalErrorAction
@@ -11,6 +12,7 @@ class ExemplarModule : AbstractModule() {
     override fun configure() {
         install(WebActionModule.create<HelloWebAction>())
         install(WebActionModule.create<HelloWebPostAction>())
+        install(WebActionModule.create<MetricsJsonAction>())
         install(WebActionModule.create<InternalErrorAction>())
         install(WebActionModule.create<ReadinessCheckAction>())
         install(WebActionModule.create<LivenessCheckAction>())

--- a/misk/build.gradle
+++ b/misk/build.gradle
@@ -34,6 +34,8 @@ dependencies {
   compile dep.jacksonKotlin
   compile dep.metricsCore
   compile dep.metricsParent
+  compile dep.metricsGraphite
+  compile dep.metricsStackDriver
 
   testCompile dep.junit
   testCompile dep.truth

--- a/misk/src/main/kotlin/misk/MiskModule.kt
+++ b/misk/src/main/kotlin/misk/MiskModule.kt
@@ -4,12 +4,17 @@ import com.google.common.util.concurrent.Service
 import com.google.common.util.concurrent.ServiceManager
 import com.google.inject.AbstractModule
 import com.google.inject.Provides
+
 import misk.healthchecks.HealthChecksModule
+import misk.metrics.MetricsModule
+import misk.time.ClockModule
 import javax.inject.Singleton
 
 class MiskModule : AbstractModule() {
     override fun configure() {
         install(HealthChecksModule())
+        install(MetricsModule())
+        install(ClockModule())
     }
 
     @Provides

--- a/misk/src/main/kotlin/misk/environment/AwsInstanceMetadataModule.kt
+++ b/misk/src/main/kotlin/misk/environment/AwsInstanceMetadataModule.kt
@@ -1,0 +1,37 @@
+package misk.environment
+
+import com.google.inject.AbstractModule
+import com.google.inject.Provides
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import javax.inject.Singleton
+
+/** Retrieves instance metadata for applications running on AWS */
+class AwsInstanceMetadataModule : AbstractModule() {
+    companion object {
+        @JvmStatic internal val AWS_INSTANCE_METADATA_URL = "http://169.254.169.254/latest/meta-data"
+    }
+
+    override fun configure() {}
+
+    @Provides
+    @Singleton
+    fun providesInstanceMetadata(): InstanceMetadata {
+        val instanceName = get("instance-id")
+        val zone = get("placement/availability-zone")
+        return InstanceMetadata(instanceName, zone)
+    }
+
+    fun get(metadataCategory: String): String {
+        val httpClient = OkHttpClient()
+        val request = Request.Builder()
+                .get()
+                .url("$AWS_INSTANCE_METADATA_URL/$metadataCategory")
+                .build()
+
+        val response = httpClient.newCall(request).execute().body()
+        return response?.string()
+                ?: throw IllegalStateException("could not retrieve $metadataCategory")
+    }
+
+}

--- a/misk/src/main/kotlin/misk/environment/GcpInstanceMetadataModule.kt
+++ b/misk/src/main/kotlin/misk/environment/GcpInstanceMetadataModule.kt
@@ -1,0 +1,41 @@
+package misk.environment
+
+import com.google.inject.AbstractModule
+import com.google.inject.Provides
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import javax.inject.Singleton
+
+/** Retrieves instance metadata for applications running on GCP */
+class GcpInstanceMetadataModule : AbstractModule() {
+    companion object {
+        @JvmStatic internal val GCP_INSTANCE_METADATA_URL = "http://metadata.google.internal/computeMetadata/v1"
+    }
+
+    override fun configure() {}
+
+    @Provides
+    @Singleton
+    fun providesInstanceMetadata(): InstanceMetadata {
+        var instanceName = get("name")
+        if (instanceName.isBlank()) {
+            instanceName = get("id")
+        }
+
+        val zone = get("zone")
+        return InstanceMetadata(instanceName, zone)
+    }
+
+    fun get(metadataCategory: String): String {
+        val httpClient = OkHttpClient()
+        val request = Request.Builder()
+                .get()
+                .url("${GCP_INSTANCE_METADATA_URL}/$metadataCategory")
+                .build()
+
+        val response = httpClient.newCall(request).execute().body()
+        return response?.string()
+                ?: throw IllegalStateException("could not retrieve $metadataCategory")
+    }
+
+}

--- a/misk/src/main/kotlin/misk/environment/InstanceMetadata.kt
+++ b/misk/src/main/kotlin/misk/environment/InstanceMetadata.kt
@@ -1,0 +1,4 @@
+package misk.environment
+
+/** Metadata about the running instance */
+data class InstanceMetadata(val instanceName: String, val zone: String)

--- a/misk/src/main/kotlin/misk/environment/StaticInstanceMetadataModule.kt
+++ b/misk/src/main/kotlin/misk/environment/StaticInstanceMetadataModule.kt
@@ -1,0 +1,10 @@
+package misk.environment
+
+import com.google.inject.AbstractModule
+
+/** Provides a hard-coded set of instance metadata */
+class StaticInstanceMetadataModule(val metadata: InstanceMetadata) : AbstractModule() {
+    override fun configure() {
+        bind(InstanceMetadata::class.java).toInstance(metadata)
+    }
+}

--- a/misk/src/main/kotlin/misk/metrics/MetricsConfig.kt
+++ b/misk/src/main/kotlin/misk/metrics/MetricsConfig.kt
@@ -1,0 +1,7 @@
+package misk.metrics
+
+import misk.config.Config
+import misk.metrics.backends.MetricsBackendConfig
+
+data class MetricsConfig(val backends: MetricsBackendConfig) : Config
+

--- a/misk/src/main/kotlin/misk/metrics/MetricsModule.kt
+++ b/misk/src/main/kotlin/misk/metrics/MetricsModule.kt
@@ -2,11 +2,10 @@ package misk.metrics
 
 import com.codahale.metrics.MetricRegistry
 import com.google.inject.AbstractModule
-import com.google.inject.Singleton
 
 class MetricsModule : AbstractModule() {
     override fun configure() {
-        bind(MetricRegistry::class.java).toInstance(MetricRegistry())
-        bind(Metrics::class.java).`in`(Singleton::class.java)
+        bind(Metrics::class.java).asEagerSingleton()
+        bind(MetricRegistry::class.java).asEagerSingleton()
     }
 }

--- a/misk/src/main/kotlin/misk/metrics/backends/MetricsBackendConfig.kt
+++ b/misk/src/main/kotlin/misk/metrics/backends/MetricsBackendConfig.kt
@@ -1,0 +1,10 @@
+package misk.metrics.backends
+
+import misk.config.Config
+import misk.metrics.backends.graphite.GraphiteBackendConfig
+import misk.metrics.backends.stackdriver.StackDriverBackendConfig
+
+data class MetricsBackendConfig(
+        val graphite: GraphiteBackendConfig?,
+        val stack_driver: StackDriverBackendConfig?
+) : Config

--- a/misk/src/main/kotlin/misk/metrics/backends/graphite/GraphiteBackendConfig.kt
+++ b/misk/src/main/kotlin/misk/metrics/backends/graphite/GraphiteBackendConfig.kt
@@ -1,0 +1,6 @@
+package misk.metrics.backends.graphite
+
+import misk.config.Config
+import java.time.Duration
+
+data class GraphiteBackendConfig(val host: String, val port: Int, val interval: Duration) : Config

--- a/misk/src/main/kotlin/misk/metrics/backends/graphite/GraphiteBackendModule.kt
+++ b/misk/src/main/kotlin/misk/metrics/backends/graphite/GraphiteBackendModule.kt
@@ -1,0 +1,47 @@
+package misk.metrics.backends.graphite
+
+import com.codahale.metrics.MetricRegistry
+import com.codahale.metrics.graphite.Graphite
+import com.codahale.metrics.graphite.GraphiteReporter
+import com.codahale.metrics.graphite.GraphiteSender
+import com.google.common.util.concurrent.Service
+import com.google.inject.AbstractModule
+import com.google.inject.Provides
+import com.google.inject.Singleton
+import misk.config.AppName
+import misk.environment.InstanceMetadata
+import misk.inject.addMultibinderBinding
+import misk.inject.to
+import misk.metrics.Metrics
+import java.util.concurrent.TimeUnit
+
+class GraphiteBackendModule : AbstractModule() {
+    override fun configure() {
+        binder().addMultibinderBinding<Service>().to<GraphiteReporterService>()
+    }
+
+    @Provides
+    @Singleton
+    fun graphiteSender(config: GraphiteBackendConfig): GraphiteSender =
+            Graphite(config.host, config.port)
+
+    @Provides
+    @Singleton
+    fun graphiteReporter(
+            @AppName appName: String,
+            instanceMetadata: InstanceMetadata,
+            metricRegistry: MetricRegistry,
+            sender: GraphiteSender): GraphiteReporter {
+
+        val instanceName = Metrics.sanitize(instanceMetadata.instanceName)
+        val zone = Metrics.sanitize(instanceMetadata.zone)
+        val prefix = "$appName.$zone.$instanceName"
+
+        return GraphiteReporter.forRegistry(metricRegistry)
+                .prefixedWith(prefix)
+                .convertDurationsTo(TimeUnit.MILLISECONDS)
+                .convertRatesTo(TimeUnit.MILLISECONDS)
+                .build(sender)
+    }
+
+}

--- a/misk/src/main/kotlin/misk/metrics/backends/graphite/GraphiteReporterService.kt
+++ b/misk/src/main/kotlin/misk/metrics/backends/graphite/GraphiteReporterService.kt
@@ -1,0 +1,14 @@
+package misk.metrics.backends.graphite
+
+import com.codahale.metrics.graphite.GraphiteReporter
+import com.google.common.util.concurrent.AbstractIdleService
+import java.util.concurrent.TimeUnit
+import javax.inject.Inject
+
+internal class GraphiteReporterService @Inject internal constructor(
+        private val config: GraphiteBackendConfig,
+        private val reporter: GraphiteReporter
+) : AbstractIdleService() {
+    override fun startUp() = reporter.start(config.interval.toMillis(), TimeUnit.MILLISECONDS)
+    override fun shutDown() = reporter.stop()
+}

--- a/misk/src/main/kotlin/misk/metrics/backends/stackdriver/StackDriverBackendConfig.kt
+++ b/misk/src/main/kotlin/misk/metrics/backends/stackdriver/StackDriverBackendConfig.kt
@@ -1,0 +1,12 @@
+package misk.metrics.backends.stackdriver
+
+import misk.config.Config
+import java.time.Duration
+
+data class StackDriverBackendConfig(
+        val project_id: String,
+        val service_path: String,
+        val root_url: String,
+        val interval: Duration,
+        val batch_size: Int = 200
+) : Config

--- a/misk/src/main/kotlin/misk/metrics/backends/stackdriver/StackDriverBackendModule.kt
+++ b/misk/src/main/kotlin/misk/metrics/backends/stackdriver/StackDriverBackendModule.kt
@@ -1,0 +1,33 @@
+package misk.metrics.backends.stackdriver
+
+import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport
+import com.google.api.client.json.jackson2.JacksonFactory
+import com.google.api.services.monitoring.v3.Monitoring
+import com.google.common.util.concurrent.Service
+import com.google.inject.AbstractModule
+import com.google.inject.Provides
+import com.google.inject.Singleton
+import misk.config.AppName
+import misk.inject.addMultibinderBinding
+import misk.inject.asSingleton
+import misk.inject.to
+
+class StackDriverBackendModule : AbstractModule() {
+    override fun configure() {
+        bind(StackDriverSender::class.java)
+                .to(StackDriverBatchedSender::class.java)
+                .asSingleton()
+
+        binder().addMultibinderBinding<Service>().to<StackDriverReporterService>()
+    }
+
+    @Provides
+    @Singleton
+    fun monitoring(@AppName appName: String, config: StackDriverBackendConfig): Monitoring =
+            Monitoring.Builder(GoogleNetHttpTransport.newTrustedTransport(), JacksonFactory(), null)
+                    .setApplicationName(appName)
+                    .setServicePath(config.service_path)
+                    .setRootUrl(config.root_url)
+                    .build()
+
+}

--- a/misk/src/main/kotlin/misk/metrics/backends/stackdriver/StackDriverBatchedSender.kt
+++ b/misk/src/main/kotlin/misk/metrics/backends/stackdriver/StackDriverBatchedSender.kt
@@ -1,0 +1,51 @@
+package misk.metrics.backends.stackdriver
+
+import com.google.api.client.googleapis.batch.json.JsonBatchCallback
+import com.google.api.client.googleapis.json.GoogleJsonError
+import com.google.api.client.http.HttpHeaders
+import com.google.api.services.monitoring.v3.Monitoring
+import com.google.api.services.monitoring.v3.model.CreateTimeSeriesRequest
+import com.google.api.services.monitoring.v3.model.Empty
+import com.google.api.services.monitoring.v3.model.TimeSeries
+import misk.logging.getLogger
+import javax.inject.Inject
+
+internal class StackDriverBatchedSender @Inject internal constructor(
+        val monitoring: Monitoring,
+        val config: StackDriverBackendConfig
+) : StackDriverSender {
+    companion object {
+        @JvmStatic
+        val log = getLogger<StackDriverSender>()
+    }
+
+    val timeSeriesApi = monitoring.projects().timeSeries()
+
+    override fun send(timeSeries: List<TimeSeries>) {
+        if (timeSeries.size > config.batch_size) {
+            val batch = monitoring.batch()
+            timeSeries
+                    .chunked(config.batch_size)
+                    .map { CreateTimeSeriesRequest().setTimeSeries(it) }
+                    .forEach {
+                        timeSeriesApi.create(config.project_id, it).queue(batch, ResponseCallback())
+                    }
+            batch.execute()
+        } else {
+            val request = CreateTimeSeriesRequest().setTimeSeries(timeSeries)
+            val create = timeSeriesApi.create(config.project_id, request).execute()
+            if (!create.isEmpty()) {
+                log.warn(create.toPrettyString())
+            }
+        }
+    }
+
+    class ResponseCallback : JsonBatchCallback<Empty>() {
+        override fun onFailure(e: GoogleJsonError?, responseHeaders: HttpHeaders?) {
+            log.warn("failed to send timeseries to stack driver ${e?.toPrettyString()}")
+        }
+
+        override fun onSuccess(t: Empty?, responseHeaders: HttpHeaders?) {}
+    }
+
+}

--- a/misk/src/main/kotlin/misk/metrics/backends/stackdriver/StackDriverReporter.kt
+++ b/misk/src/main/kotlin/misk/metrics/backends/stackdriver/StackDriverReporter.kt
@@ -1,0 +1,216 @@
+package misk.metrics.backends.stackdriver
+
+import com.codahale.metrics.Counter
+import com.codahale.metrics.Gauge
+import com.codahale.metrics.Histogram
+import com.codahale.metrics.Meter
+import com.codahale.metrics.Metered
+import com.codahale.metrics.ScheduledReporter
+import com.codahale.metrics.Timer
+import com.google.api.client.util.DateTime
+import com.google.api.services.monitoring.v3.model.Metric
+import com.google.api.services.monitoring.v3.model.Point
+import com.google.api.services.monitoring.v3.model.TimeInterval
+import com.google.api.services.monitoring.v3.model.TimeSeries
+import com.google.api.services.monitoring.v3.model.TypedValue
+import com.google.common.base.Joiner
+import misk.config.AppName
+import misk.environment.InstanceMetadata
+import java.math.BigDecimal
+import java.math.BigInteger
+import java.time.Clock
+import java.util.SortedMap
+import java.util.concurrent.TimeUnit
+import javax.inject.Inject
+
+internal class StackDriverReporter @Inject internal constructor(
+        val clock: Clock,
+        @AppName val appName: String,
+        val instanceMetadata: InstanceMetadata,
+        val sender: StackDriverSender,
+        metricRegistry: com.codahale.metrics.MetricRegistry
+) : ScheduledReporter(metricRegistry, "stack-driver", null,
+        TimeUnit.MILLISECONDS, TimeUnit.MILLISECONDS) {
+    private val startTime = DateTime(clock.millis())
+
+    override fun report(
+            gauges: SortedMap<String, Gauge<Any>>?,
+            counters: SortedMap<String, Counter>?,
+            histograms: SortedMap<String, Histogram>?,
+            meters: SortedMap<String, Meter>?,
+            timers: SortedMap<String, Timer>?) {
+        val timeSeries = toTimeSeries(gauges, counters, histograms, meters,
+                timers, startTime, DateTime(clock.millis()))
+        if (timeSeries.isEmpty()) {
+            return
+        }
+
+        sender.send(timeSeries)
+    }
+
+    enum class MetricKind {
+        GAUGE,
+        CUMULATIVE
+    }
+
+    companion object {
+        private val CUSTOM_METRICS_PREFIX = "custom.googleapis.com/dw"
+
+        private val pathJoiner = Joiner.on('/')
+    }
+
+    fun toTimeSeries(
+            gauges: SortedMap<String, Gauge<Any>>?,
+            counters: SortedMap<String, Counter>?,
+            histograms: SortedMap<String, Histogram>?,
+            meters: SortedMap<String, Meter>?,
+            timers: SortedMap<String, Timer>?,
+            startTime: DateTime,
+            now: DateTime): List<TimeSeries> {
+        val timeSeries = ArrayList<TimeSeries>()
+        gauges?.forEach { timeSeries.addAll(toTimeSeries(it.key, it.value, startTime, now)) }
+        counters?.forEach { timeSeries.addAll(toTimeSeries(it.key, it.value, startTime, now)) }
+        histograms?.forEach { timeSeries.addAll(toTimeSeries(it.key, it.value, startTime, now)) }
+        timers?.forEach { timeSeries.addAll(toTimeSeries(it.key, it.value, startTime, now)) }
+        meters?.forEach { timeSeries.addAll(toTimeSeries(it.key, it.value, startTime, now)) }
+        return timeSeries
+    }
+
+    fun toTimeSeries(
+            name: String,
+            gauge: Gauge<Any>,
+            startTime: DateTime,
+            now: DateTime
+    ): Array<TimeSeries> = arrayOf(
+            timeSeries(name, gauge.value, startTime, now, "value", MetricKind.GAUGE))
+
+    fun toTimeSeries(
+            name: String,
+            counter: Counter,
+            startTime: DateTime,
+            now: DateTime
+    ): Array<TimeSeries> = arrayOf(
+            timeSeries(name, counter.count, startTime, now, "count", MetricKind.CUMULATIVE))
+
+    fun toTimeSeries(
+            name: String,
+            timer: Timer,
+            startTime: DateTime,
+            now: DateTime
+    ): Array<TimeSeries> {
+        val snapshot = timer.snapshot
+        return arrayOf(
+                timeSeries(name, convertDuration(snapshot.max.toDouble()), startTime, now, "max",
+                        MetricKind.GAUGE),
+                timeSeries(name, convertDuration(snapshot.min.toDouble()), startTime, now, "min",
+                        MetricKind.GAUGE),
+                timeSeries(name, convertDuration(snapshot.mean), startTime, now, "mean",
+                        MetricKind.GAUGE),
+                timeSeries(name, convertDuration(snapshot.stdDev), startTime, now, "stdDev",
+                        MetricKind.GAUGE),
+                timeSeries(name, convertDuration(snapshot.median), startTime, now, "p50",
+                        MetricKind.GAUGE),
+                timeSeries(name, convertDuration(snapshot.get75thPercentile()), startTime, now,
+                        "p75", MetricKind.GAUGE),
+                timeSeries(name, convertDuration(snapshot.get95thPercentile()), startTime, now,
+                        "p95", MetricKind.GAUGE),
+                timeSeries(name, convertDuration(snapshot.get98thPercentile()), startTime, now,
+                        "p98", MetricKind.GAUGE),
+                timeSeries(name, convertDuration(snapshot.get99thPercentile()), startTime, now,
+                        "p99", MetricKind.GAUGE),
+                timeSeries(name, convertDuration(snapshot.get999thPercentile()), startTime, now,
+                        "p999", MetricKind.GAUGE),
+                *toTimeSeries(name, timer as Metered, startTime, now))
+    }
+
+    fun toTimeSeries(
+            name: String,
+            hist: Histogram,
+            startTime: DateTime,
+            now: DateTime
+    ): Array<TimeSeries> {
+        val snapshot = hist.snapshot
+        return arrayOf(
+                timeSeries(name, hist.count, startTime, now, "count", MetricKind.CUMULATIVE),
+                timeSeries(name, snapshot.max.toDouble(), startTime, now, "max", MetricKind.GAUGE),
+                timeSeries(name, snapshot.min.toDouble(), startTime, now, "min", MetricKind.GAUGE),
+                timeSeries(name, snapshot.mean, startTime, now, "mean", MetricKind.GAUGE),
+                timeSeries(name, snapshot.stdDev, startTime, now, "stdDev", MetricKind.GAUGE),
+                timeSeries(name, snapshot.median, startTime, now, "p50", MetricKind.GAUGE),
+                timeSeries(name, snapshot.get75thPercentile(), startTime, now, "p75",
+                        MetricKind.GAUGE),
+                timeSeries(name, snapshot.get95thPercentile(), startTime, now, "p95",
+                        MetricKind.GAUGE),
+                timeSeries(name, snapshot.get98thPercentile(), startTime, now, "p98",
+                        MetricKind.GAUGE),
+                timeSeries(name, snapshot.get99thPercentile(), startTime, now, "p99",
+                        MetricKind.GAUGE),
+                timeSeries(name, snapshot.get999thPercentile(), startTime, now, "p999",
+                        MetricKind.GAUGE))
+    }
+
+    fun toTimeSeries(
+            name: String,
+            metered: Metered,
+            startTime: DateTime,
+            now: DateTime
+    ): Array<TimeSeries> = arrayOf(
+            timeSeries(name, metered.count, startTime, now, "count", MetricKind.CUMULATIVE),
+            timeSeries(name, convertRate(metered.oneMinuteRate), startTime, now, "m1_rate",
+                    MetricKind.GAUGE),
+            timeSeries(name, convertRate(metered.meanRate), startTime, now, "mean_rate",
+                    MetricKind.GAUGE),
+            timeSeries(name, convertRate(metered.fiveMinuteRate), startTime, now, "m5_rate",
+                    MetricKind.GAUGE),
+            timeSeries(name, convertRate(metered.fifteenMinuteRate), startTime, now, "m15_rate",
+                    MetricKind.GAUGE))
+
+    private fun timeSeries(
+            name: String,
+            pointValue: Any,
+            startTime: DateTime,
+            now: DateTime,
+            subType: String,
+            metricKind: MetricKind
+    ): TimeSeries = TimeSeries()
+            .setMetricKind(metricKind.name)
+            .setMetric(metric(type(name, subType)))
+            .setPoints(listOf(point(metricKind, startTime, now, typedValue(pointValue))))
+
+    private fun point(
+            metricKind: MetricKind,
+            startTime: DateTime,
+            now: DateTime,
+            value: TypedValue
+    ): Point = Point()
+            .setInterval(timeInterval(startTime, now, metricKind))
+            .setValue(value)
+
+    private fun timeInterval(
+            startTime: DateTime,
+            now: DateTime,
+            metricKind: MetricKind
+    ): TimeInterval = when (metricKind) {
+        MetricKind.CUMULATIVE -> TimeInterval()
+                .setStartTime(startTime.toStringRfc3339())
+                .setEndTime(now.toStringRfc3339())
+        MetricKind.GAUGE -> TimeInterval().setEndTime(now.toStringRfc3339())
+    }
+
+    private fun type(root: String, vararg others: String) =
+            pathJoiner.join(CUSTOM_METRICS_PREFIX,
+                    appName, instanceMetadata.zone, instanceMetadata.instanceName,
+                    root, *others)
+
+    private fun metric(type: String): Metric = Metric().setType(type)
+
+    private fun typedValue(o: Any): TypedValue = when (o) {
+        is Float -> TypedValue().setDoubleValue(o.toDouble())
+        is Double -> TypedValue().setDoubleValue(o.toDouble())
+        is BigInteger -> TypedValue().setDoubleValue(o.toDouble())
+        is BigDecimal -> TypedValue().setDoubleValue(o.toDouble())
+        is Number -> TypedValue().setInt64Value(o.toLong())
+        else -> TypedValue()
+    }
+
+}

--- a/misk/src/main/kotlin/misk/metrics/backends/stackdriver/StackDriverReporterService.kt
+++ b/misk/src/main/kotlin/misk/metrics/backends/stackdriver/StackDriverReporterService.kt
@@ -1,0 +1,13 @@
+package misk.metrics.backends.stackdriver
+
+import com.google.common.util.concurrent.AbstractIdleService
+import java.util.concurrent.TimeUnit
+import javax.inject.Inject
+
+internal class StackDriverReporterService @Inject internal constructor(
+        private val config: StackDriverBackendConfig,
+        private val reporter: StackDriverReporter
+) : AbstractIdleService() {
+    override fun startUp() = reporter.start(config.interval.toMillis(), TimeUnit.MILLISECONDS)
+    override fun shutDown() = reporter.stop()
+}

--- a/misk/src/main/kotlin/misk/metrics/backends/stackdriver/StackDriverSender.kt
+++ b/misk/src/main/kotlin/misk/metrics/backends/stackdriver/StackDriverSender.kt
@@ -1,0 +1,7 @@
+package misk.metrics.backends.stackdriver
+
+import com.google.api.services.monitoring.v3.model.TimeSeries
+
+internal interface StackDriverSender {
+    fun send(timeSeries: List<TimeSeries>)
+}

--- a/misk/src/main/kotlin/misk/metrics/web/JsonMetrics.kt
+++ b/misk/src/main/kotlin/misk/metrics/web/JsonMetrics.kt
@@ -1,0 +1,82 @@
+package misk.metrics.web
+
+import com.codahale.metrics.Counter
+import com.codahale.metrics.Gauge
+import com.codahale.metrics.Histogram
+import com.codahale.metrics.Snapshot
+import com.codahale.metrics.Timer
+import misk.metrics.Metrics
+import java.util.concurrent.TimeUnit
+
+data class JsonCounter(val count: Long) {
+    constructor(counter: Counter) : this(counter.count)
+}
+
+data class JsonGauge<T>(val value: T) {
+    constructor(gauge: Gauge<T>) : this(gauge.value)
+}
+
+data class JsonTimer(
+        val count: Long,
+        val oneMinuteRate: Double,
+        val fiveMinuteRate: Double,
+        val fifteenMinuteRate: Double,
+        val meanRate: Double,
+        val snapshot: JsonHistogramSnapshot
+) {
+    constructor(timer: Timer) : this(
+            timer.count,
+            timer.oneMinuteRate * RATE_FACTOR,
+            timer.fiveMinuteRate * RATE_FACTOR,
+            timer.fifteenMinuteRate * RATE_FACTOR,
+            timer.meanRate * RATE_FACTOR,
+            JsonHistogramSnapshot(timer.snapshot, DURATION_FACTOR)
+    )
+}
+
+data class JsonHistogramSnapshot(
+        val min: Double,
+        val max: Double,
+        val mean: Double,
+        val stdDev: Double,
+        val p50: Double,
+        val p75: Double,
+        val p95: Double,
+        val p98: Double,
+        val p99: Double,
+        val p999: Double
+) {
+    constructor(snapshot: Snapshot, conversionFactor: Double = 1.0) : this(
+            min = snapshot.min.toDouble() * conversionFactor,
+            max = snapshot.max.toDouble() * conversionFactor,
+            mean = snapshot.mean * conversionFactor,
+            stdDev = snapshot.stdDev * conversionFactor,
+            p50 = snapshot.median * conversionFactor,
+            p75 = snapshot.get75thPercentile() * conversionFactor,
+            p95 = snapshot.get95thPercentile() * conversionFactor,
+            p98 = snapshot.get98thPercentile() * conversionFactor,
+            p99 = snapshot.get99thPercentile() * conversionFactor,
+            p999 = snapshot.get999thPercentile() * conversionFactor)
+}
+
+data class JsonHistogram(val count: Long, val snapshot: JsonHistogramSnapshot) {
+    constructor(hist: Histogram) : this(hist.count, JsonHistogramSnapshot(hist.snapshot))
+}
+
+data class JsonMetrics(
+        val counters: Map<String, JsonCounter>,
+        val timers: Map<String, JsonTimer>,
+        val histograms: Map<String, JsonHistogram>,
+        val gauges: Map<String, JsonGauge<Any>>
+) {
+    constructor(metrics: Metrics) : this(
+            metrics.counters.map { it.key to JsonCounter(it.value) }.toMap(),
+            metrics.timers.map { it.key to JsonTimer(it.value) }.toMap(),
+            metrics.histograms.map { it.key to JsonHistogram(it.value) }.toMap(),
+            metrics.gauges.map { it.key to JsonGauge(it.value) }.toMap()
+    )
+}
+
+private val RATE_FACTOR = 1.0 / TimeUnit.MILLISECONDS.toNanos(1)
+private val DURATION_FACTOR = 1.0 / TimeUnit.MILLISECONDS.toNanos(1)
+

--- a/misk/src/main/kotlin/misk/metrics/web/MetricsJsonAction.kt
+++ b/misk/src/main/kotlin/misk/metrics/web/MetricsJsonAction.kt
@@ -1,0 +1,16 @@
+package misk.metrics.web
+
+import misk.metrics.Metrics
+import misk.web.Get
+import misk.web.JsonResponseBody
+import misk.web.actions.WebAction
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/** Exposes metrics as JSON over HTTP */
+@Singleton
+class MetricsJsonAction @Inject internal constructor(val metrics: Metrics) : WebAction {
+    @JsonResponseBody
+    @Get("/_metrics")
+    fun getMetrics(): JsonMetrics = JsonMetrics(metrics)
+}

--- a/misk/src/main/kotlin/misk/time/ClockModule.kt
+++ b/misk/src/main/kotlin/misk/time/ClockModule.kt
@@ -1,0 +1,10 @@
+package misk.time
+
+import com.google.inject.AbstractModule
+import java.time.Clock
+
+class ClockModule : AbstractModule() {
+    override fun configure() {
+        bind(Clock::class.java).toInstance(Clock.systemUTC())
+    }
+}

--- a/misk/src/main/kotlin/misk/time/FakeClock.kt
+++ b/misk/src/main/kotlin/misk/time/FakeClock.kt
@@ -1,0 +1,26 @@
+package misk.time
+
+import java.time.Clock
+import java.time.Duration
+import java.time.Instant
+import java.time.ZoneId
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicLong
+
+class FakeClock(private val zone: ZoneId = ZoneId.of("UTC")) : Clock() {
+    val millis = AtomicLong()
+
+    override fun getZone(): ZoneId {
+        return zone
+    }
+
+    override fun withZone(zone: ZoneId?): Clock {
+        // TODO(mmihic): Adjust for time zone
+        throw UnsupportedOperationException("nope")
+    }
+
+    override fun instant(): Instant = Instant.ofEpochMilli(millis.get())
+
+    fun add(d: Duration) = millis.addAndGet(d.toMillis())
+    fun add(n: Long, unit: TimeUnit) = millis.addAndGet(TimeUnit.MILLISECONDS.convert(n, unit))
+}

--- a/misk/src/main/kotlin/misk/time/FakeClockModule.kt
+++ b/misk/src/main/kotlin/misk/time/FakeClockModule.kt
@@ -1,0 +1,11 @@
+package misk.time
+
+import com.google.inject.AbstractModule
+import java.time.Clock
+
+class FakeClockModule : AbstractModule() {
+    override fun configure() {
+        bind(Clock::class.java).to(FakeClock::class.java)
+        bind(FakeClock::class.java).asEagerSingleton()
+    }
+}

--- a/misk/src/test/kotlin/misk/metrics/backends/stackdriver/StackDriverReporterTest.kt
+++ b/misk/src/test/kotlin/misk/metrics/backends/stackdriver/StackDriverReporterTest.kt
@@ -1,0 +1,279 @@
+package misk.metrics.backends.stackdriver
+
+import com.codahale.metrics.Gauge
+import com.google.api.client.util.DateTime
+import com.google.api.services.monitoring.v3.model.TimeSeries
+import com.google.common.truth.Truth.assertThat
+import com.google.inject.AbstractModule
+import com.google.inject.Provides
+import misk.config.AppName
+import misk.environment.InstanceMetadata
+import misk.metrics.Metrics
+import misk.metrics.MetricsModule
+import misk.testing.MiskTestRule
+import misk.time.FakeClock
+import misk.time.FakeClockModule
+import org.junit.Rule
+import org.junit.Test
+import java.math.BigDecimal
+import java.math.BigInteger
+import java.util.concurrent.TimeUnit
+import javax.inject.Inject
+import javax.inject.Singleton
+
+internal class StackDriverReporterTest {
+    companion object {
+        val APP_NAME = "my_app"
+        val INSTANCE_METADATA = InstanceMetadata("165.33.45.25", "us-west2")
+        val METRIC_PREFIX = "custom.googleapis.com/dw/$APP_NAME/${INSTANCE_METADATA.zone}/${INSTANCE_METADATA.instanceName}"
+        val START_TIME = DateTime("2017-11-23T16:46:32Z")
+        val NOW = DateTime("2017-11-24T21:56:30Z")
+
+        fun assertGauge(timeSeries: TimeSeries, expected: Double) {
+            assertThat(timeSeries.metricKind).isEqualTo("GAUGE")
+            assertThat(timeSeries.points).hasSize(1)
+            assertThat(timeSeries.points[0].value.doubleValue).isWithin(0.001).of(expected)
+            assertThat(timeSeries.points[0].interval.startTime).isNull()
+            assertThat(timeSeries.points[0].interval.endTime).isEqualTo(NOW.toStringRfc3339())
+        }
+
+        fun assertGauge(timeSeries: TimeSeries, expected: Long) {
+            assertThat(timeSeries.metricKind).isEqualTo("GAUGE")
+            assertThat(timeSeries.points).hasSize(1)
+            assertThat(timeSeries.points[0].value.int64Value).isEqualTo(expected)
+            assertThat(timeSeries.points[0].interval.startTime).isNull()
+            assertThat(timeSeries.points[0].interval.endTime).isEqualTo(NOW.toStringRfc3339())
+        }
+
+        fun assertCumulative(timeSeries: TimeSeries, expected: Long) {
+            assertThat(timeSeries.metricKind).isEqualTo("CUMULATIVE")
+            assertThat(timeSeries.points).hasSize(1)
+            assertThat(timeSeries.points[0].value.int64Value).isEqualTo(expected)
+            assertThat(timeSeries.points[0].interval.startTime)
+                    .isEqualTo(START_TIME.toStringRfc3339())
+            assertThat(timeSeries.points[0].interval.endTime).isEqualTo(NOW.toStringRfc3339())
+        }
+    }
+
+    @get:Rule
+    val miskTestRule = MiskTestRule(MetricsModule(), FakeClockModule(), TestModule())
+
+    @Inject internal lateinit var metrics: Metrics
+    @Inject internal lateinit var clock: FakeClock
+    @Inject internal lateinit var reporter: StackDriverReporter
+
+    @Test
+    fun timer() {
+        val timer = metrics.timer("foo")
+        timer.update(10, TimeUnit.SECONDS)
+        timer.update(11, TimeUnit.SECONDS)
+        timer.update(9, TimeUnit.SECONDS)
+        timer.update(12, TimeUnit.SECONDS)
+
+        val timeSeries = reporter.toTimeSeries("foo", timer, START_TIME, NOW)
+        val byType = timeSeries.map { it.metric.type to it }.toMap()
+
+        assertCumulative(byType["$METRIC_PREFIX/foo/count"]!!, 4)
+        assertGauge(byType["$METRIC_PREFIX/foo/max"]!!, 12000.0)
+        assertGauge(byType["$METRIC_PREFIX/foo/min"]!!, 9000.0)
+        assertGauge(byType["$METRIC_PREFIX/foo/mean"]!!, 10500.0)
+        assertGauge(byType["$METRIC_PREFIX/foo/stdDev"]!!, 1118.0339)
+        assertGauge(byType["$METRIC_PREFIX/foo/p50"]!!, 11000.0)
+        assertGauge(byType["$METRIC_PREFIX/foo/p75"]!!, 12000.0)
+        assertGauge(byType["$METRIC_PREFIX/foo/p95"]!!, 12000.0)
+        assertGauge(byType["$METRIC_PREFIX/foo/p98"]!!, 12000.0)
+        assertGauge(byType["$METRIC_PREFIX/foo/p99"]!!, 12000.0)
+        assertGauge(byType["$METRIC_PREFIX/foo/p999"]!!, 12000.0)
+    }
+
+    @Test
+    fun counter() {
+        val counter = metrics.counter("foo")
+        counter.inc(75)
+
+        val timeSeries = reporter.toTimeSeries("foo", counter, START_TIME, NOW)
+        val byType = timeSeries.map { it.metric.type to it }.toMap()
+        assertCumulative(byType["$METRIC_PREFIX/foo/count"]!!, 75)
+    }
+
+    @Test
+    fun histogram() {
+        val hist = metrics.histogram("foo")
+        hist.update(10000)
+        hist.update(11000)
+        hist.update(9000)
+        hist.update(12000)
+
+        val timeSeries = reporter.toTimeSeries("foo", hist, START_TIME, NOW)
+        val byType = timeSeries.map { it.metric.type to it }.toMap()
+
+        assertCumulative(byType["$METRIC_PREFIX/foo/count"]!!, 4)
+        assertGauge(byType["$METRIC_PREFIX/foo/max"]!!, 12000.0)
+        assertGauge(byType["$METRIC_PREFIX/foo/min"]!!, 9000.0)
+        assertGauge(byType["$METRIC_PREFIX/foo/mean"]!!, 10500.0)
+        assertGauge(byType["$METRIC_PREFIX/foo/stdDev"]!!, 1118.0339)
+        assertGauge(byType["$METRIC_PREFIX/foo/p50"]!!, 11000.0)
+        assertGauge(byType["$METRIC_PREFIX/foo/p75"]!!, 12000.0)
+        assertGauge(byType["$METRIC_PREFIX/foo/p95"]!!, 12000.0)
+        assertGauge(byType["$METRIC_PREFIX/foo/p98"]!!, 12000.0)
+        assertGauge(byType["$METRIC_PREFIX/foo/p99"]!!, 12000.0)
+        assertGauge(byType["$METRIC_PREFIX/foo/p999"]!!, 12000.0)
+    }
+
+    @Test
+    fun longGauge() {
+        val f: () -> Long = { 42 }
+        val gauge: Gauge<Any> = metrics.gauge("foo", f)
+
+        val timeSeries = reporter.toTimeSeries("foo", gauge, START_TIME, NOW)
+        val byType = timeSeries.map { it.metric.type to it }.toMap()
+        assertGauge(byType["$METRIC_PREFIX/foo/value"]!!, 42)
+    }
+
+    @Test
+    fun intGauge() {
+        val f: () -> Int = { 42 }
+        val gauge: Gauge<Any> = metrics.gauge("foo", f)
+
+        val timeSeries = reporter.toTimeSeries("foo", gauge, START_TIME, NOW)
+        val byType = timeSeries.map { it.metric.type to it }.toMap()
+        assertGauge(byType["$METRIC_PREFIX/foo/value"]!!, 42)
+    }
+
+    @Test
+    fun doubleGauge() {
+        val f: () -> Double = { 42.4 }
+        val gauge: Gauge<Any> = metrics.gauge("foo", f)
+
+        val timeSeries = reporter.toTimeSeries("foo", gauge, START_TIME, NOW)
+        val byType = timeSeries.map { it.metric.type to it }.toMap()
+        assertGauge(byType["$METRIC_PREFIX/foo/value"]!!, 42.4)
+
+    }
+
+    @Test
+    fun floatGauge() {
+        val f: () -> Float = { 42.4f }
+        val gauge: Gauge<Any> = metrics.gauge("foo", f)
+
+        val timeSeries = reporter.toTimeSeries("foo", gauge, START_TIME, NOW)
+        val byType = timeSeries.map { it.metric.type to it }.toMap()
+        assertGauge(byType["$METRIC_PREFIX/foo/value"]!!, 42.4)
+    }
+
+    @Test
+    fun byteGauge() {
+        val f: () -> Byte = { 42 }
+        val gauge: Gauge<Any> = metrics.gauge("foo", f)
+
+        val timeSeries = reporter.toTimeSeries("foo", gauge, START_TIME, NOW)
+        val byType = timeSeries.map { it.metric.type to it }.toMap()
+        assertGauge(byType["$METRIC_PREFIX/foo/value"]!!, 42)
+    }
+
+    @Test
+    fun bigDecimalGauge() {
+        val f: () -> BigDecimal = { BigDecimal.valueOf(42.4) }
+        val gauge: Gauge<Any> = metrics.gauge("foo", f)
+
+        val timeSeries = reporter.toTimeSeries("foo", gauge, START_TIME, NOW)
+        val byType = timeSeries.map { it.metric.type to it }.toMap()
+        assertGauge(byType["$METRIC_PREFIX/foo/value"]!!, 42.4)
+    }
+
+    @Test
+    fun bigIntegerGauge() {
+        val f: () -> BigInteger = { BigInteger.valueOf(42) }
+        val gauge: Gauge<Any> = metrics.gauge("foo", f)
+
+        val timeSeries = reporter.toTimeSeries("foo", gauge, START_TIME, NOW)
+        val byType = timeSeries.map { it.metric.type to it }.toMap()
+        assertGauge(byType["$METRIC_PREFIX/foo/value"]!!, 42.toDouble())
+    }
+
+    @Test
+    fun toTimeSeries() {
+        metrics.timer("fiddy").update(10, TimeUnit.MILLISECONDS)
+        metrics.timer("fiddy").update(23, TimeUnit.MILLISECONDS)
+        metrics.counter("fenty").inc(245)
+        metrics.counter("rent").inc(744)
+        metrics.counter("kent").inc(95)
+        metrics.gauge("im-basic", { 42 })
+        metrics.histogram("histy").update(65)
+        metrics.histogram("histy").update(66)
+        metrics.histogram("histy").update(67)
+        metrics.histogram("crows").update(99)
+        metrics.histogram("crows").update(102)
+
+        val timeSeries = reporter.toTimeSeries(
+                metrics.gauges,
+                metrics.counters,
+                metrics.histograms,
+                null,
+                metrics.timers,
+                START_TIME, NOW)
+
+        val names = timeSeries.map { it.metric.type to it }.toMap()
+        assertThat(names.keys).containsExactly(
+                "custom.googleapis.com/dw/my_app/us-west2/165.33.45.25/im-basic/value",
+                "custom.googleapis.com/dw/my_app/us-west2/165.33.45.25/fenty/count",
+                "custom.googleapis.com/dw/my_app/us-west2/165.33.45.25/kent/count",
+                "custom.googleapis.com/dw/my_app/us-west2/165.33.45.25/rent/count",
+                "custom.googleapis.com/dw/my_app/us-west2/165.33.45.25/crows/count",
+                "custom.googleapis.com/dw/my_app/us-west2/165.33.45.25/crows/max",
+                "custom.googleapis.com/dw/my_app/us-west2/165.33.45.25/crows/min",
+                "custom.googleapis.com/dw/my_app/us-west2/165.33.45.25/crows/mean",
+                "custom.googleapis.com/dw/my_app/us-west2/165.33.45.25/crows/stdDev",
+                "custom.googleapis.com/dw/my_app/us-west2/165.33.45.25/crows/p50",
+                "custom.googleapis.com/dw/my_app/us-west2/165.33.45.25/crows/p75",
+                "custom.googleapis.com/dw/my_app/us-west2/165.33.45.25/crows/p95",
+                "custom.googleapis.com/dw/my_app/us-west2/165.33.45.25/crows/p98",
+                "custom.googleapis.com/dw/my_app/us-west2/165.33.45.25/crows/p99",
+                "custom.googleapis.com/dw/my_app/us-west2/165.33.45.25/crows/p999",
+                "custom.googleapis.com/dw/my_app/us-west2/165.33.45.25/histy/count",
+                "custom.googleapis.com/dw/my_app/us-west2/165.33.45.25/histy/max",
+                "custom.googleapis.com/dw/my_app/us-west2/165.33.45.25/histy/min",
+                "custom.googleapis.com/dw/my_app/us-west2/165.33.45.25/histy/mean",
+                "custom.googleapis.com/dw/my_app/us-west2/165.33.45.25/histy/stdDev",
+                "custom.googleapis.com/dw/my_app/us-west2/165.33.45.25/histy/p50",
+                "custom.googleapis.com/dw/my_app/us-west2/165.33.45.25/histy/p75",
+                "custom.googleapis.com/dw/my_app/us-west2/165.33.45.25/histy/p95",
+                "custom.googleapis.com/dw/my_app/us-west2/165.33.45.25/histy/p98",
+                "custom.googleapis.com/dw/my_app/us-west2/165.33.45.25/histy/p99",
+                "custom.googleapis.com/dw/my_app/us-west2/165.33.45.25/histy/p999",
+                "custom.googleapis.com/dw/my_app/us-west2/165.33.45.25/fiddy/max",
+                "custom.googleapis.com/dw/my_app/us-west2/165.33.45.25/fiddy/min",
+                "custom.googleapis.com/dw/my_app/us-west2/165.33.45.25/fiddy/mean",
+                "custom.googleapis.com/dw/my_app/us-west2/165.33.45.25/fiddy/stdDev",
+                "custom.googleapis.com/dw/my_app/us-west2/165.33.45.25/fiddy/p50",
+                "custom.googleapis.com/dw/my_app/us-west2/165.33.45.25/fiddy/p75",
+                "custom.googleapis.com/dw/my_app/us-west2/165.33.45.25/fiddy/p95",
+                "custom.googleapis.com/dw/my_app/us-west2/165.33.45.25/fiddy/p98",
+                "custom.googleapis.com/dw/my_app/us-west2/165.33.45.25/fiddy/p99",
+                "custom.googleapis.com/dw/my_app/us-west2/165.33.45.25/fiddy/p999",
+                "custom.googleapis.com/dw/my_app/us-west2/165.33.45.25/fiddy/count",
+                "custom.googleapis.com/dw/my_app/us-west2/165.33.45.25/fiddy/m1_rate",
+                "custom.googleapis.com/dw/my_app/us-west2/165.33.45.25/fiddy/mean_rate",
+                "custom.googleapis.com/dw/my_app/us-west2/165.33.45.25/fiddy/m5_rate",
+                "custom.googleapis.com/dw/my_app/us-west2/165.33.45.25/fiddy/m15_rate")
+    }
+
+    class TestModule : AbstractModule() {
+        override fun configure() {
+        }
+
+        @Provides
+        @Singleton
+        fun stackDriverSender(): StackDriverSender = object : StackDriverSender {
+            override fun send(timeSeries: List<TimeSeries>) {}
+        }
+
+        @Provides
+        @Singleton
+        fun instanceMetadata(): InstanceMetadata = INSTANCE_METADATA
+
+        @Provides
+        @AppName
+        fun appName(): String = APP_NAME
+    }
+}

--- a/misk/src/test/kotlin/misk/metrics/web/MetricsJsonActionTest.kt
+++ b/misk/src/test/kotlin/misk/metrics/web/MetricsJsonActionTest.kt
@@ -1,0 +1,39 @@
+package misk.metrics.web
+
+import com.google.common.truth.Truth.assertThat
+import misk.metrics.Metrics
+import misk.metrics.MetricsModule
+import misk.testing.MiskTestRule
+import org.junit.Rule
+import org.junit.Test
+import java.util.concurrent.TimeUnit
+import javax.inject.Inject
+
+internal class MetricsJsonActionTest {
+    @get:Rule
+    val miskTestRule = MiskTestRule(MetricsModule())
+
+    @Inject internal lateinit var metrics: Metrics
+    @Inject internal lateinit var metricsAction: MetricsJsonAction
+
+    @Test
+    fun exposeMetrics() {
+        metrics.counter("myfav").inc(32)
+        metrics.counter("banana").inc(17)
+        metrics.counter("joist").inc(5)
+        metrics.timer("slow").update(392, TimeUnit.MILLISECONDS)
+        metrics.timer("slow").update(256, TimeUnit.MILLISECONDS)
+        metrics.histogram("mork").update(24)
+        metrics.histogram("mork").update(17)
+        metrics.histogram("mork").update(27)
+        metrics.gauge("g1", { 42 })
+        metrics.gauge("g2", { 3.14 })
+        metrics.gauge("g3", { "howdy pardner" })
+
+        val json = metricsAction.getMetrics()
+        assertThat(json.counters.keys).containsExactly("myfav", "banana", "joist")
+        assertThat(json.timers.keys).containsExactly("slow")
+        assertThat(json.histograms.keys).containsExactly("mork")
+        assertThat(json.gauges.keys).containsExactly("g1", "g2", "g3")
+    }
+}


### PR DESCRIPTION
Graphite + StackDriver + web endpoint exposing metrics as JSON over HTTP
for manual expection and pull-based tooling such as Prometheus