### PR TITLE
Adds ActionScoped and relating bindings

### DIFF
--- a/misk/src/main/kotlin/misk/concurrent/WrappingListeningExecutorService.kt
+++ b/misk/src/main/kotlin/misk/concurrent/WrappingListeningExecutorService.kt
@@ -1,0 +1,56 @@
+package misk.concurrent
+
+import com.google.common.util.concurrent.ForwardingListeningExecutorService
+import com.google.common.util.concurrent.ListenableFuture
+import com.google.common.util.concurrent.ListeningExecutorService
+import java.util.concurrent.Callable
+import java.util.concurrent.ExecutionException
+import java.util.concurrent.Future
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.TimeoutException
+
+/** [ListeningExecutorService] which wraps all calls */
+abstract class WrappingListeningExecutorService() : ForwardingListeningExecutorService() {
+    /** Wraps the specified callable and returns the new wrapped one. */
+    protected abstract fun <T> wrap(callable: Callable<T>): Callable<T>
+
+    override fun <T> submit(callable: Callable<T>): ListenableFuture<T> {
+        val wrapped = wrap(callable)
+        return delegate().submit<T>(wrapped)
+    }
+
+    override fun <T> submit(runnable: Runnable, result: T): ListenableFuture<T> {
+        return submit<T>({ runnable.run(); result })
+    }
+
+    override fun submit(runnable: Runnable): ListenableFuture<*> {
+        val wrapped = wrap<Unit>(Callable { runnable.run() })
+        return delegate().submit(wrapped)
+    }
+
+    @Throws(InterruptedException::class)
+    override fun <T> invokeAll(callables: Collection<Callable<T>>): List<Future<T>> {
+        return delegate().invokeAll(callables.map { wrap(it) })
+    }
+
+    @Throws(InterruptedException::class)
+    override fun <T> invokeAll(callables: Collection<Callable<T>>, timeout: Long,
+            timeUnit: TimeUnit): List<Future<T>> {
+        return delegate().invokeAll(callables.map { wrap(it) }, timeout, timeUnit)
+    }
+
+    @Throws(InterruptedException::class, ExecutionException::class)
+    override fun <T> invokeAny(callables: Collection<Callable<T>>): T {
+        return delegate().invokeAny(callables.map { wrap(it) })
+    }
+
+    @Throws(InterruptedException::class, ExecutionException::class, TimeoutException::class)
+    override fun <T> invokeAny(callables: Collection<Callable<T>>, timeout: Long,
+            timeUnit: TimeUnit): T {
+        return delegate().invokeAny(callables.map { wrap(it) }, timeout, timeUnit)
+    }
+
+    override fun execute(runnable: Runnable) {
+        delegate().submit(wrap<Unit>(Callable { runnable.run() }))
+    }
+}

--- a/misk/src/main/kotlin/misk/inject/Guice.kt
+++ b/misk/src/main/kotlin/misk/inject/Guice.kt
@@ -2,6 +2,7 @@ package misk.inject
 
 import com.google.inject.Binder
 import com.google.inject.Injector
+import com.google.inject.Key
 import com.google.inject.TypeLiteral
 import com.google.inject.binder.LinkedBindingBuilder
 import com.google.inject.binder.ScopedBindingBuilder
@@ -13,19 +14,23 @@ import java.lang.reflect.WildcardType
 import javax.inject.Inject
 import javax.inject.Provider
 import javax.inject.Singleton
+import kotlin.reflect.KClass
 import kotlin.reflect.KType
 import kotlin.reflect.jvm.javaType
 
 internal inline fun <reified T : Any> LinkedBindingBuilder<in T>.to() = to(T::class.java)
 
-internal inline fun <reified T : Any, reified A : Annotation> Binder.addMultibinderBindingWithAnnotation() = addMultibinderBinding<T>(A::class.java)
+internal inline fun <reified T : Any, reified A : Annotation> Binder.addMultibinderBindingWithAnnotation() =
+        addMultibinderBinding<T>(A::class.java)
 
 @Suppress("UNCHECKED_CAST")
 internal inline fun <reified T : Any> Binder.addMultibinderBinding(
-    annotation: Class<out Annotation>? = null
+        annotation: Class<out Annotation>? = null
 ): LinkedBindingBuilder<T> {
-    val typeLiteral = parameterizedType<List<*>>(subtypeOf<T>()).typeLiteral() as TypeLiteral<List<T>>
-    bind(typeLiteral).toProvider(parameterizedType<ListProvider<*>>(T::class.java).typeLiteral() as TypeLiteral<Provider<List<T>>>)
+    val typeLiteral =
+            parameterizedType<List<*>>(subtypeOf<T>()).typeLiteral() as TypeLiteral<List<T>>
+    bind(typeLiteral).toProvider(parameterizedType<ListProvider<*>>(
+            T::class.java).typeLiteral() as TypeLiteral<Provider<List<T>>>)
 
     return when (annotation) {
         null -> Multibinder.newSetBinder(this, T::class.java).addBinding()
@@ -47,7 +52,8 @@ internal inline fun <reified T : Any> subtypeOf(): WildcardType {
     return Types.subtypeOf(T::class.java)
 }
 
-internal inline fun <reified T : Any> parameterizedType(vararg typeParameters: Type): ParameterizedType {
+internal inline fun <reified T : Any> parameterizedType(
+        vararg typeParameters: Type): ParameterizedType {
     return Types.newParameterizedType(T::class.java, *typeParameters)
 }
 
@@ -61,6 +67,28 @@ internal inline fun <reified T : Any> Injector.getInstance(): T {
     return getInstance(T::class.java)
 }
 
+internal inline fun <reified T : Any> keyOf(): Key<T> = Key.get(T::class.java)
+internal inline fun <reified T : Any> keyOf(a: Annotation): Key<T> = Key.get(T::class.java, a)
+internal inline fun <reified T : Any, A : Annotation> keyOf(a: KClass<A>): Key<T> =
+        Key.get(T::class.java, a.java)
+
 fun uninject(target: Any) {
-    // TODO.
+    try {
+        var c: Class<*> = target.javaClass
+        while (c != Any::class.java) {
+            for (f in c.declaredFields) {
+                if (f.isAnnotationPresent(Inject::class.java)) {
+                    f.isAccessible = true
+                    if (!f.type.isPrimitive) f.set(target, null)
+                }
+                if (f.isAnnotationPresent(com.google.inject.Inject::class.java)) {
+                    throw AssertionError("prefer @javax.inject.Inject for " + target.javaClass)
+                }
+            }
+            c = c.superclass
+        }
+    } catch (e: IllegalAccessException) {
+        throw AssertionError(e)
+    }
+
 }

--- a/misk/src/main/kotlin/misk/scope/ActionScope.kt
+++ b/misk/src/main/kotlin/misk/scope/ActionScope.kt
@@ -1,0 +1,127 @@
+package misk.scope
+
+import com.google.inject.Key
+import com.google.inject.Provider
+import java.util.concurrent.Callable
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlin.reflect.KFunction
+import kotlin.reflect.KParameter
+import kotlin.reflect.KType
+import kotlin.reflect.KTypeParameter
+import kotlin.reflect.KVisibility
+
+@Singleton
+class ActionScope @Inject internal constructor(
+        // NB(mmihic): ActionScoped depends on ActionScope depends on
+        // on ActionScopedProviders, which might depend on other ActionScopeds. We break
+        // this circular dependency by injecting a map of Provider<ActionScopedProvider>
+        // rather than the map of ActionScopedProvider directly
+        private val providers: @JvmSuppressWildcards Map<Key<*>, Provider<ActionScopedProvider<*>>>
+) : AutoCloseable {
+    companion object {
+        private val tls = ThreadLocal<LinkedHashMap<Key<*>, Any>>()
+    }
+
+    /** Starts the scope on a thread with the provided seed data */
+    fun enter(seedData: Map<Key<*>, Any>): ActionScope {
+        check(tls.get() == null) {
+            "cannot begin an ActionScope on a thread that is already running in an action scope"
+        }
+
+        tls.set(LinkedHashMap(seedData))
+        return this
+    }
+
+    override fun close() {
+        tls.remove()
+    }
+
+    /** Returns true if currently in the scope */
+    fun inScope(): Boolean = tls.get() != null
+
+    /**
+     * Wraps a [Callable] that will be called on another thread, propagating the current
+     * scoped data onto that thread
+     */
+    fun <T> propagate(c: Callable<T>): Callable<T> {
+        check(tls.get() != null) { "not running within an ActionScope" }
+
+        val currentScopedData = tls.get().toMap()
+        return Callable {
+            enter(currentScopedData).use {
+                c.call()
+            }
+        }
+    }
+
+    /**
+     * Wraps a [KFunction] that will be called on another thread, propagating the current
+     * scoped data onto that thread
+     */
+    fun <T> propagate(f: KFunction<T>): KFunction<T> {
+        check(tls.get() != null) { "not running within an ActionScope" }
+
+        val currentScopedData = tls.get().toMap()
+        return WrappedKFunction(currentScopedData, this, f)
+    }
+
+    /**
+     * Wraps a function or lambda that will be called on another thread, propagating the current
+     * scoped data onto that thread
+     */
+    fun <T> propagate(f: () -> T): () -> T {
+        check(tls.get() != null) { "not running within an ActionScope" }
+
+        val currentScopedData = tls.get().toMap()
+        return {
+            enter(currentScopedData).use {
+                f.invoke()
+            }
+        }
+    }
+
+    /** Returns the action scoped value for the given key */
+    fun <T> get(key: Key<T>): T {
+        check(tls.get() != null) { "not running within an ActionScope" }
+
+        @Suppress("UNCHECKED_CAST")
+        return tls.get().computeIfAbsent(key) { providerFor(key as Key<Any>).get() as Any } as T
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun providerFor(key: Key<*>): ActionScopedProvider<*> {
+        return requireNotNull(providers[key]?.get()) {
+            "no ActionScopedProvider available for $key"
+        }
+    }
+
+    private class WrappedKFunction<T>(
+            val seedData: Map<Key<*>, Any>,
+            val scope: ActionScope,
+            val wrapped: KFunction<T>
+    ) : KFunction<T> {
+        override fun call(vararg args: Any?): T = scope.enter(seedData).use {
+            wrapped.call(*args)
+        }
+
+        override fun callBy(args: Map<KParameter, Any?>): T = scope.enter(seedData).use {
+            wrapped.callBy(args)
+        }
+
+        override val annotations: List<Annotation> = wrapped.annotations
+        override val isAbstract: Boolean = wrapped.isAbstract
+        override val isFinal: Boolean = true
+        override val isOpen: Boolean = false
+        override val name: String = wrapped.name
+        override val parameters: List<KParameter> = wrapped.parameters
+        override val returnType: KType = wrapped.returnType
+        override val typeParameters: List<KTypeParameter> = wrapped.typeParameters
+        override val visibility: KVisibility? = wrapped.visibility
+        override val isExternal: Boolean = wrapped.isExternal
+        override val isInfix: Boolean = wrapped.isInfix
+        override val isInline: Boolean = wrapped.isInline
+        override val isOperator: Boolean = wrapped.isOperator
+        override val isSuspend: Boolean = wrapped.isSuspend
+    }
+}

--- a/misk/src/main/kotlin/misk/scope/ActionScoped.kt
+++ b/misk/src/main/kotlin/misk/scope/ActionScoped.kt
@@ -1,0 +1,13 @@
+package misk.scope
+
+/** Provides access to a context object specific to the current action */
+interface ActionScoped<out T> {
+    fun get() : T
+
+    companion object {
+        /** @return an [ActionScoped] hard-coded to a specific value, useful for tests */
+        fun <T> of(value: T) = object: ActionScoped<T> {
+            override fun get() = value
+        }
+    }
+}

--- a/misk/src/main/kotlin/misk/scope/ActionScopedProvider.kt
+++ b/misk/src/main/kotlin/misk/scope/ActionScopedProvider.kt
@@ -1,0 +1,9 @@
+package misk.scope
+
+/**
+ * An [ActionScopedProvider] is implemented by components and application code that wants
+ * provide contextual information based on an incoming request, job data, etc.
+ */
+interface ActionScopedProvider<out T> {
+    fun get(): T
+}

--- a/misk/src/main/kotlin/misk/scope/ActionScopedProviderModule.kt
+++ b/misk/src/main/kotlin/misk/scope/ActionScopedProviderModule.kt
@@ -1,0 +1,112 @@
+package misk.scope
+
+import com.google.inject.Key
+import com.google.inject.Provider
+import com.google.inject.TypeLiteral
+import com.google.inject.multibindings.MapBinder
+import com.google.inject.multibindings.Multibinder
+import misk.inject.KAbstractModule
+import misk.inject.asSingleton
+import misk.inject.parameterizedType
+import misk.inject.typeLiteral
+import javax.inject.Inject
+import kotlin.reflect.KClass
+
+/** Module used by components and applications to provide [ActionScoped] context objects */
+abstract class ActionScopedProviderModule : KAbstractModule() {
+    override fun configure() {
+        MapBinder.newMapBinder(binder(), KEY_TYPE, ACTION_SCOPED_PROVIDER_TYPE)
+        Multibinder.newSetBinder(binder(), KEY_TYPE)
+        configureProviders()
+    }
+
+    abstract fun configureProviders()
+
+    /** Binds an [ActionScoped] which only pulls from data seeded at the scope entry */
+    fun <T : Any> bindSeedData(kclass: KClass<T>) {
+        bindSeedData(Key.get(kclass.java), Key.get(actionScopedType(kclass)))
+    }
+
+    /** Binds an annotation qualified [ActionScoped] which only pulls from data seeded at the scope entry */
+    fun <T : Any> bindSeedData(kclass: KClass<T>, a: Annotation) {
+        bindSeedData(Key.get(kclass.java, a), Key.get(actionScopedType(kclass), a))
+    }
+
+    /** Binds an annotation qualified [ActionScoped] which only pulls from data seeded at the scope entry */
+    fun <T : Any, A : Annotation> bindSeedData(kclass: KClass<T>, a: KClass<A>) {
+        bindSeedData(Key.get(kclass.java, a.java), Key.get(actionScopedType(kclass), a.java))
+    }
+
+    private fun <T : Any> bindSeedData(key: Key<T>, actionScopedKey: Key<ActionScoped<T>>) {
+        bindProvider(key, actionScopedKey, Provider<ActionScopedProvider<T>> {
+            SeedDataActionScopedProvider(key)
+        })
+    }
+
+    /** Binds an unqualified [ActionScoped] along with its provider */
+    fun <T : Any> bindProvider(
+            kclass: KClass<T>,
+            providerClass: KClass<out ActionScopedProvider<T>>) {
+        bindProvider(
+                Key.get(kclass.java),
+                Key.get(actionScopedType(kclass)),
+                binder().getProvider(providerClass.java))
+    }
+
+    /** Binds an annotation qualified [ActionScoped] along with its provider */
+    fun <T : Any> bindProvider(
+            kclass: KClass<T>,
+            a: Annotation,
+            providerClass: KClass<out ActionScopedProvider<T>>) {
+        bindProvider(
+                Key.get(kclass.java, a),
+                Key.get(actionScopedType(kclass), a),
+                binder().getProvider(providerClass.java))
+    }
+
+    /** Binds an annotation qualified [ActionScoped] along with its provider */
+    fun <T : Any, A : Annotation> bindProvider(
+            kclass: KClass<T>,
+            a: KClass<Annotation>,
+            providerClass: KClass<out ActionScopedProvider<T>>) {
+        bindProvider(
+                Key.get(kclass.java, a.java),
+                Key.get(actionScopedType(kclass), a.java),
+                binder().getProvider(providerClass.java))
+    }
+
+    private fun <T : Any> bindProvider(
+            key: Key<T>,
+            actionScopedKey: Key<ActionScoped<T>>,
+            providerProvider: Provider<out ActionScopedProvider<T>>
+    ) {
+        MapBinder.newMapBinder(binder(), KEY_TYPE, ACTION_SCOPED_PROVIDER_TYPE)
+                .addBinding(key)
+                .toProvider(providerProvider)
+        bind(actionScopedKey).toProvider(RealActionScopedProvider(key)).asSingleton()
+    }
+
+    companion object {
+        @Suppress("UNCHECKED_CAST")
+        private fun <T : Any> actionScopedType(kclass: KClass<T>) =
+                parameterizedType<ActionScoped<T>>(kclass.java).typeLiteral()
+                        as TypeLiteral<ActionScoped<T>>
+
+        private val KEY_TYPE = object : TypeLiteral<Key<*>>() {}
+        private val ACTION_SCOPED_PROVIDER_TYPE = object : TypeLiteral<ActionScopedProvider<*>>() {}
+
+        private class SeedDataActionScopedProvider<T>(private val key: Key<T>) :
+                ActionScopedProvider<T> {
+            override fun get(): T {
+                throw IllegalStateException("$key can only be provided as seed data")
+            }
+        }
+
+        private class RealActionScopedProvider<T>(private val key: Key<T>) : Provider<ActionScoped<T>> {
+            @Inject lateinit var scope: ActionScope
+
+            override fun get(): ActionScoped<T> = RealActionScoped(key, scope)
+        }
+    }
+
+}

--- a/misk/src/main/kotlin/misk/scope/RealActionScoped.kt
+++ b/misk/src/main/kotlin/misk/scope/RealActionScoped.kt
@@ -1,0 +1,11 @@
+package misk.scope
+
+import com.google.inject.Key
+import javax.inject.Inject
+
+internal class RealActionScoped<T> @Inject internal constructor(
+        val key: Key<T>,
+        val scope: ActionScope
+) : ActionScoped<T> {
+    override fun get(): T = scope.get(key)
+}

--- a/misk/src/main/kotlin/misk/scope/executor/ActionScopedExecutorService.kt
+++ b/misk/src/main/kotlin/misk/scope/executor/ActionScopedExecutorService.kt
@@ -1,0 +1,24 @@
+package misk.scope.executor
+
+import com.google.common.util.concurrent.ListeningExecutorService
+import com.google.common.util.concurrent.MoreExecutors
+import misk.concurrent.WrappingListeningExecutorService
+import misk.scope.ActionScope
+import java.util.concurrent.Callable
+import java.util.concurrent.ExecutorService
+
+/**
+ * Wraps a [ListeningExecutorService] to propagate the current action scope to any tasks
+ * submitted by the current thread
+ */
+class ActionScopedExecutorService(
+        target: ExecutorService,
+        private val scope: ActionScope
+) : WrappingListeningExecutorService() {
+
+    private val target = MoreExecutors.listeningDecorator(target)
+
+    override fun <T> wrap(callable: Callable<T>): Callable<T> = scope.propagate(callable)
+
+    override fun delegate(): ListeningExecutorService = target
+}

--- a/misk/src/main/kotlin/misk/web/BoundAction.kt
+++ b/misk/src/main/kotlin/misk/web/BoundAction.kt
@@ -125,7 +125,7 @@ private fun HttpServletRequest.httpMethod() = HttpMethod.valueOf(method)
 
 private fun HttpServletRequest.bufferedSource() = Okio.buffer(Okio.source(inputStream))
 
-private fun HttpServletRequest.asRequest() = Request(
+internal fun HttpServletRequest.asRequest() = Request(
         httpUrl(),
         httpMethod(),
         headers(),

--- a/misk/src/main/kotlin/misk/web/WebModule.kt
+++ b/misk/src/main/kotlin/misk/web/WebModule.kt
@@ -6,6 +6,7 @@ import misk.inject.KAbstractModule
 import misk.inject.addMultibinderBinding
 import misk.inject.addMultibinderBindingWithAnnotation
 import misk.inject.to
+import misk.scope.ActionScopedProviderModule
 import misk.web.extractors.HeadersParameterExtractorFactory
 import misk.web.extractors.JsonBodyParameterExtractorFactory
 import misk.web.extractors.ParameterExtractor
@@ -17,10 +18,17 @@ import misk.web.interceptors.MetricsInterceptor
 import misk.web.interceptors.PlaintextInterceptorFactory
 import misk.web.interceptors.RequestLoggingInterceptor
 import misk.web.jetty.JettyModule
+import javax.servlet.http.HttpServletRequest
 
 class WebModule : KAbstractModule() {
     override fun configure() {
         install(JettyModule())
+        install(object: ActionScopedProviderModule() {
+            override fun configureProviders() {
+                bindSeedData(Request::class)
+                bindSeedData(HttpServletRequest::class)
+            }
+        })
 
         // Create an empty set binder of interceptor factories that can be added to by users.
         newSetBinder<Interceptor.Factory>()

--- a/misk/src/main/kotlin/misk/web/jetty/WebActionsServlet.kt
+++ b/misk/src/main/kotlin/misk/web/jetty/WebActionsServlet.kt
@@ -1,8 +1,12 @@
 package misk.web.jetty
 
+import misk.inject.keyOf
 import misk.logging.getLogger
+import misk.scope.ActionScope
 import misk.web.BoundAction
+import misk.web.Request
 import misk.web.actions.WebAction
+import misk.web.asRequest
 import javax.inject.Inject
 import javax.inject.Singleton
 import javax.servlet.http.HttpServlet
@@ -13,7 +17,8 @@ private val logger = getLogger<WebActionsServlet>()
 
 @Singleton
 internal class WebActionsServlet @Inject constructor(
-    private val boundActions: MutableSet<BoundAction<out WebAction, *>>
+        private val boundActions: MutableSet<BoundAction<out WebAction, *>>,
+        private val scope: ActionScope
 ) : HttpServlet() {
     override fun doGet(request: HttpServletRequest, response: HttpServletResponse) {
         handleCall(request, response)
@@ -24,8 +29,14 @@ internal class WebActionsServlet @Inject constructor(
     }
 
     private fun handleCall(request: HttpServletRequest, response: HttpServletResponse) {
-        if (boundActions.any { it.tryHandle(request, response) }) {
-            logger.debug("Request handled by WebActionServlet")
+        val seedData = mapOf(
+                keyOf<HttpServletRequest>() to request,
+                keyOf<Request>() to request.asRequest())
+
+        scope.enter(seedData).use {
+            if (boundActions.any { it.tryHandle(request, response) }) {
+                logger.debug("Request handled by WebActionServlet")
+            }
         }
     }
 }

--- a/misk/src/test/kotlin/misk/concurrent/WrappingListeningExecutorServiceTest.kt
+++ b/misk/src/test/kotlin/misk/concurrent/WrappingListeningExecutorServiceTest.kt
@@ -1,0 +1,78 @@
+package misk.concurrent
+
+import com.google.common.truth.Truth.assertThat
+import com.google.common.util.concurrent.ListeningExecutorService
+import com.google.common.util.concurrent.MoreExecutors
+import org.junit.Before
+import org.junit.Test
+import java.util.concurrent.Callable
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicInteger
+
+internal class WrappingListeningExecutorServiceTest {
+
+    private val wrapCounter = AtomicInteger()
+    private val executor = object : WrappingListeningExecutorService() {
+        val wrapped = MoreExecutors.listeningDecorator(Executors.newSingleThreadExecutor())
+
+        override fun <T> wrap(callable: Callable<T>): Callable<T> {
+            return Callable {
+                wrapCounter.incrementAndGet()
+                callable.call()
+            }
+        }
+
+        override fun delegate(): ListeningExecutorService = wrapped
+    }
+
+    @Before
+    fun clearWrapped() {
+        wrapCounter.set(0)
+    }
+
+    @Test
+    fun submit() {
+        val result = executor.submit(Callable { "foo" }).get()
+        assertThat(result).isEqualTo("foo")
+        assertThat(wrapCounter.get()).isEqualTo(1)
+    }
+
+    @Test
+    fun submitRunnable() {
+        val executed = AtomicBoolean()
+        executor.submit({ executed.set(true)}).get()
+        assertThat(executed.get()).isTrue()
+        assertThat(wrapCounter.get()).isEqualTo(1)
+    }
+
+    @Test
+    fun submitWithResult() {
+        val executed = AtomicBoolean()
+        val result = executor.submit({ executed.set(true) }, "foo").get()
+        assertThat(result).isEqualTo("foo")
+        assertThat(executed.get()).isTrue()
+        assertThat(wrapCounter.get()).isEqualTo(1)
+    }
+
+    @Test
+    fun invokeAll() {
+        val results = executor.invokeAll(listOf(
+                Callable { "foo" },
+                Callable { "bar" },
+                Callable { "zed" }
+        )).map { it.get() }
+
+        assertThat(results).containsExactly("foo", "bar", "zed")
+        assertThat(wrapCounter.get()).isEqualTo(3)
+    }
+
+    @Test
+    fun execute() {
+        val latch = CountDownLatch(1)
+        executor.execute( { latch.countDown() })
+        latch.await()
+        assertThat(wrapCounter.get()).isEqualTo(1)
+    }
+}

--- a/misk/src/test/kotlin/misk/scope/ActionScopePropagationTest.kt
+++ b/misk/src/test/kotlin/misk/scope/ActionScopePropagationTest.kt
@@ -1,0 +1,84 @@
+package misk.scope
+
+import com.google.common.truth.Truth.assertThat
+import com.google.inject.Guice
+import com.google.inject.Key
+import com.google.inject.name.Named
+import com.google.inject.name.Names
+import misk.inject.keyOf
+import org.junit.Test
+import java.util.concurrent.Callable
+import java.util.concurrent.Executors
+import javax.inject.Inject
+import kotlin.reflect.KFunction
+
+internal class ActionScopePropagationTest {
+    class Tester {
+        @Inject
+        @Named("foo") lateinit var foo: ActionScoped<String>
+
+        fun fooValue(): String = foo.get()
+    }
+
+    private val executor = Executors.newSingleThreadExecutor()
+
+    @Test
+    fun propagatesScopeOnNewThreadForCallable() {
+        val injector = Guice.createInjector(TestActionScopedProviderModule())
+        val scope = injector.getInstance(ActionScope::class.java)
+        val tester = injector.getInstance(Tester::class.java)
+
+        val seedData: Map<Key<*>, Any> = mapOf(
+                keyOf<String>(Names.named("from-seed")) to "my seed data")
+
+        val callable = scope.enter(seedData).use {
+            scope.propagate(Callable { tester.fooValue() })
+        }
+
+        // Submit to other thread after we've exited the scope
+        val result = executor.submit(callable).get()
+        assertThat(result).isEqualTo("my seed data and bar and foo!")
+    }
+
+    @Test
+    fun propagatesScopeOnNewThreadForKFunction() {
+        val injector = Guice.createInjector(TestActionScopedProviderModule())
+        val scope = injector.getInstance(ActionScope::class.java)
+        val tester = injector.getInstance(Tester::class.java)
+
+        val seedData: Map<Key<*>, Any> = mapOf(
+                keyOf<String>(Names.named("from-seed")) to "my seed data")
+
+        // Propagate on the the KCallable directly
+        val f : KFunction<String> = tester::fooValue
+        val callable = scope.enter(seedData).use {
+            scope.propagate(f)
+        }
+
+        // Submit to other thread after we've exited the scope
+        val result = executor.submit(Callable {
+            callable.call()
+        }).get()
+        assertThat(result).isEqualTo("my seed data and bar and foo!")
+    }
+
+    @Test
+    fun propagatesScopeOnNewThreadForLambda() {
+        val injector = Guice.createInjector(TestActionScopedProviderModule())
+        val scope = injector.getInstance(ActionScope::class.java)
+        val tester = injector.getInstance(Tester::class.java)
+
+        val seedData: Map<Key<*>, Any> = mapOf(
+                keyOf<String>(Names.named("from-seed")) to "my seed data")
+
+        // Propagate on a lambda directly
+        val function = scope.enter(seedData).use {
+            scope.propagate( { tester.fooValue() })
+        }
+
+        // Submit to other thread after we've exited the scope
+        val result = executor.submit(Callable { function() }).get()
+        assertThat(result).isEqualTo("my seed data and bar and foo!")
+    }
+
+}

--- a/misk/src/test/kotlin/misk/scope/ActionScopedTest.kt
+++ b/misk/src/test/kotlin/misk/scope/ActionScopedTest.kt
@@ -1,0 +1,67 @@
+package misk.scope
+
+import com.google.common.truth.Truth.assertThat
+import com.google.inject.Guice
+import com.google.inject.Key
+import com.google.inject.name.Named
+import com.google.inject.name.Names
+import misk.inject.keyOf
+import misk.inject.uninject
+import org.junit.Before
+import org.junit.Test
+import javax.inject.Inject
+
+class ActionScopedTest {
+    @Inject @Named("foo")
+    private lateinit var foo : ActionScoped<String>
+
+    @Inject private lateinit var scope: ActionScope
+
+    @Before
+    fun clearInjections() {
+        uninject(this)
+    }
+
+    @Test
+    fun resolvedChainedActionScoped() {
+        val injector = Guice.createInjector(TestActionScopedProviderModule())
+        injector.injectMembers(this)
+
+        val seedData: Map<Key<*>, Any> = mapOf(
+                keyOf<String>(Names.named("from-seed")) to "seed-value"
+
+        )
+        scope.enter(seedData).use {
+            assertThat(foo.get()).isEqualTo("seed-value and bar and foo!")
+        }
+    }
+
+    @Test(expected = IllegalStateException::class)
+    fun doubleEnterScopeFails() {
+        val injector = Guice.createInjector(TestActionScopedProviderModule())
+        injector.injectMembers(this)
+
+        scope.enter(mapOf()).use {
+            scope.enter(mapOf()).use { }
+        }
+
+    }
+
+    @Test(expected = IllegalStateException::class)
+    fun resolveOutsideOfScopeFails() {
+        val injector = Guice.createInjector(TestActionScopedProviderModule())
+        injector.injectMembers(this)
+
+        foo.get()
+    }
+
+    @Test(expected = IllegalStateException::class)
+    fun seedDataNotFoundFails() {
+        val injector = Guice.createInjector(TestActionScopedProviderModule())
+        injector.injectMembers(this)
+
+        // NB(mmihic): Seed data not specified
+        scope.enter(mapOf()).use { foo.get() }
+    }
+
+}

--- a/misk/src/test/kotlin/misk/scope/TestActionScopedProviderModule.kt
+++ b/misk/src/test/kotlin/misk/scope/TestActionScopedProviderModule.kt
@@ -1,0 +1,25 @@
+package misk.scope
+
+import com.google.inject.name.Named
+import com.google.inject.name.Names
+import javax.inject.Inject
+
+class TestActionScopedProviderModule : ActionScopedProviderModule() {
+    override fun configureProviders() {
+        bindSeedData(String::class, Names.named("from-seed"))
+        bindProvider(String::class, Names.named("foo"), FooProvider::class)
+        bindProvider(String::class, Names.named("bar"), BarProvider::class)
+    }
+
+    class BarProvider @Inject internal constructor(
+            @Named("from-seed") val seedData: ActionScoped<String>
+    ) : ActionScopedProvider<String> {
+        override fun get(): String = "${seedData.get()} and bar"
+    }
+
+    class FooProvider @Inject internal constructor(
+            @Named("bar") val bar: ActionScoped<String>
+    ) : ActionScopedProvider<String> {
+        override fun get(): String = "${bar.get()} and foo!"
+    }
+}

--- a/misk/src/test/kotlin/misk/scope/executor/ActionScopedExecutorServiceTest.kt
+++ b/misk/src/test/kotlin/misk/scope/executor/ActionScopedExecutorServiceTest.kt
@@ -1,0 +1,70 @@
+package misk.scope.executor
+
+import com.google.common.truth.Truth.assertThat
+import com.google.inject.Guice
+import com.google.inject.Key
+import com.google.inject.Provides
+import com.google.inject.name.Named
+import com.google.inject.name.Names
+import misk.inject.KAbstractModule
+import misk.inject.keyOf
+import misk.scope.ActionScope
+import misk.scope.ActionScoped
+import misk.scope.TestActionScopedProviderModule
+import org.junit.Test
+import java.util.concurrent.Callable
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.Executors
+import javax.inject.Inject
+import javax.inject.Singleton
+
+internal class ActionScopedExecutorServiceTest {
+    class Tester {
+        @Inject
+        @Named("foo") lateinit var foo: ActionScoped<String>
+
+        fun fooValue() = foo.get()
+    }
+
+    @Test
+    fun propagatesScopeIfInScope() {
+        val injector = Guice.createInjector(
+                TestActionScopedProviderModule(),
+                ActionScopedExecutorServiceModule())
+
+        val tester = injector.getInstance(Tester::class.java)
+        val executor = injector.getInstance(ExecutorService::class.java)
+        val scope = injector.getInstance(ActionScope::class.java)
+
+        val seedData: Map<Key<*>, Any> = mapOf(
+                keyOf<String>(Names.named("from-seed")) to "my seed data")
+
+        val future = scope.enter(seedData).use {
+            executor.submit( Callable { tester.fooValue() })
+        }
+
+        assertThat(future.get()).isEqualTo("my seed data and bar and foo!")
+    }
+
+    @Test(expected = IllegalStateException::class)
+    fun doesNotPropagateScopeIfNotInScope() {
+        val injector = Guice.createInjector(
+                TestActionScopedProviderModule(),
+                ActionScopedExecutorServiceModule())
+
+        val tester = injector.getInstance(Tester::class.java)
+        val executor = injector.getInstance(ExecutorService::class.java)
+
+        executor.submit( Callable { tester.fooValue() })
+    }
+
+    class ActionScopedExecutorServiceModule : KAbstractModule() {
+        override fun configure() {}
+
+        @Provides
+        @Singleton
+        fun provideExecutorService(scope: ActionScope): ExecutorService {
+            return ActionScopedExecutorService(Executors.newSingleThreadExecutor(), scope)
+        }
+    }
+}


### PR DESCRIPTION
 Allows components and actions to define context objects that are scoped to the current action execution. Dispatch code initializes the action scope with initial seed data from the request; other components can provide additional context objects based on the seed data, or on other action scoped data. Scopes can be propagated onto other threads; an ActionScopedExecutorService is provided which automatically propagates the current scope to any callables / runnables schedule from the current thread.
