### PR TITLE
Make Moshi instance use user-provided adapter factories

### DIFF
--- a/exemplar/src/main/kotlin/com/squareup/exemplar/ExemplarService.kt
+++ b/exemplar/src/main/kotlin/com/squareup/exemplar/ExemplarService.kt
@@ -2,7 +2,6 @@ package com.squareup.exemplar
 
 import misk.MiskApplication
 import misk.MiskModule
-import misk.environment.Environment
 import misk.environment.EnvironmentModule
 import misk.hibernate.HibernateModule
 import misk.moshi.MoshiModule

--- a/misk/src/main/kotlin/misk/moshi/MoshiModule.kt
+++ b/misk/src/main/kotlin/misk/moshi/MoshiModule.kt
@@ -2,15 +2,25 @@ package misk.moshi
 
 import com.google.inject.AbstractModule
 import com.google.inject.Provides
+import com.google.inject.multibindings.Multibinder
+import com.squareup.moshi.JsonAdapter
 import com.squareup.moshi.Moshi
 import javax.inject.Singleton
 
 class MoshiModule : AbstractModule() {
-    override fun configure() {}
+    override fun configure() {
+        Multibinder.newSetBinder(binder(), JsonAdapter.Factory::class.java)
+    }
 
     @Provides
     @Singleton
-    fun provideMoshi(): Moshi {
-        return Moshi.Builder().build()
+    fun provideMoshi(
+        jsonAdapterFactories: MutableSet<JsonAdapter.Factory>
+    ): Moshi {
+        val builder = Moshi.Builder()
+        for (jsonAdapterFactory in jsonAdapterFactories) {
+            builder.add(jsonAdapterFactory)
+        }
+        return builder.build()
     }
 }


### PR DESCRIPTION
Users can contribute adapters to the Multibinder, which will be used when requests are serialized to JSON.