### PR TITLE
Improve the documentation for classes in the web.extractors package

### DIFF
--- a/misk/src/main/kotlin/misk/web/WebActionsModule.kt
+++ b/misk/src/main/kotlin/misk/web/WebActionsModule.kt
@@ -7,7 +7,7 @@ import misk.inject.to
 import misk.web.extractors.HeadersParameterExtractorFactory
 import misk.web.extractors.JsonBodyParameterExtractorFactory
 import misk.web.extractors.ParameterExtractor
-import misk.web.extractors.PathPatternParameterExtractor
+import misk.web.extractors.PathPatternParameterExtractorFactory
 import misk.web.interceptors.BoxResponseInterceptorFactory
 import misk.web.interceptors.InternalErrorInterceptorFactory
 import misk.web.interceptors.JsonInterceptorFactory
@@ -23,7 +23,7 @@ class WebActionsModule : AbstractModule() {
         binder().addMultibinderBinding<Interceptor.Factory>().toInstance(PlaintextInterceptorFactory)
         binder().addMultibinderBinding<Interceptor.Factory>().to<MetricsInterceptor.Factory>()
         binder().addMultibinderBinding<Interceptor.Factory>().to<BoxResponseInterceptorFactory>()
-        binder().addMultibinderBinding<ParameterExtractor.Factory>().toInstance(PathPatternParameterExtractor)
+        binder().addMultibinderBinding<ParameterExtractor.Factory>().toInstance(PathPatternParameterExtractorFactory)
         binder().addMultibinderBinding<ParameterExtractor.Factory>().to<JsonBodyParameterExtractorFactory>()
         binder().addMultibinderBinding<ParameterExtractor.Factory>().toInstance(HeadersParameterExtractorFactory)
     }

--- a/misk/src/main/kotlin/misk/web/extractors/HeadersParameterExtractorFactory.kt
+++ b/misk/src/main/kotlin/misk/web/extractors/HeadersParameterExtractorFactory.kt
@@ -8,7 +8,11 @@ import java.util.regex.Matcher
 import kotlin.reflect.KParameter
 import kotlin.reflect.full.findAnnotation
 
-val HeadersParameterExtractorFactory = object : ParameterExtractor.Factory {
+/**
+ * Creates a [ParameterExtractor] that returns [Request.headers] from a [Request] if the parameter
+ * is annotated with [RequestHeaders].
+ */
+object HeadersParameterExtractorFactory : ParameterExtractor.Factory {
     private val extractor = object : ParameterExtractor {
         override fun extract(webAction: WebAction, request: Request, pathMatcher: Matcher): Any? {
             return request.headers

--- a/misk/src/main/kotlin/misk/web/extractors/JsonBodyParameterExtractorFactory.kt
+++ b/misk/src/main/kotlin/misk/web/extractors/JsonBodyParameterExtractorFactory.kt
@@ -7,13 +7,19 @@ import misk.web.actions.WebAction
 import com.squareup.moshi.Moshi
 import java.util.regex.Matcher
 import javax.inject.Inject
+import javax.inject.Singleton
 import kotlin.reflect.KParameter
 import kotlin.reflect.full.findAnnotation
 import kotlin.reflect.jvm.javaType
 
+@Singleton
 internal class JsonBodyParameterExtractorFactory @Inject constructor(
     private val moshi: Moshi
 ) : ParameterExtractor.Factory {
+    /**
+     * Creates a [ParameterExtractor] that returns the JSON body of a request if the parameter
+     * is annotated with [JsonRequestBody], otherwise returns null.
+     */
     override fun create(parameter: KParameter, pathPattern: PathPattern): ParameterExtractor? {
         if (parameter.findAnnotation<JsonRequestBody>() == null) return null
 

--- a/misk/src/main/kotlin/misk/web/extractors/ParameterExtractor.kt
+++ b/misk/src/main/kotlin/misk/web/extractors/ParameterExtractor.kt
@@ -7,9 +7,19 @@ import java.util.regex.Matcher
 import kotlin.reflect.KParameter
 
 interface ParameterExtractor {
+    /**
+     * Extracts a parameter from [request], such as a URL parameter or the request body.
+     */
     fun extract(webAction: WebAction, request: Request, pathMatcher: Matcher): Any?
 
     interface Factory {
+        /**
+         * Returns an instance of a [ParameterExtractor] that extracts the value for [parameter],
+         * or null if the extractor does not apply to [parameter].
+         *
+         * See [HeadersParameterExtractorFactory] and [JsonBodyParameterExtractorFactory] for
+         * examples.
+         */
         fun create(parameter: KParameter, pathPattern: PathPattern): ParameterExtractor?
     }
 }

--- a/misk/src/main/kotlin/misk/web/extractors/PathPatternParameterExtractor.kt
+++ b/misk/src/main/kotlin/misk/web/extractors/PathPatternParameterExtractor.kt
@@ -8,7 +8,11 @@ import java.util.regex.Matcher
 import kotlin.reflect.KParameter
 import kotlin.reflect.full.findAnnotation
 
-val PathPatternParameterExtractor = object : ParameterExtractor.Factory {
+/**
+ * Creates a [ParameterExtractor] that extracts the URL parameter with the same name as [parameter]
+ * and returns it as a [String]. If the parameter name doesn't occur in [pathPattern], returns null.
+ */
+object PathPatternParameterExtractorFactory : ParameterExtractor.Factory {
     override fun create(parameter: KParameter, pathPattern: PathPattern): ParameterExtractor? {
         val pathParamAnnotation = parameter.findAnnotation<PathParam>()
         val parameterName = pathParamAnnotation?.value ?: parameter.name


### PR DESCRIPTION
Part of an ongoing effort to shore up the documentation for classes that likely won't change a whole lot, like the JSON and path pattern parameter extractors.