### PR TITLE
Add Guice extension functions

### DIFF
--- a/exemplar/src/main/java/com/squareup/exemplar/ExemplarJavaApp.java
+++ b/exemplar/src/main/java/com/squareup/exemplar/ExemplarJavaApp.java
@@ -18,7 +18,6 @@ public class ExemplarJavaApp {
 
         new ExemplarJavaModule(),
         new ExemplarJavaConfigModule(),
-        new MoshiModule(),
         EnvironmentModule.fromEnvironmentVariable()
     ).startAndAwaitStopped();
   }

--- a/misk/src/main/kotlin/misk/Actions.kt
+++ b/misk/src/main/kotlin/misk/Actions.kt
@@ -1,6 +1,6 @@
 package misk
 
-import misk.web.typeLiteral
+import misk.inject.typeLiteral
 import kotlin.reflect.KClass
 import kotlin.reflect.KFunction
 import kotlin.reflect.full.instanceParameter
@@ -9,8 +9,8 @@ fun KFunction<*>.asAction(): Action {
     val instanceParameter = this.instanceParameter
             ?: throw IllegalArgumentException("only methods may be actions")
 
-    val parameterTypes = this.parameters.drop(1).map { it.type.typeLiteral }
-    val returnType = this.returnType.typeLiteral
+    val parameterTypes = this.parameters.drop(1).map { it.type.typeLiteral() }
+    val returnType = this.returnType.typeLiteral()
     val name = instanceParameter.type.classifier?.let {
         when (it) {
             is KClass<*> -> it.simpleName

--- a/misk/src/main/kotlin/misk/MiskApplication.kt
+++ b/misk/src/main/kotlin/misk/MiskApplication.kt
@@ -3,13 +3,12 @@ package misk
 import com.google.common.util.concurrent.ServiceManager
 import com.google.inject.Guice
 import com.google.inject.Module
+import misk.inject.getInstance
 
 class MiskApplication(private vararg val modules: Module) {
     fun startAndAwaitStopped() {
-        val injector = Guice.createInjector(
-               modules.asList()
-        )
-        val serviceManager = injector.getInstance(ServiceManager::class.java)
+        val injector = Guice.createInjector(*modules)
+        val serviceManager = injector.getInstance<ServiceManager>()
 
         Runtime.getRuntime().addShutdownHook(object : Thread() {
             override fun run() {

--- a/misk/src/main/kotlin/misk/config/ConfigModule.kt
+++ b/misk/src/main/kotlin/misk/config/ConfigModule.kt
@@ -1,10 +1,10 @@
 package misk.config
 
-import com.google.inject.AbstractModule
 import com.google.inject.TypeLiteral
 import com.google.inject.name.Names
+import misk.inject.KAbstractModule
 import misk.inject.asSingleton
-import misk.web.typeLiteral
+import misk.inject.typeLiteral
 import javax.inject.Provider
 import kotlin.reflect.KProperty1
 import kotlin.reflect.full.createType
@@ -15,10 +15,10 @@ import kotlin.reflect.jvm.javaType
 class ConfigModule(
     private val configClass: Class<out Config>,
     private val appName: String
-) : AbstractModule() {
+) : KAbstractModule() {
     @Suppress("UNCHECKED_CAST")
     override fun configure() {
-        bind(String::class.java).annotatedWith(AppName::class.java).toInstance(appName)
+        bind<String>().annotatedWith<AppName>().toInstance(appName)
         bind(configClass).toProvider(ConfigProvider(configClass, appName)).asSingleton()
         bindConfigClassRecursively(configClass)
     }
@@ -29,7 +29,7 @@ class ConfigModule(
             if (!property.returnType.isSubtypeOf(Config::class.createType())) {
                 continue
             }
-            bindConfigClassRecursively(property.returnType.typeLiteral.rawType as Class<out Config>)
+            bindConfigClassRecursively(property.returnType.typeLiteral().rawType as Class<out Config>)
             val subConfigProvider = SubConfigProvider(getProvider(configClass), property as KProperty1<Config, Any?>)
             val subConfigTypeLiteral = TypeLiteral.get(property.returnType.javaType) as TypeLiteral<Any?>
 

--- a/misk/src/main/kotlin/misk/environment/EnvironmentModule.kt
+++ b/misk/src/main/kotlin/misk/environment/EnvironmentModule.kt
@@ -1,13 +1,13 @@
 package misk.environment
 
-import com.google.inject.AbstractModule
+import misk.inject.KAbstractModule
 import misk.logging.getLogger
 
 private val logger = getLogger<EnvironmentModule>()
 
-class EnvironmentModule(val environment: Environment) : AbstractModule() {
+class EnvironmentModule(val environment: Environment) : KAbstractModule() {
     override fun configure() {
-        bind(Environment::class.java).toInstance(environment)
+        bind<Environment>().toInstance(environment)
     }
 
     companion object {

--- a/misk/src/main/kotlin/misk/environment/StaticInstanceMetadataModule.kt
+++ b/misk/src/main/kotlin/misk/environment/StaticInstanceMetadataModule.kt
@@ -1,10 +1,10 @@
 package misk.environment
 
-import com.google.inject.AbstractModule
+import misk.inject.KAbstractModule
 
 /** Provides a hard-coded set of instance metadata */
-class StaticInstanceMetadataModule(val metadata: InstanceMetadata) : AbstractModule() {
+class StaticInstanceMetadataModule(val metadata: InstanceMetadata) : KAbstractModule() {
     override fun configure() {
-        bind(InstanceMetadata::class.java).toInstance(metadata)
+        bind<InstanceMetadata>().toInstance(metadata)
     }
 }

--- a/misk/src/main/kotlin/misk/healthchecks/HealthChecksModule.kt
+++ b/misk/src/main/kotlin/misk/healthchecks/HealthChecksModule.kt
@@ -1,13 +1,12 @@
 package misk.healthchecks
 
-import com.google.inject.AbstractModule
-import com.google.inject.multibindings.Multibinder
+import misk.inject.KAbstractModule
 
 class HealthChecksModule(
     private vararg val healthCheckClasses: Class<out HealthCheck>
-) : AbstractModule() {
+) : KAbstractModule() {
     override fun configure() {
-        val setBinder = Multibinder.newSetBinder(binder(), HealthCheck::class.java)
+        val setBinder = newSetBinder<HealthCheck>()
         for (healthCheckClass in healthCheckClasses) {
             setBinder.addBinding().to(healthCheckClass)
         }

--- a/misk/src/main/kotlin/misk/inject/Guice.kt
+++ b/misk/src/main/kotlin/misk/inject/Guice.kt
@@ -1,14 +1,20 @@
 package misk.inject
 
 import com.google.inject.Binder
+import com.google.inject.Injector
 import com.google.inject.TypeLiteral
 import com.google.inject.binder.LinkedBindingBuilder
 import com.google.inject.binder.ScopedBindingBuilder
 import com.google.inject.multibindings.Multibinder
 import com.google.inject.util.Types
+import java.lang.reflect.ParameterizedType
+import java.lang.reflect.Type
+import java.lang.reflect.WildcardType
 import javax.inject.Inject
 import javax.inject.Provider
 import javax.inject.Singleton
+import kotlin.reflect.KType
+import kotlin.reflect.jvm.javaType
 
 internal inline fun <reified T : Any> LinkedBindingBuilder<in T>.to() = to(T::class.java)
 
@@ -18,8 +24,8 @@ internal inline fun <reified T : Any, reified A : Annotation> Binder.addMultibin
 internal inline fun <reified T : Any> Binder.addMultibinderBinding(
     annotation: Class<out Annotation>? = null
 ): LinkedBindingBuilder<T> {
-    val typeLiteral = TypeLiteral.get(Types.newParameterizedType(List::class.java, Types.subtypeOf(T::class.java))) as TypeLiteral<List<T>>
-    bind(typeLiteral).toProvider(TypeLiteral.get(Types.newParameterizedType(ListProvider::class.java, T::class.java)) as TypeLiteral<Provider<List<T>>>)
+    val typeLiteral = parameterizedType<List<*>>(subtypeOf<T>()).typeLiteral() as TypeLiteral<List<T>>
+    bind(typeLiteral).toProvider(parameterizedType<ListProvider<*>>(T::class.java).typeLiteral() as TypeLiteral<Provider<List<T>>>)
 
     return when (annotation) {
         null -> Multibinder.newSetBinder(this, T::class.java).addBinding()
@@ -35,6 +41,24 @@ internal class ListProvider<T> : Provider<List<T>> {
     @Inject lateinit var set: MutableSet<T>
 
     override fun get(): List<T> = ArrayList(set)
+}
+
+internal inline fun <reified T : Any> subtypeOf(): WildcardType {
+    return Types.subtypeOf(T::class.java)
+}
+
+internal inline fun <reified T : Any> parameterizedType(vararg typeParameters: Type): ParameterizedType {
+    return Types.newParameterizedType(T::class.java, *typeParameters)
+}
+
+internal fun ParameterizedType.typeLiteral() = TypeLiteral.get(this)
+
+internal fun KType.typeLiteral(): TypeLiteral<*> {
+    return TypeLiteral.get(javaType)
+}
+
+internal inline fun <reified T : Any> Injector.getInstance(): T {
+    return getInstance(T::class.java)
 }
 
 fun uninject(target: Any) {

--- a/misk/src/main/kotlin/misk/inject/KAbstractModule.kt
+++ b/misk/src/main/kotlin/misk/inject/KAbstractModule.kt
@@ -1,0 +1,46 @@
+package misk.inject
+
+import com.google.inject.AbstractModule
+import com.google.inject.binder.AnnotatedBindingBuilder
+import com.google.inject.binder.LinkedBindingBuilder
+import com.google.inject.binder.ScopedBindingBuilder
+import com.google.inject.multibindings.Multibinder
+
+/**
+ * A class that provides helper methods for working with Kotlin and Guice, allowing implementing
+ * classes to operate in the Kotlin type system rather than converting to Java.
+ *
+ * The more Kotlin friendly API allows calls like:
+ *
+ * ```
+ * bind(Foo::class.java).to(RealFoo::class.java)
+ * ```
+ *
+ * To be rewritten as:
+ * ```
+ * bind<Foo>().to<RealFoo>()
+ * ```
+ */
+abstract class KAbstractModule : AbstractModule() {
+    protected class KotlinAnnotatedBindingBuilder<X>(
+        private val annotatedBuilder: AnnotatedBindingBuilder<X>
+    ) : AnnotatedBindingBuilder<X> by annotatedBuilder {
+        inline fun <reified T : Annotation> annotatedWith(): LinkedBindingBuilder<X> {
+            return annotatedWith(T::class.java)
+        }
+    }
+
+    protected inline fun <reified T : Any> bind(): KotlinAnnotatedBindingBuilder<in T> {
+        return KotlinAnnotatedBindingBuilder<T>(binder().bind(T::class.java))
+    }
+
+    protected inline fun <reified T : Any> AnnotatedBindingBuilder<in T>.to(): ScopedBindingBuilder {
+        return to(T::class.java)
+    }
+
+    protected inline fun <reified T : Any> newSetBinder(): Multibinder<T> {
+        return Multibinder.newSetBinder(binder(), T::class.java)
+    }
+}
+
+

--- a/misk/src/main/kotlin/misk/metrics/MetricsModule.kt
+++ b/misk/src/main/kotlin/misk/metrics/MetricsModule.kt
@@ -1,11 +1,11 @@
 package misk.metrics
 
 import com.codahale.metrics.MetricRegistry
-import com.google.inject.AbstractModule
+import misk.inject.KAbstractModule
 
-class MetricsModule : AbstractModule() {
+class MetricsModule : KAbstractModule() {
     override fun configure() {
-        bind(Metrics::class.java).asEagerSingleton()
-        bind(MetricRegistry::class.java).asEagerSingleton()
+        bind<Metrics>().asEagerSingleton()
+        bind<MetricRegistry>().asEagerSingleton()
     }
 }

--- a/misk/src/main/kotlin/misk/metrics/backends/graphite/GraphiteBackendModule.kt
+++ b/misk/src/main/kotlin/misk/metrics/backends/graphite/GraphiteBackendModule.kt
@@ -23,15 +23,16 @@ class GraphiteBackendModule : AbstractModule() {
     @Provides
     @Singleton
     fun graphiteSender(config: GraphiteBackendConfig): GraphiteSender =
-            Graphite(config.host, config.port)
+        Graphite(config.host, config.port)
 
     @Provides
     @Singleton
     fun graphiteReporter(
-            @AppName appName: String,
-            instanceMetadata: InstanceMetadata,
-            metricRegistry: MetricRegistry,
-            sender: GraphiteSender): GraphiteReporter {
+        @AppName appName: String,
+        instanceMetadata: InstanceMetadata,
+        metricRegistry: MetricRegistry,
+        sender: GraphiteSender
+    ): GraphiteReporter {
 
         val instanceName = Metrics.sanitize(instanceMetadata.instanceName)
         val zone = Metrics.sanitize(instanceMetadata.zone)

--- a/misk/src/main/kotlin/misk/metrics/backends/stackdriver/StackDriverBackendModule.kt
+++ b/misk/src/main/kotlin/misk/metrics/backends/stackdriver/StackDriverBackendModule.kt
@@ -4,18 +4,18 @@ import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport
 import com.google.api.client.json.jackson2.JacksonFactory
 import com.google.api.services.monitoring.v3.Monitoring
 import com.google.common.util.concurrent.Service
-import com.google.inject.AbstractModule
 import com.google.inject.Provides
 import com.google.inject.Singleton
 import misk.config.AppName
+import misk.inject.KAbstractModule
 import misk.inject.addMultibinderBinding
 import misk.inject.asSingleton
 import misk.inject.to
 
-class StackDriverBackendModule : AbstractModule() {
+class StackDriverBackendModule : KAbstractModule() {
     override fun configure() {
-        bind(StackDriverSender::class.java)
-                .to(StackDriverBatchedSender::class.java)
+        bind<StackDriverSender>()
+                .to<StackDriverBatchedSender>()
                 .asSingleton()
 
         binder().addMultibinderBinding<Service>().to<StackDriverReporterService>()
@@ -24,10 +24,10 @@ class StackDriverBackendModule : AbstractModule() {
     @Provides
     @Singleton
     fun monitoring(@AppName appName: String, config: StackDriverBackendConfig): Monitoring =
-            Monitoring.Builder(GoogleNetHttpTransport.newTrustedTransport(), JacksonFactory(), null)
-                    .setApplicationName(appName)
-                    .setServicePath(config.service_path)
-                    .setRootUrl(config.root_url)
-                    .build()
+        Monitoring.Builder(GoogleNetHttpTransport.newTrustedTransport(), JacksonFactory(), null)
+                .setApplicationName(appName)
+                .setServicePath(config.service_path)
+                .setRootUrl(config.root_url)
+                .build()
 
 }

--- a/misk/src/main/kotlin/misk/moshi/MoshiModule.kt
+++ b/misk/src/main/kotlin/misk/moshi/MoshiModule.kt
@@ -1,15 +1,14 @@
 package misk.moshi
 
-import com.google.inject.AbstractModule
 import com.google.inject.Provides
-import com.google.inject.multibindings.Multibinder
 import com.squareup.moshi.JsonAdapter
 import com.squareup.moshi.Moshi
+import misk.inject.KAbstractModule
 import javax.inject.Singleton
 
-class MoshiModule : AbstractModule() {
+class MoshiModule : KAbstractModule() {
     override fun configure() {
-        Multibinder.newSetBinder(binder(), JsonAdapter.Factory::class.java)
+        newSetBinder<JsonAdapter.Factory>()
     }
 
     @Provides

--- a/misk/src/main/kotlin/misk/time/ClockModule.kt
+++ b/misk/src/main/kotlin/misk/time/ClockModule.kt
@@ -1,10 +1,10 @@
 package misk.time
 
-import com.google.inject.AbstractModule
+import misk.inject.KAbstractModule
 import java.time.Clock
 
-class ClockModule : AbstractModule() {
+class ClockModule : KAbstractModule() {
     override fun configure() {
-        bind(Clock::class.java).toInstance(Clock.systemUTC())
+        bind<Clock>().toInstance(Clock.systemUTC())
     }
 }

--- a/misk/src/main/kotlin/misk/time/FakeClockModule.kt
+++ b/misk/src/main/kotlin/misk/time/FakeClockModule.kt
@@ -1,11 +1,11 @@
 package misk.time
 
-import com.google.inject.AbstractModule
+import misk.inject.KAbstractModule
 import java.time.Clock
 
-class FakeClockModule : AbstractModule() {
+class FakeClockModule : KAbstractModule() {
     override fun configure() {
-        bind(Clock::class.java).to(FakeClock::class.java)
-        bind(FakeClock::class.java).asEagerSingleton()
+        bind<Clock>().to<FakeClock>()
+        bind<FakeClock>().asEagerSingleton()
     }
 }

--- a/misk/src/main/kotlin/misk/web/WebActionModule.kt
+++ b/misk/src/main/kotlin/misk/web/WebActionModule.kt
@@ -1,12 +1,13 @@
 package misk.web
 
 import com.google.inject.AbstractModule
-import com.google.inject.TypeLiteral
 import com.google.inject.multibindings.Multibinder
-import com.squareup.moshi.Types
 import misk.Interceptor
 import misk.MiskDefault
 import misk.asAction
+import misk.inject.parameterizedType
+import misk.inject.subtypeOf
+import misk.inject.typeLiteral
 import misk.web.actions.WebAction
 import misk.web.extractors.ParameterExtractor
 import org.eclipse.jetty.http.HttpMethod
@@ -14,8 +15,6 @@ import javax.inject.Inject
 import javax.inject.Provider
 import kotlin.reflect.KClass
 import kotlin.reflect.KFunction
-import kotlin.reflect.KType
-import kotlin.reflect.jvm.javaType
 
 class WebActionModule<A : WebAction> private constructor(
     val webActionClass: KClass<A>,
@@ -28,9 +27,7 @@ class WebActionModule<A : WebAction> private constructor(
         @Suppress("UNCHECKED_CAST")
         val binder: Multibinder<BoundAction<A, *>> = Multibinder.newSetBinder(
                 binder(),
-                TypeLiteral.get(Types.newParameterizedType(BoundAction::class.java,
-                        Types.subtypeOf(WebAction::class.java),
-                        Types.subtypeOf(Object::class.java)))
+                parameterizedType<BoundAction<*, *>>(subtypeOf<WebAction>(), subtypeOf<Any>()).typeLiteral()
         ) as Multibinder<BoundAction<A, *>>
         binder.addBinding().toProvider(BoundActionProvider(provider, member, pathPattern, httpMethod))
     }
@@ -88,7 +85,3 @@ internal class BoundActionProvider<A : WebAction, R>(
                 PathPattern.parse(pathPattern), httpMethod)
     }
 }
-
-val KType.typeLiteral: TypeLiteral<*>
-    get() = TypeLiteral.get(javaType)
-

--- a/misk/src/main/kotlin/misk/web/WebModule.kt
+++ b/misk/src/main/kotlin/misk/web/WebModule.kt
@@ -1,9 +1,8 @@
 package misk.web
 
-import com.google.inject.AbstractModule
-import com.google.inject.multibindings.Multibinder
 import misk.Interceptor
 import misk.MiskDefault
+import misk.inject.KAbstractModule
 import misk.inject.addMultibinderBinding
 import misk.inject.addMultibinderBindingWithAnnotation
 import misk.inject.to
@@ -19,12 +18,12 @@ import misk.web.interceptors.PlaintextInterceptorFactory
 import misk.web.interceptors.RequestLoggingInterceptor
 import misk.web.jetty.JettyModule
 
-class WebModule : AbstractModule() {
+class WebModule : KAbstractModule() {
     override fun configure() {
         install(JettyModule())
 
         // Create an empty set binder of interceptor factories that can be added to by users.
-        Multibinder.newSetBinder(binder(), Interceptor.Factory::class.java)
+        newSetBinder<Interceptor.Factory>()
 
         binder().addMultibinderBindingWithAnnotation<Interceptor.Factory, MiskDefault>().to<InternalErrorInterceptorFactory>()
         binder().addMultibinderBindingWithAnnotation<Interceptor.Factory, MiskDefault>().to<RequestLoggingInterceptor.Factory>()

--- a/misk/src/test/kotlin/misk/metrics/MetricsTest.kt
+++ b/misk/src/test/kotlin/misk/metrics/MetricsTest.kt
@@ -2,6 +2,7 @@ package misk.metrics
 
 import com.google.common.truth.Truth.assertThat
 import com.google.inject.Guice
+import misk.inject.getInstance
 import org.junit.Test
 import java.time.Duration
 import java.util.concurrent.TimeUnit
@@ -73,7 +74,6 @@ class MetricsTest {
     }
 
     fun buildMetrics(): Metrics {
-        val injector = Guice.createInjector(MetricsModule())
-        return injector.getInstance(Metrics::class.java)
+        return Guice.createInjector(MetricsModule()).getInstance()
     }
 }


### PR DESCRIPTION
Use Kotlin extension functions to allow interaction with Guice without converting types from Kotlin to Java.