### PR TITLE
Truth -> AssertJ

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ ext {
           kotlinReflect: "org.jetbrains.kotlin:kotlin-reflect:$kotlinVersion",
           kotlinGradlePlugin: "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion",
           kotlinReflection: "org.jetbrains.kotlin:kotlin-reflect:$kotlinVersion",
-          truth: 'com.google.truth:truth:0.30',
+          assertj: "org.assertj:assertj-core:3.8.0",
           guava: 'com.google.guava:guava:23.3-jre',
           guice: 'com.google.inject:guice:4.1.0',
           guiceMultibindings: 'com.google.inject.extensions:guice-multibindings:4.1.0',

--- a/exemplar/src/test/kotlin/com/squareup/exemplar/HelloWebActionTest.kt
+++ b/exemplar/src/test/kotlin/com/squareup/exemplar/HelloWebActionTest.kt
@@ -1,6 +1,6 @@
 package com.squareup.exemplar
 
-import com.google.common.truth.Truth.assertThat
+import org.assertj.core.api.Assertions.assertThat
 import misk.testing.ActionTest
 import okhttp3.Headers
 import org.junit.jupiter.api.Test

--- a/misk/src/test/kotlin/misk/ActionsTest.kt
+++ b/misk/src/test/kotlin/misk/ActionsTest.kt
@@ -1,6 +1,6 @@
 package misk
 
-import com.google.common.truth.Truth.assertThat
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Test
 

--- a/misk/src/test/kotlin/misk/cloud/aws/environment/AwsInstanceMetadataProviderTest.kt
+++ b/misk/src/test/kotlin/misk/cloud/aws/environment/AwsInstanceMetadataProviderTest.kt
@@ -1,11 +1,11 @@
 package misk.cloud.aws.environment
 
-import com.google.common.truth.Truth
 import misk.cloud.aws.environment.AwsInstanceMetadataProvider.Companion.AWS_INSTANCE_METADATA_PATH
 import misk.testing.okhttp.RoutingDispatcher
 import misk.testing.okhttp.path
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
 internal class AwsInstanceMetadataProviderTest {
@@ -29,8 +29,8 @@ internal class AwsInstanceMetadataProviderTest {
 
         try {
             val instanceMetadata = provider.get()
-            Truth.assertThat(instanceMetadata.instanceName).isEqualTo("i-1234567890abcdef0")
-            Truth.assertThat(instanceMetadata.zone).isEqualTo("us-west-2c")
+            assertThat(instanceMetadata.instanceName).isEqualTo("i-1234567890abcdef0")
+            assertThat(instanceMetadata.zone).isEqualTo("us-west-2c")
         } finally {
             server.shutdown()
         }

--- a/misk/src/test/kotlin/misk/cloud/fake/security/keys/FakeKeyServiceTest.kt
+++ b/misk/src/test/kotlin/misk/cloud/fake/security/keys/FakeKeyServiceTest.kt
@@ -1,6 +1,6 @@
 package misk.cloud.fake.security.keys
 
-import com.google.common.truth.Truth.assertThat
+import org.assertj.core.api.Assertions.assertThat
 import okio.ByteString
 import org.junit.jupiter.api.Test
 

--- a/misk/src/test/kotlin/misk/cloud/gcp/environment/GcpInstanceMetadataProviderTest.kt
+++ b/misk/src/test/kotlin/misk/cloud/gcp/environment/GcpInstanceMetadataProviderTest.kt
@@ -1,6 +1,6 @@
 package misk.cloud.gcp.environment
 
-import com.google.common.truth.Truth.assertThat
+import org.assertj.core.api.Assertions.assertThat
 import misk.cloud.gcp.environment.GcpInstanceMetadataProvider.Companion.GCP_INSTANCE_METADATA_PATH
 import misk.testing.okhttp.RoutingDispatcher
 import misk.testing.okhttp.path

--- a/misk/src/test/kotlin/misk/cloud/gcp/security/keys/GcpKeyServiceTest.kt
+++ b/misk/src/test/kotlin/misk/cloud/gcp/security/keys/GcpKeyServiceTest.kt
@@ -4,7 +4,7 @@ import com.google.api.client.json.jackson2.JacksonFactory
 import com.google.api.services.cloudkms.v1.CloudKMS
 import com.google.api.services.cloudkms.v1.model.DecryptResponse
 import com.google.api.services.cloudkms.v1.model.EncryptResponse
-import com.google.common.truth.Truth.assertThat
+import org.assertj.core.api.Assertions.assertThat
 import misk.cloud.gcp.testing.FakeHttpRouter
 import misk.cloud.gcp.testing.FakeHttpRouter.Companion.respondWithError
 import misk.cloud.gcp.testing.FakeHttpRouter.Companion.respondWithJson

--- a/misk/src/test/kotlin/misk/cloud/gcp/testing/FakeHttpRouterTest.kt
+++ b/misk/src/test/kotlin/misk/cloud/gcp/testing/FakeHttpRouterTest.kt
@@ -4,7 +4,7 @@ import com.google.api.client.http.GenericUrl
 import com.google.api.client.http.HttpResponseException
 import com.google.api.client.json.jackson2.JacksonFactory
 import com.google.api.client.testing.http.MockHttpContent
-import com.google.common.truth.Truth.assertThat
+import org.assertj.core.api.Assertions.assertThat
 import misk.cloud.gcp.testing.FakeHttpRouter.Companion.respondWithError
 import misk.cloud.gcp.testing.FakeHttpRouter.Companion.respondWithText
 import org.junit.jupiter.api.Assertions.fail

--- a/misk/src/test/kotlin/misk/concurrent/WrappingListeningExecutorServiceTest.kt
+++ b/misk/src/test/kotlin/misk/concurrent/WrappingListeningExecutorServiceTest.kt
@@ -1,6 +1,6 @@
 package misk.concurrent
 
-import com.google.common.truth.Truth.assertThat
+import org.assertj.core.api.Assertions.assertThat
 import com.google.common.util.concurrent.ListeningExecutorService
 import com.google.common.util.concurrent.MoreExecutors
 import org.junit.jupiter.api.BeforeEach

--- a/misk/src/test/kotlin/misk/config/ConfigTest.kt
+++ b/misk/src/test/kotlin/misk/config/ConfigTest.kt
@@ -1,6 +1,6 @@
 package misk.config
 
-import com.google.common.truth.Truth.assertThat
+import org.assertj.core.api.Assertions.assertThat
 import com.google.inject.util.Modules
 import misk.environment.Environment.TESTING
 import misk.environment.EnvironmentModule

--- a/misk/src/test/kotlin/misk/logging/LoggingTest.kt
+++ b/misk/src/test/kotlin/misk/logging/LoggingTest.kt
@@ -1,6 +1,6 @@
 package misk.logging
 
-import com.google.common.truth.Truth.assertThat
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
 class LoggingTest {

--- a/misk/src/test/kotlin/misk/metrics/MetricsTest.kt
+++ b/misk/src/test/kotlin/misk/metrics/MetricsTest.kt
@@ -1,8 +1,8 @@
 package misk.metrics
 
-import com.google.common.truth.Truth.assertThat
 import com.google.inject.Guice
 import misk.inject.getInstance
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import java.time.Duration
 import java.util.concurrent.TimeUnit
@@ -36,9 +36,9 @@ class MetricsTest {
 
         metrics.gauge("my_gauge", { n.get() })
         assertThat(metrics.gauges).containsKey("my_gauge")
-        assertThat(metrics.gauges["my_gauge"]!!.value).isEqualTo(0)
+        assertThat(metrics.gauges["my_gauge"]!!.value).isEqualTo(0L)
         n.set(254)
-        assertThat(metrics.gauges["my_gauge"]!!.value).isEqualTo(254)
+        assertThat(metrics.gauges["my_gauge"]!!.value).isEqualTo(254L)
     }
 
     @Test
@@ -47,9 +47,9 @@ class MetricsTest {
         val gauge = metrics.settableGauge("my_gauge")
 
         assertThat(metrics.gauges).containsKey("my_gauge")
-        assertThat(metrics.gauges["my_gauge"]!!.value).isEqualTo(0)
+        assertThat(metrics.gauges["my_gauge"]!!.value).isEqualTo(0L)
         gauge.value.set(254)
-        assertThat(metrics.gauges["my_gauge"]!!.value).isEqualTo(254)
+        assertThat(metrics.gauges["my_gauge"]!!.value).isEqualTo(254L)
     }
 
     @Test
@@ -59,11 +59,11 @@ class MetricsTest {
 
         metrics.cachedGauge("my_gauge", Duration.ofMillis(100), n::get)
         assertThat(metrics.gauges).containsKey("my_gauge")
-        assertThat(metrics.gauges["my_gauge"]!!.value).isEqualTo(0)
+        assertThat(metrics.gauges["my_gauge"]!!.value).isEqualTo(0L)
         n.set(254)
-        assertThat(metrics.gauges["my_gauge"]!!.value).isEqualTo(0)
+        assertThat(metrics.gauges["my_gauge"]!!.value).isEqualTo(0L)
         Thread.sleep(120)
-        assertThat(metrics.gauges["my_gauge"]!!.value).isEqualTo(254)
+        assertThat(metrics.gauges["my_gauge"]!!.value).isEqualTo(254L)
     }
 
     @Test

--- a/misk/src/test/kotlin/misk/metrics/backends/stackdriver/StackDriverReporterTest.kt
+++ b/misk/src/test/kotlin/misk/metrics/backends/stackdriver/StackDriverReporterTest.kt
@@ -3,7 +3,6 @@ package misk.metrics.backends.stackdriver
 import com.codahale.metrics.Gauge
 import com.google.api.client.util.DateTime
 import com.google.api.services.monitoring.v3.model.TimeSeries
-import com.google.common.truth.Truth.assertThat
 import com.google.inject.AbstractModule
 import com.google.inject.Provides
 import com.google.inject.util.Modules
@@ -15,6 +14,8 @@ import misk.testing.ActionTest
 import misk.testing.ActionTestModule
 import misk.time.FakeClock
 import misk.time.FakeClockModule
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.data.Percentage
 import org.junit.jupiter.api.Test
 import java.math.BigDecimal
 import java.math.BigInteger
@@ -34,7 +35,7 @@ internal class StackDriverReporterTest {
         fun assertGauge(timeSeries: TimeSeries, expected: Double) {
             assertThat(timeSeries.metricKind).isEqualTo("GAUGE")
             assertThat(timeSeries.points).hasSize(1)
-            assertThat(timeSeries.points[0].value.doubleValue).isWithin(0.001).of(expected)
+            assertThat(timeSeries.points[0].value.doubleValue).isCloseTo(expected, Percentage.withPercentage(0.1))
             assertThat(timeSeries.points[0].interval.startTime).isNull()
             assertThat(timeSeries.points[0].interval.endTime).isEqualTo(NOW.toStringRfc3339())
         }

--- a/misk/src/test/kotlin/misk/metrics/web/MetricsJsonActionTest.kt
+++ b/misk/src/test/kotlin/misk/metrics/web/MetricsJsonActionTest.kt
@@ -1,10 +1,10 @@
 package misk.metrics.web
 
-import com.google.common.truth.Truth.assertThat
 import misk.metrics.Metrics
 import misk.metrics.MetricsModule
 import misk.testing.ActionTest
 import misk.testing.ActionTestModule
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import java.util.concurrent.TimeUnit
 import javax.inject.Inject
@@ -32,9 +32,9 @@ internal class MetricsJsonActionTest {
         metrics.gauge("g3", { "howdy pardner" })
 
         val json = metricsAction.getMetrics()
-        assertThat(json.counters.keys).containsExactly("myfav", "banana", "joist")
+        assertThat(json.counters.keys).containsExactlyInAnyOrder("myfav", "banana", "joist")
         assertThat(json.timers.keys).containsExactly("slow")
         assertThat(json.histograms.keys).containsExactly("mork")
-        assertThat(json.gauges.keys).containsExactly("g1", "g2", "g3")
+        assertThat(json.gauges.keys).containsExactlyInAnyOrder("g1", "g2", "g3")
     }
 }

--- a/misk/src/test/kotlin/misk/resources/ResourceLoaderTest.kt
+++ b/misk/src/test/kotlin/misk/resources/ResourceLoaderTest.kt
@@ -1,6 +1,6 @@
 package misk.resources
 
-import com.google.common.truth.Truth.assertThat
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
 class ResourceLoaderTest {

--- a/misk/src/test/kotlin/misk/scope/ActionScopePropagationTest.kt
+++ b/misk/src/test/kotlin/misk/scope/ActionScopePropagationTest.kt
@@ -1,6 +1,6 @@
 package misk.scope
 
-import com.google.common.truth.Truth.assertThat
+import org.assertj.core.api.Assertions.assertThat
 import com.google.inject.Guice
 import com.google.inject.Key
 import com.google.inject.name.Named

--- a/misk/src/test/kotlin/misk/scope/ActionScopedTest.kt
+++ b/misk/src/test/kotlin/misk/scope/ActionScopedTest.kt
@@ -1,6 +1,6 @@
 package misk.scope
 
-import com.google.common.truth.Truth.assertThat
+import org.assertj.core.api.Assertions.assertThat
 import com.google.inject.Guice
 import com.google.inject.Key
 import com.google.inject.name.Named

--- a/misk/src/test/kotlin/misk/scope/executor/ActionScopedExecutorServiceTest.kt
+++ b/misk/src/test/kotlin/misk/scope/executor/ActionScopedExecutorServiceTest.kt
@@ -1,6 +1,6 @@
 package misk.scope.executor
 
-import com.google.common.truth.Truth.assertThat
+import org.assertj.core.api.Assertions.assertThat
 import com.google.inject.Guice
 import com.google.inject.Key
 import com.google.inject.Provides

--- a/misk/src/test/kotlin/misk/time/FakeClockTest.kt
+++ b/misk/src/test/kotlin/misk/time/FakeClockTest.kt
@@ -1,6 +1,6 @@
 package misk.time
 
-import com.google.common.truth.Truth.assertThat
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import java.time.Duration
 import java.time.Instant

--- a/misk/src/test/kotlin/misk/web/PathPatternTest.kt
+++ b/misk/src/test/kotlin/misk/web/PathPatternTest.kt
@@ -1,6 +1,6 @@
 package misk.web
 
-import com.google.common.truth.Truth.assertThat
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
 internal class PathPatternTest {

--- a/misk/src/test/kotlin/misk/web/WebDispatchTest.kt
+++ b/misk/src/test/kotlin/misk/web/WebDispatchTest.kt
@@ -1,6 +1,6 @@
 package misk.web
 
-import com.google.common.truth.Truth.assertThat
+import org.assertj.core.api.Assertions.assertThat
 import com.google.inject.util.Modules
 import com.squareup.moshi.Moshi
 import misk.MiskModule

--- a/misk/src/test/kotlin/misk/web/actions/LivenessCheckActionTest.kt
+++ b/misk/src/test/kotlin/misk/web/actions/LivenessCheckActionTest.kt
@@ -1,6 +1,6 @@
 package misk.web.actions
 
-import com.google.common.truth.Truth.assertThat
+import org.assertj.core.api.Assertions.assertThat
 import com.google.common.util.concurrent.ServiceManager
 import com.google.inject.util.Modules
 import misk.MiskModule

--- a/misk/src/test/kotlin/misk/web/actions/NotFoundActionTest.kt
+++ b/misk/src/test/kotlin/misk/web/actions/NotFoundActionTest.kt
@@ -1,6 +1,6 @@
 package misk.web.actions
 
-import com.google.common.truth.Truth.assertThat
+import org.assertj.core.api.Assertions.assertThat
 import misk.testing.ActionTest
 import misk.web.Response
 import org.junit.jupiter.api.Test

--- a/misk/src/test/kotlin/misk/web/actions/ReadinessCheckActionTest.kt
+++ b/misk/src/test/kotlin/misk/web/actions/ReadinessCheckActionTest.kt
@@ -1,6 +1,6 @@
 package misk.web.actions
 
-import com.google.common.truth.Truth.assertThat
+import org.assertj.core.api.Assertions.assertThat
 import com.google.common.util.concurrent.ServiceManager
 import com.google.inject.util.Modules
 import misk.MiskModule

--- a/misk/src/test/kotlin/misk/web/interceptors/MetricsInterceptorTest.kt
+++ b/misk/src/test/kotlin/misk/web/interceptors/MetricsInterceptorTest.kt
@@ -1,6 +1,6 @@
 package misk.web.interceptors
 
-import com.google.common.truth.Truth.assertThat
+import org.assertj.core.api.Assertions.assertThat
 import misk.asAction
 import misk.metrics.Metrics
 import misk.metrics.MetricsModule

--- a/misk/src/test/kotlin/misk/web/interceptors/ProtobufInterceptorFactoryTest.kt
+++ b/misk/src/test/kotlin/misk/web/interceptors/ProtobufInterceptorFactoryTest.kt
@@ -1,6 +1,6 @@
 package misk.web.interceptors
 
-import com.google.common.truth.Truth.assertThat
+import org.assertj.core.api.Assertions.assertThat
 import helpers.protos.Dinosaur
 import misk.asAction
 import misk.testing.ActionTest

--- a/misk/testing/build.gradle
+++ b/misk/testing/build.gradle
@@ -23,7 +23,7 @@ dependencies {
   compile dep.junitApi
   compile dep.junitParams
   compile dep.junitEngine
-  compile dep.truth
+  compile dep.assertj
   compile dep.loggingImpl
   compile dep.okHttpMockWebServer
 }


### PR DESCRIPTION
How strongly do you feel about Truth over AssertJ? AssertJ supports JUnit 5; Truth pulls in JUnit 4 as a transitive dependency. Feature-wise, they're near-identical.
