### PR TITLE
Fix broken web dispatch pipeline and add tests

### DIFF
--- a/exemplar/src/test/kotlin/com/squareup/exemplar/HelloWebActionTest.kt
+++ b/exemplar/src/test/kotlin/com/squareup/exemplar/HelloWebActionTest.kt
@@ -1,7 +1,7 @@
 package com.squareup.exemplar
 
 import com.google.common.truth.Truth.assertThat
-import misk.testing.MiskTestRule
+import misk.testing.InjectionTestRule
 import okhttp3.Headers
 import org.junit.Rule
 import org.junit.Test
@@ -10,7 +10,7 @@ import javax.inject.Inject
 class HelloWebActionTest {
     @Rule
     @JvmField
-    val miskTestRule = MiskTestRule()
+    val miskTestRule = InjectionTestRule()
 
     @Inject lateinit var helloWebAction: HelloWebAction
 

--- a/misk/src/main/kotlin/misk/MiskDefault.kt
+++ b/misk/src/main/kotlin/misk/MiskDefault.kt
@@ -1,7 +1,7 @@
 package misk
 
-import com.google.inject.BindingAnnotation
 import misk.web.interceptors.JsonInterceptorFactory
+import javax.inject.Qualifier
 import kotlin.annotation.AnnotationRetention.RUNTIME
 
 /**
@@ -9,7 +9,11 @@ import kotlin.annotation.AnnotationRetention.RUNTIME
  * For example, the [JsonInterceptorFactory] is bound with [MiskDefault] and is automatically
  * installed.
  */
-@BindingAnnotation
+@Qualifier
 @Retention(RUNTIME)
-@Target(AnnotationTarget.CLASS, AnnotationTarget.VALUE_PARAMETER, AnnotationTarget.TYPE)
+@Target(
+        AnnotationTarget.CLASS,
+        AnnotationTarget.VALUE_PARAMETER,
+        AnnotationTarget.FIELD,
+        AnnotationTarget.TYPE)
 internal annotation class MiskDefault

--- a/misk/src/main/kotlin/misk/testing/InjectionTestRule.kt
+++ b/misk/src/main/kotlin/misk/testing/InjectionTestRule.kt
@@ -1,24 +1,31 @@
 package misk.testing
 
 import com.google.inject.Guice
+import com.google.inject.Injector
 import com.google.inject.Module
 import misk.inject.uninject
 import org.junit.rules.MethodRule
 import org.junit.runners.model.FrameworkMethod
 import org.junit.runners.model.Statement
 
-class MiskTestRule(vararg val modules: Module) : MethodRule {
+open class InjectionTestRule(vararg val modules: Module) : MethodRule {
     override fun apply(base: Statement, method: FrameworkMethod, target: Any): Statement {
         return object : Statement() {
             override fun evaluate() {
                 val injector = Guice.createInjector(modules.asList())
                 injector.injectMembers(target)
                 try {
+                    beforeMethod(injector, method, target)
                     base.evaluate()
                 } finally {
+                    afterMethod(injector, method, target)
                     uninject(target)
                 }
             }
         }
     }
+
+    open fun beforeMethod(injector: Injector, method: FrameworkMethod, target: Any) {}
+    open fun afterMethod(injector: Injector, method: FrameworkMethod, target: Any) {}
+
 }

--- a/misk/src/main/kotlin/misk/web/Http.kt
+++ b/misk/src/main/kotlin/misk/web/Http.kt
@@ -1,6 +1,5 @@
 package misk.web
 
-
 @Target(AnnotationTarget.FUNCTION)
 annotation class Get(val pathPattern: String)
 

--- a/misk/src/main/kotlin/misk/web/WebActionModule.kt
+++ b/misk/src/main/kotlin/misk/web/WebActionModule.kt
@@ -70,7 +70,7 @@ internal class BoundActionProvider<A : WebAction, R>(
 ) : Provider<BoundAction<A, *>> {
 
     @Inject lateinit var userProvidedInterceptorFactories: List<Interceptor.Factory>
-    @Inject lateinit var miskInterceptorFactories: @MiskDefault List<Interceptor.Factory>
+    @Inject @JvmSuppressWildcards @MiskDefault lateinit var miskInterceptorFactories: Set<Interceptor.Factory>
     @Inject lateinit var parameterExtractorFactories: List<ParameterExtractor.Factory>
 
     override fun get(): BoundAction<A, *> {

--- a/misk/src/main/kotlin/misk/web/jetty/JettyService.kt
+++ b/misk/src/main/kotlin/misk/web/jetty/JettyService.kt
@@ -4,6 +4,7 @@ import com.google.common.base.Stopwatch
 import com.google.common.util.concurrent.AbstractIdleService
 import misk.logging.getLogger
 import misk.web.WebConfig
+import okhttp3.HttpUrl
 import org.eclipse.jetty.server.Server
 import org.eclipse.jetty.server.ServerConnector
 import org.eclipse.jetty.servlet.ServletHandler
@@ -14,12 +15,21 @@ import javax.inject.Singleton
 private val logger = getLogger<JettyService>()
 
 @Singleton
-internal class JettyService @Inject constructor(
-    private val webActionsServlet: WebActionsServlet,
-    private val webConfig: WebConfig
+class JettyService @Inject internal constructor(
+        private val webActionsServlet: WebActionsServlet,
+        private val webConfig: WebConfig
 ) : AbstractIdleService() {
 
     private val server = Server()
+
+    val serverUrl: HttpUrl
+        get() {
+            return HttpUrl.Builder()
+                    .scheme(server.uri.scheme)
+                    .host(server.uri.host)
+                    .port(server.uri.port)
+                    .build()
+        }
 
     override fun startUp() {
         val stopwatch = Stopwatch.createStarted()

--- a/misk/src/test/kotlin/misk/cloud/aws/environment/AwsInstanceMetadataProviderTest.kt
+++ b/misk/src/test/kotlin/misk/cloud/aws/environment/AwsInstanceMetadataProviderTest.kt
@@ -2,8 +2,8 @@ package misk.cloud.aws.environment
 
 import com.google.common.truth.Truth
 import misk.cloud.aws.environment.AwsInstanceMetadataProvider.Companion.AWS_INSTANCE_METADATA_PATH
-import misk.testing.http.RoutingDispatcher
-import misk.testing.http.path
+import misk.testing.okhttp.RoutingDispatcher
+import misk.testing.okhttp.path
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.Test

--- a/misk/src/test/kotlin/misk/cloud/gcp/environment/GcpInstanceMetadataProviderTest.kt
+++ b/misk/src/test/kotlin/misk/cloud/gcp/environment/GcpInstanceMetadataProviderTest.kt
@@ -2,8 +2,8 @@ package misk.cloud.gcp.environment
 
 import com.google.common.truth.Truth.assertThat
 import misk.cloud.gcp.environment.GcpInstanceMetadataProvider.Companion.GCP_INSTANCE_METADATA_PATH
-import misk.testing.http.RoutingDispatcher
-import misk.testing.http.path
+import misk.testing.okhttp.RoutingDispatcher
+import misk.testing.okhttp.path
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.Test

--- a/misk/src/test/kotlin/misk/config/ConfigTest.kt
+++ b/misk/src/test/kotlin/misk/config/ConfigTest.kt
@@ -3,7 +3,7 @@ package misk.config
 import com.google.common.truth.Truth.assertThat
 import misk.environment.Environment.TESTING
 import misk.environment.EnvironmentModule
-import misk.testing.MiskTestRule
+import misk.testing.InjectionTestRule
 import misk.web.WebConfig
 import org.junit.Rule
 import org.junit.Test
@@ -12,7 +12,7 @@ import javax.inject.Named
 
 class ConfigTest {
     @get:Rule
-    val miskTestRule = MiskTestRule(
+    val miskTestRule = InjectionTestRule(
             ConfigModule.create<TestConfig>("test_app"),
             EnvironmentModule(TESTING)
     )

--- a/misk/src/test/kotlin/misk/metrics/backends/stackdriver/StackDriverReporterTest.kt
+++ b/misk/src/test/kotlin/misk/metrics/backends/stackdriver/StackDriverReporterTest.kt
@@ -10,7 +10,7 @@ import misk.config.AppName
 import misk.environment.InstanceMetadata
 import misk.metrics.Metrics
 import misk.metrics.MetricsModule
-import misk.testing.MiskTestRule
+import misk.testing.InjectionTestRule
 import misk.time.FakeClock
 import misk.time.FakeClockModule
 import org.junit.Rule
@@ -56,7 +56,7 @@ internal class StackDriverReporterTest {
     }
 
     @get:Rule
-    val miskTestRule = MiskTestRule(MetricsModule(), FakeClockModule(), TestModule())
+    val miskTestRule = InjectionTestRule(MetricsModule(), FakeClockModule(), TestModule())
 
     @Inject internal lateinit var metrics: Metrics
     @Inject internal lateinit var clock: FakeClock

--- a/misk/src/test/kotlin/misk/metrics/web/MetricsJsonActionTest.kt
+++ b/misk/src/test/kotlin/misk/metrics/web/MetricsJsonActionTest.kt
@@ -3,7 +3,7 @@ package misk.metrics.web
 import com.google.common.truth.Truth.assertThat
 import misk.metrics.Metrics
 import misk.metrics.MetricsModule
-import misk.testing.MiskTestRule
+import misk.testing.InjectionTestRule
 import org.junit.Rule
 import org.junit.Test
 import java.util.concurrent.TimeUnit
@@ -11,7 +11,7 @@ import javax.inject.Inject
 
 internal class MetricsJsonActionTest {
     @get:Rule
-    val miskTestRule = MiskTestRule(MetricsModule())
+    val miskTestRule = InjectionTestRule(MetricsModule())
 
     @Inject internal lateinit var metrics: Metrics
     @Inject internal lateinit var metricsAction: MetricsJsonAction

--- a/misk/src/test/kotlin/misk/testing/MiskTestRule.kt
+++ b/misk/src/test/kotlin/misk/testing/MiskTestRule.kt
@@ -1,0 +1,48 @@
+package misk.web
+
+import com.google.common.util.concurrent.ServiceManager
+import com.google.inject.Injector
+import com.google.inject.Module
+import com.google.inject.Provides
+import misk.MiskModule
+import misk.inject.KAbstractModule
+import misk.testing.InjectionTestRule
+import misk.web.jetty.JettyService
+import okhttp3.HttpUrl
+import org.junit.runners.model.FrameworkMethod
+import java.util.concurrent.TimeUnit
+import javax.inject.Singleton
+
+class MiskTestRule(vararg modules: Module) : InjectionTestRule(
+        WebModule(),
+        MiskModule(),
+        WebConfigModule(),
+        *modules
+) {
+    private var jettyServerUrl : HttpUrl? = null
+
+    fun serverUrl(): HttpUrl.Builder = jettyServerUrl!!.newBuilder()
+
+    override fun beforeMethod(injector: Injector, method: FrameworkMethod, target: Any) {
+        val serviceManager = injector.getInstance(ServiceManager::class.java)
+        serviceManager.startAsync()
+        serviceManager.awaitHealthy(5, TimeUnit.SECONDS)
+
+        val jettyService = injector.getInstance(JettyService::class.java)
+        jettyServerUrl = jettyService.serverUrl
+    }
+
+    override fun afterMethod(injector: Injector, method: FrameworkMethod, target: Any) {
+        val serviceManager = injector.getInstance(ServiceManager::class.java)
+        serviceManager.stopAsync()
+        serviceManager.awaitStopped(5, TimeUnit.SECONDS)
+    }
+
+    class WebConfigModule : KAbstractModule() {
+        override fun configure() {}
+
+        @Provides
+        @Singleton
+        fun provideWebConfig() = WebConfig(0, 500000)
+    }
+}

--- a/misk/src/test/kotlin/misk/testing/okhttp/HttpRequestUrl.kt
+++ b/misk/src/test/kotlin/misk/testing/okhttp/HttpRequestUrl.kt
@@ -1,4 +1,4 @@
-package misk.testing.http
+package misk.testing.okhttp
 
 import com.google.common.base.Joiner
 import okhttp3.HttpUrl

--- a/misk/src/test/kotlin/misk/testing/okhttp/RoutingDispatcher.kt
+++ b/misk/src/test/kotlin/misk/testing/okhttp/RoutingDispatcher.kt
@@ -1,4 +1,4 @@
-package misk.testing.http
+package misk.testing.okhttp
 
 import okhttp3.mockwebserver.Dispatcher
 import okhttp3.mockwebserver.MockResponse

--- a/misk/src/test/kotlin/misk/web/WebDispatchTest.kt
+++ b/misk/src/test/kotlin/misk/web/WebDispatchTest.kt
@@ -1,0 +1,96 @@
+package misk.web
+
+import com.google.common.truth.Truth.assertThat
+import com.squareup.moshi.Moshi
+import misk.inject.KAbstractModule
+import misk.web.actions.WebAction
+import okhttp3.MediaType
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody
+import org.junit.Rule
+import org.junit.Test
+import javax.inject.Inject
+
+internal class WebDispatchTest {
+    data class HelloBye(val message: String)
+
+    val jsonMediaType = MediaType.parse("application/json")
+
+    @Rule
+    @JvmField
+    val misk = MiskTestRule(TestModule())
+
+    @Inject lateinit var moshi: Moshi
+    private val helloByeJsonAdapter get() = moshi.adapter(HelloBye::class.java)
+
+    @Test
+    fun post() {
+        val requestContent = helloByeJsonAdapter.toJson(HelloBye("my friend"))
+        val httpClient = OkHttpClient()
+        val request = Request.Builder()
+                .post(RequestBody.create(jsonMediaType, requestContent))
+                .url(misk.serverUrl().encodedPath("/hello").build())
+                .build()
+
+        val response = httpClient.newCall(request).execute()
+        assertThat(response.code()).isEqualTo(200)
+        val responseContent = response.body()!!.source()
+        assertThat(helloByeJsonAdapter.fromJson(responseContent)!!.message)
+                .isEqualTo("post hello my friend")
+    }
+
+    @Test
+    fun get() {
+        val httpClient = OkHttpClient()
+        val request = Request.Builder()
+                .get()
+                .url(misk.serverUrl().encodedPath("/hello/my_friend").build())
+                .build()
+
+        val response = httpClient.newCall(request).execute()
+        assertThat(response.code()).isEqualTo(200)
+        val responseContent = response.body()!!.source()
+        assertThat(helloByeJsonAdapter.fromJson(responseContent)!!.message)
+                .isEqualTo("get hello my_friend")
+    }
+
+    class TestModule : KAbstractModule() {
+        override fun configure() {
+            install(WebActionModule.create<PostHello>())
+            install(WebActionModule.create<GetHello>())
+            install(WebActionModule.create<PostBye>())
+            install(WebActionModule.create<GetBye>())
+        }
+    }
+
+    class PostHello : WebAction {
+        @Post("/hello")
+        @JsonResponseBody
+        fun postHello(@JsonRequestBody request: HelloBye) =
+                HelloBye("post hello ${request.message}")
+
+    }
+
+    class GetHello : WebAction {
+        @Get("/hello/{message}")
+        @JsonResponseBody
+        fun postHello(@PathParam("message") message: String) =
+                HelloBye("get hello $message")
+    }
+
+    class PostBye : WebAction {
+        @Post("/bye")
+        @JsonResponseBody
+        fun postBye(@JsonRequestBody request: HelloBye) =
+                HelloBye("post bye ${request.message}")
+    }
+
+    class GetBye : WebAction {
+        @Get("/bye/{message}")
+        @JsonResponseBody
+        fun getBye(@PathParam("message") message: String) =
+                HelloBye("get bye $message")
+    }
+
+}

--- a/misk/src/test/kotlin/misk/web/actions/LivenessCheckActionTest.kt
+++ b/misk/src/test/kotlin/misk/web/actions/LivenessCheckActionTest.kt
@@ -4,7 +4,7 @@ import com.google.common.truth.Truth.assertThat
 import com.google.common.util.concurrent.ServiceManager
 import misk.MiskModule
 import misk.services.FakeServiceModule
-import misk.testing.MiskTestRule
+import misk.testing.InjectionTestRule
 import org.junit.Rule
 import org.junit.Test
 import javax.inject.Inject
@@ -12,7 +12,7 @@ import javax.inject.Inject
 class LivenessCheckActionTest {
     @Rule
     @JvmField
-    val testRule = MiskTestRule(
+    val testRule = InjectionTestRule(
             MiskModule(),
             FakeServiceModule()
     )

--- a/misk/src/test/kotlin/misk/web/actions/NotFoundActionTest.kt
+++ b/misk/src/test/kotlin/misk/web/actions/NotFoundActionTest.kt
@@ -1,7 +1,7 @@
 package misk.web.actions
 
 import com.google.common.truth.Truth.assertThat
-import misk.testing.MiskTestRule
+import misk.testing.InjectionTestRule
 import misk.web.Response
 import org.junit.Rule
 import org.junit.Test
@@ -10,7 +10,7 @@ import javax.inject.Inject
 class NotFoundActionTest {
     @Rule
     @JvmField
-    val testRule = MiskTestRule()
+    val testRule = InjectionTestRule()
 
     @Inject lateinit var notFoundAction: NotFoundAction
 

--- a/misk/src/test/kotlin/misk/web/actions/ReadinessCheckActionTest.kt
+++ b/misk/src/test/kotlin/misk/web/actions/ReadinessCheckActionTest.kt
@@ -6,7 +6,7 @@ import misk.MiskModule
 import misk.healthchecks.FakeHealthCheck
 import misk.healthchecks.FakeHealthCheckModule
 import misk.services.FakeServiceModule
-import misk.testing.MiskTestRule
+import misk.testing.InjectionTestRule
 import org.junit.Rule
 import org.junit.Test
 import javax.inject.Inject
@@ -14,7 +14,7 @@ import javax.inject.Inject
 class ReadinessCheckActionTest {
     @Rule
     @JvmField
-    val testRule = MiskTestRule(
+    val testRule = InjectionTestRule(
             MiskModule(),
             FakeServiceModule(),
             FakeHealthCheckModule()

--- a/misk/src/test/kotlin/misk/web/interceptors/MetricsInterceptorTest.kt
+++ b/misk/src/test/kotlin/misk/web/interceptors/MetricsInterceptorTest.kt
@@ -4,7 +4,7 @@ import com.google.common.truth.Truth.assertThat
 import misk.asAction
 import misk.metrics.Metrics
 import misk.metrics.MetricsModule
-import misk.testing.MiskTestRule
+import misk.testing.InjectionTestRule
 import misk.web.Get
 import misk.web.Response
 import misk.web.actions.WebAction
@@ -16,7 +16,7 @@ import javax.inject.Inject
 
 class MetricsInterceptorTest {
     @get:Rule
-    val miskTestRule = MiskTestRule(MetricsModule())
+    val miskTestRule = InjectionTestRule(MetricsModule())
 
     @Inject internal lateinit var metricsInterceptorFactory: MetricsInterceptor.Factory
     @Inject internal lateinit var testAction: TestAction

--- a/misk/src/test/kotlin/misk/web/interceptors/ProtobufInterceptorFactoryTest.kt
+++ b/misk/src/test/kotlin/misk/web/interceptors/ProtobufInterceptorFactoryTest.kt
@@ -3,7 +3,7 @@ package misk.web.interceptors
 import com.google.common.truth.Truth.assertThat
 import helpers.protos.Dinosaur
 import misk.asAction
-import misk.testing.MiskTestRule
+import misk.testing.InjectionTestRule
 import misk.web.Get
 import misk.web.ProtobufResponseBody
 import misk.web.Response
@@ -18,7 +18,7 @@ import javax.inject.Inject
 
 class ProtobufInterceptorFactoryTest {
     @get:Rule
-    val miskTestRule = MiskTestRule()
+    val miskTestRule = InjectionTestRule()
 
     @Inject internal lateinit var protobufAction: ProtobufAction
     @Inject internal lateinit var protobufInterceptorFactory: ProtobufInterceptorFactory<*, *>


### PR DESCRIPTION
The core dispatch pipeline was broken - none of the default interceptors
were being installed due errors in the way the MiskDefault annotation
and interceptor factory multibindings were being specified. Fixed the
bug, and added a basic test for core web dispatching.