### PR TITLE
Deterministically route requests

### DIFF
--- a/misk/src/main/kotlin/misk/web/BoundAction.kt
+++ b/misk/src/main/kotlin/misk/web/BoundAction.kt
@@ -21,28 +21,19 @@ import kotlin.reflect.KParameter
  * Decodes an HTTP request into a call to a web action, then encodes its response into an HTTP
  * response.
  */
-internal class BoundAction<A : WebAction, R>(
-        val webActionProvider: Provider<A>,
+internal class BoundAction<A : WebAction, out R>(
+        private val webActionProvider: Provider<A>,
         val interceptors: MutableList<Interceptor>,
         parameterExtractorFactories: List<ParameterExtractor.Factory>,
         val function: KFunction<R>,
         val pathPattern: PathPattern,
-        val httpMethod: HttpMethod,
-        val acceptedContentTypes: List<MediaRange>,
-        val responseContentType: MediaType?
+        private val httpMethod: HttpMethod,
+        private val acceptedContentTypes: List<MediaRange>,
+        private val responseContentType: MediaType?
 ) {
-    val parameterExtractors = ArrayList<ParameterExtractor>()
-
-    init {
-        for (parameter in function.parameters) {
-            // This first parameter is always this.
-            if (parameter.index == 0) {
-                continue
-            }
-
-            parameterExtractors.add(findParameterExtractor(parameterExtractorFactories, parameter))
-        }
-    }
+    private val parameterExtractors = function.parameters
+            .drop(1) // the first parameter is always _this_
+            .map { findParameterExtractor(parameterExtractorFactories, it) }
 
     private fun findParameterExtractor(
             parameterExtractorFactories: List<ParameterExtractor.Factory>,
@@ -63,33 +54,28 @@ internal class BoundAction<A : WebAction, R>(
         return result
     }
 
-    /** Returns true if this bound action handled the request. */
-    fun tryHandle(
-            jettyRequest: HttpServletRequest,
-            jettyResponse: HttpServletResponse
-    ): Boolean {
-        val pathMatcher = matcher(jettyRequest.httpUrl()) ?: return false
-        if (jettyRequest.method != httpMethod.name) return false
+    fun match(jettyRequest: HttpServletRequest): RequestMatch? {
+        // Confirm the path and method matches
+        val pathMatcher = pathMatcher(jettyRequest.httpUrl()) ?: return null
+        if (jettyRequest.method != httpMethod.name) return null
 
+        // Confirm the request content type matches the types we accept, and pick the most specific
+        // content type match
         val requestContentType = jettyRequest.contentType?.let { MediaType.parse(it) }
-        if (requestContentType != null) {
-            if (acceptedContentTypes.none { it.matches(requestContentType) }) return false
-        }
+        val requestContentTypeMatch =
+                requestContentType?.closestMediaRangeMatch(acceptedContentTypes)
+        if (requestContentType != null && requestContentTypeMatch == null) return null
 
-        if (responseContentType != null) {
-            val acceptedResponseContentTypes = jettyRequest.accepts()
-            if (acceptedResponseContentTypes.none { it.matches(responseContentType) }) return false
-        }
+        // Confirm we can generate a response content type matching the set accepted by the request,
+        // and pick the most specific response content type match
+        val responseContentTypeMatch =
+                responseContentType?.closestMediaRangeMatch(jettyRequest.accepts())
+        if (responseContentType != null && responseContentTypeMatch == null) return null
 
-        val result = handle(jettyRequest.asRequest(), pathMatcher)
-        result.writeToJettyResponse(jettyResponse)
-        return true
+        return RequestMatch(this, pathMatcher, requestContentTypeMatch, responseContentTypeMatch)
     }
 
-    private fun handle(
-            request: Request,
-            pathMather: Matcher
-    ): Response<ResponseBody> {
+    internal fun handle(request: Request, pathMather: Matcher): Response<ResponseBody> {
         // Find values for all the parameters.
         val webAction = webActionProvider.get()
         val parameters = parameterExtractors.map {
@@ -109,7 +95,7 @@ internal class BoundAction<A : WebAction, R>(
     }
 
     /** Returns a Matcher if requestUrl can be matched, else null */
-    private fun matcher(requestUrl: HttpUrl): Matcher? {
+    private fun pathMatcher(requestUrl: HttpUrl): Matcher? {
         val matcher = pathPattern.pattern.matcher(requestUrl.encodedPath())
         return if (matcher.matches()) matcher else null
     }
@@ -127,6 +113,28 @@ private fun HttpServletRequest.accepts(): List<MediaRange> {
         accepts
     }
 }
+
+/** Matches a request to an action. Can be sorted to pick the most specific match amongst a set of candidates */
+internal class RequestMatch(
+        val action: BoundAction<*, *>,
+        val pathMatcher: Matcher,
+        val requestContentTypeMatch: MediaRange.Matcher?,
+        val responseContentTypeMatch: MediaRange.Matcher?
+) : Comparable<RequestMatch> {
+    override fun compareTo(other: RequestMatch): Int {
+        val patternDiff = action.pathPattern.compareTo(other.action.pathPattern)
+        if (patternDiff != 0) return patternDiff
+        return 0
+    }
+
+    fun handle(jettyRequest: HttpServletRequest, jettyResponse: HttpServletResponse) {
+        val result = action.handle(jettyRequest.asRequest(), pathMatcher)
+        result.writeToJettyResponse(jettyResponse)
+    }
+}
+
+private fun MediaType.closestMediaRangeMatch(ranges: List<MediaRange>) =
+        ranges.mapNotNull { it.matcher(this) }.sorted().firstOrNull()
 
 private fun HttpServletRequest.headers(): Headers {
     val headersBuilder = Headers.Builder()

--- a/misk/src/main/kotlin/misk/web/PathPattern.kt
+++ b/misk/src/main/kotlin/misk/web/PathPattern.kt
@@ -8,26 +8,77 @@ import java.util.regex.Pattern
  * like this: `{username:[a-z]+}`. If no regex is specified the variable is a sequence of non-'/'
  * characters.
  */
-data class PathPattern(val pattern: Pattern, val variableNames: List<String>) {
+data class PathPattern(
+        val pattern: Pattern,
+        val variableNames: List<String>,
+        val numRegexVariables: Int,
+        val numSegments: Int,
+        val matchesWildcardPath: Boolean
+) : Comparable<PathPattern> {
+
+    /** Compares path patterns by specificity, with the more specific pattern ordered first */
+    override fun compareTo(other: PathPattern): Int {
+        // A path with more segments requires a more specific match
+        val numSegmentDiff = other.numSegments - numSegments
+        if (numSegmentDiff != 0) return numSegmentDiff
+
+        // If we have the same number of fixed segments, but one of the patterns captures
+        // the trailing part of the path in a variable, that pattern is less specific
+        if (matchesWildcardPath && !other.matchesWildcardPath) return 1
+        if (!matchesWildcardPath && other.matchesWildcardPath) return -1
+
+        // Assuming we match on the same number of segments, then the pattern that has
+        // more of those segments as constant text is a more specific match
+        val numVariablesDiff = variableNames.size - other.variableNames.size
+        if (numVariablesDiff != 0) return numVariablesDiff
+
+        // Finally, the pattern which qualifies more of its variables with regexes is a
+        // more specific match
+        return other.numRegexVariables - numRegexVariables
+    }
     companion object {
         fun parse(pattern: String): PathPattern {
             val variableNames = ArrayList<String>()
             val result = StringBuilder()
 
+            var numSegments = 0
+            var numRegexVariables = 0
+            var lastVariableIsWildcardMatch = false
             var pos = 0
             while (pos < pattern.length) {
+                lastVariableIsWildcardMatch = false
+
                 when (pattern[pos]) {
                     '{' -> {
+                        // Variables must start on path boundaries
+                        require(pos == 0 || pattern[pos-1] == '/') {
+                            "invalid path pattern $pattern; variables must start on path boundaries"
+                        }
+
                         val variableNameEnd = pattern.indexOfAny(charArrayOf('}', ':'), pos + 1)
                         require(variableNameEnd != -1)
                         variableNames.add(pattern.substring(pos + 1, variableNameEnd))
                         if (pattern[variableNameEnd] == ':') {
                             pos = pattern.indexOf('}', variableNameEnd + 1) + 1
                             require(pos != -1)
-                            result.append("(").append(pattern, variableNameEnd + 1, pos - 1).append(")")
+
+                            var regex = pattern.substring(variableNameEnd + 1, pos - 1)
+                            if (pos < pattern.length && regex.endsWith(".*")) {
+                                regex = regex.substring(0, regex.length - 2) + "[^/]*"
+                            }
+
+                            result.append("(").append(regex).append(")")
+                            numRegexVariables++
+
+                            lastVariableIsWildcardMatch = regex.endsWith(".*")
                         } else {
                             pos = variableNameEnd + 1
                             result.append("([^/]*)")
+                        }
+
+                        // Variables must end on path boundaries
+                        require(pos == pattern.length || pattern[pos] == '/') {
+                            "invalid path pattern $pattern; variables must end on path boundaries"
                         }
                     }
 
@@ -37,6 +88,16 @@ data class PathPattern(val pattern: Pattern, val variableNames: List<String>) {
                     }
 
                     else -> {
+                        result.append("\\Q")
+                        while (pos < pattern.length && pattern[pos] != '\\' && pattern[pos] != '{') {
+                            if (pattern[pos] == '/') numSegments++
+
+                            result.append(pattern[pos])
+                            pos++
+                        }
+                        result.append("\\E")
+
+                        /*
                         var nextMetacharacterStart = pattern.indexOfAny(charArrayOf('\\', '{'), pos)
                         if (nextMetacharacterStart == -1) {
                             nextMetacharacterStart = pattern.length
@@ -45,11 +106,13 @@ data class PathPattern(val pattern: Pattern, val variableNames: List<String>) {
                         result.append(pattern, pos, nextMetacharacterStart)
                         result.append("\\E")
                         pos = nextMetacharacterStart
+                        */
                     }
                 }
             }
 
-            return PathPattern(Pattern.compile(result.toString()), variableNames)
+            return PathPattern(Pattern.compile(result.toString()), variableNames, numRegexVariables,
+                    numSegments, lastVariableIsWildcardMatch)
         }
     }
 }

--- a/misk/src/main/kotlin/misk/web/jetty/WebActionsServlet.kt
+++ b/misk/src/main/kotlin/misk/web/jetty/WebActionsServlet.kt
@@ -34,7 +34,10 @@ internal class WebActionsServlet @Inject constructor(
                 keyOf<Request>() to request.asRequest())
 
         scope.enter(seedData).use {
-            if (boundActions.any { it.tryHandle(request, response) }) {
+            val candidateActions = boundActions.mapNotNull { it.match(request) }
+            val bestAction = candidateActions.sorted().firstOrNull()
+            if (bestAction != null) {
+                bestAction.handle(request, response)
                 logger.debug("Request handled by WebActionServlet")
             }
         }

--- a/misk/src/main/kotlin/misk/web/mediatype/MediaRange.kt
+++ b/misk/src/main/kotlin/misk/web/mediatype/MediaRange.kt
@@ -11,8 +11,22 @@ data class MediaRange(
         val qualityFactor: Double = 1.0,
         val parameters: Map<String, String> = mapOf(),
         val extensions: Map<String, String> = mapOf()
-) {
-    val wildcardCount: Int = computeWildcardCount(type, subtype)
+) : Comparable<MediaRange>{
+    override fun compareTo(other: MediaRange): Int {
+        if (type == WILDCARD && other.type != WILDCARD) return 1
+        if (type != WILDCARD && other.type == WILDCARD) return -1
+
+        if (subtype == WILDCARD && other.subtype != WILDCARD) return 1
+        if (subtype != WILDCARD && other.subtype == WILDCARD) return -1
+
+        val parameterDiff = other.parameters.size - parameters.size
+        if (parameterDiff != 0) return parameterDiff
+
+        val extensionDiff = other.extensions.size - extensions.size
+        if (extensionDiff != 0) return extensionDiff
+
+        return 0
+    }
 
     fun matches(mediaType: MediaType) = matcher(mediaType) != null
 
@@ -38,6 +52,9 @@ data class MediaRange(
     }
 
     data class Matcher(val mediaRange: MediaRange, val matchesCharset: Boolean = false)
+        : Comparable<Matcher> {
+        override fun compareTo(other: Matcher) = mediaRange.compareTo(other.mediaRange)
+    }
 
     companion object {
         const val WILDCARD = "*"

--- a/misk/src/test/kotlin/misk/web/DeterministicRoutingTest.kt
+++ b/misk/src/test/kotlin/misk/web/DeterministicRoutingTest.kt
@@ -1,0 +1,93 @@
+package misk.web
+
+import com.google.inject.util.Modules
+import misk.MiskModule
+import misk.inject.KAbstractModule
+import misk.testing.ActionTest
+import misk.testing.ActionTestModule
+import misk.testing.TestWebModule
+import misk.web.actions.WebAction
+import misk.web.jetty.JettyService
+import misk.web.mediatype.MediaTypes
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.util.Collections.shuffle
+import javax.inject.Inject
+
+@ActionTest(startService = true)
+internal class DeterministicRoutingTest {
+    @ActionTestModule
+    val module = Modules.combine(
+            MiskModule(),
+            WebModule(),
+            TestWebModule(),
+            TestModule())
+
+    private @Inject lateinit var jettyService: JettyService
+
+    @Test
+    fun picksMostSpecificPaths() {
+        assertThat(get("/org/admin/users")).isEqualTo("specific-path-action")
+        assertThat(get("/org/admin/foo")).isEqualTo("subsection-action")
+        assertThat(get("/org/foo/bar")).isEqualTo("section-action")
+        assertThat(get("/org/admin/users/bar")).isEqualTo("remainder-path-action")
+        assertThat(get("/org/unknown/caller/deep/path")).isEqualTo("whole-path")
+    }
+
+    class SpecificPathAction : WebAction {
+        @Get("/org/admin/users")
+        @ResponseContentType(MediaTypes.TEXT_PLAIN_UTF8)
+        fun handle() = "specific-path-action"
+    }
+
+    class SubsectionAction : WebAction {
+        @Get("/org/admin/{subsection}")
+        @ResponseContentType(MediaTypes.TEXT_PLAIN_UTF8)
+        fun handle() = "subsection-action"
+    }
+
+    class SectionAction : WebAction {
+        @Get("/org/{section}/{subsection}")
+        @ResponseContentType(MediaTypes.TEXT_PLAIN_UTF8)
+        fun handle() = "section-action"
+    }
+
+    class RemainderPathAction : WebAction {
+        @Get("/org/admin/{path:.*}")
+        @ResponseContentType(MediaTypes.TEXT_PLAIN_UTF8)
+        fun handle() = "remainder-path-action"
+    }
+
+    class WholePathAction : WebAction {
+        @Get("/{path:.*}")
+        @ResponseContentType(MediaTypes.TEXT_PLAIN_UTF8)
+        fun handle() = "whole-path"
+    }
+
+    class TestModule : KAbstractModule() {
+        override fun configure() {
+            val webActionModules = mutableListOf(
+                    WebActionModule.create<WholePathAction>(),
+                    WebActionModule.create<RemainderPathAction>(),
+                    WebActionModule.create<SectionAction>(),
+                    WebActionModule.create<SubsectionAction>(),
+                    WebActionModule.create<SpecificPathAction>()
+            )
+            shuffle(webActionModules)
+            webActionModules.forEach { install(it) }
+        }
+    }
+
+    private fun get(path: String): String = call(Request.Builder()
+            .url(jettyService.serverUrl.newBuilder().encodedPath(path).build())
+            .get())
+
+    private fun call(request: Request.Builder): String {
+        val httpClient = OkHttpClient()
+        val response = httpClient.newCall(request.build()).execute()
+        return response.body()!!.string()
+    }
+
+}

--- a/misk/src/test/kotlin/misk/web/PathPatternTest.kt
+++ b/misk/src/test/kotlin/misk/web/PathPatternTest.kt
@@ -2,22 +2,111 @@ package misk.web
 
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import java.util.Collections.shuffle
 
 internal class PathPatternTest {
     @Test
-    fun parse() {
-        assertThat(PathPattern.parse("/abc/{jeff}/def").pattern.toString())
-                .isEqualTo("\\Q/abc/\\E([^/]*)\\Q/def\\E")
-        assertThat(PathPattern.parse("\\Q").pattern.toString())
-                .isEqualTo("\\\\\\QQ\\E")
-        assertThat(PathPattern.parse("/{name:regex}").pattern.toString())
-                .isEqualTo("\\Q/\\E(regex)")
+    fun withOnlyConstants() {
+        val p = PathPattern.parse("/a/b/c/d/e/f/g")
+        assertThat(p.pattern.toString()).isEqualTo("\\Q/a/b/c/d/e/f/g\\E")
+        assertThat(p.numSegments).isEqualTo(7)
+        assertThat(p.numRegexVariables).isEqualTo(0)
+        assertThat(p.matchesWildcardPath).isFalse()
+        assertThat(p.variableNames).isEmpty()
     }
 
     @Test
-    fun variableNames() {
-        val pathPattern = PathPattern.parse("/abc/{jeff}/def/{jesse}")
-        assertThat(pathPattern.variableNames).containsExactly("jeff", "jesse")
+    fun withSimpleVariableMatches() {
+        val p = PathPattern.parse("/abc/{jeff}/def/{jesse}")
+        assertThat(p.pattern.toString()).isEqualTo("\\Q/abc/\\E([^/]*)\\Q/def/\\E([^/]*)")
+        assertThat(p.numSegments).isEqualTo(4)
+        assertThat(p.numRegexVariables).isEqualTo(0)
+        assertThat(p.matchesWildcardPath).isFalse()
+        assertThat(p.variableNames).containsExactly("jeff", "jesse")
+
+        val m1 = p.pattern.matcher("/abc/moo/def/bark")
+        assertThat(m1.matches()).isTrue()
+        assertThat(m1.group(1)).isEqualTo("moo")
+        assertThat(m1.group(2)).isEqualTo("bark")
+
+        assertThat(p.pattern.matcher("/abc/moo/def").matches()).isFalse()
+        assertThat(p.pattern.matcher("/abc/moo/def/bark/more").matches()).isFalse()
+    }
+
+    @Test
+    fun withRegexMatches() {
+        val p = PathPattern.parse("/org/admin/{folder:[a-z]+}/{object:[a-z0-9]+}")
+        assertThat(p.pattern.toString()).isEqualTo("\\Q/org/admin/\\E([a-z]+)\\Q/\\E([a-z0-9]+)")
+        assertThat(p.numSegments).isEqualTo(4)
+        assertThat(p.numRegexVariables).isEqualTo(2)
+        assertThat(p.matchesWildcardPath).isFalse()
+        assertThat(p.variableNames).containsExactly("folder", "object")
+
+        val m1 = p.pattern.matcher("/org/admin/oranges/foo")
+        assertThat(m1.matches()).isTrue()
+        assertThat(m1.group(1)).isEqualTo("oranges")
+        assertThat(m1.group(2)).isEqualTo("foo")
+
+        val m2 = p.pattern.matcher("/org/admin/apples/bar75")
+        assertThat(m2.matches()).isTrue()
+        assertThat(m2.group(1)).isEqualTo("apples")
+        assertThat(m2.group(2)).isEqualTo("bar75")
+
+        assertThat(p.pattern.matcher("/org/admin/239034/bar75").matches()).isFalse()
+        assertThat(p.pattern.matcher("/org/admin/apples/_admin").matches()).isFalse()
+        assertThat(p.pattern.matcher("/org/admin/apples/_admin").matches()).isFalse()
+        assertThat(p.pattern.matcher("/org/admin/apples/bar75/zod").matches()).isFalse()
+    }
+
+    @Test
+    fun withFullPathCapture() {
+        val p = PathPattern.parse("/org/admin/{object_type:o.*}/{path:.*}")
+        assertThat(p.pattern.toString()).isEqualTo("\\Q/org/admin/\\E(o[^/]*)\\Q/\\E(.*)")
+        assertThat(p.numSegments).isEqualTo(4)
+        assertThat(p.numRegexVariables).isEqualTo(2)
+        assertThat(p.matchesWildcardPath).isTrue()
+        assertThat(p.variableNames).containsExactly("object_type", "path")
+
+        val m1 = p.pattern.matcher("/org/admin/oranges/foo")
+        assertThat(m1.matches()).isTrue()
+        assertThat(m1.group(1)).isEqualTo("oranges")
+        assertThat(m1.group(2)).isEqualTo("foo")
+
+        val m2 = p.pattern.matcher("/org/admin/oranges/foo/bar")
+        assertThat(m2.matches()).isTrue()
+        assertThat(m2.group(1)).isEqualTo("oranges")
+        assertThat(m2.group(2)).isEqualTo("foo/bar")
+
+        assertThat(p.pattern.matcher("/org/admin/users/foo").matches()).isFalse()
+    }
+
+    @Test
+    fun withWildcardCaptureInMiddle() {
+        val p = PathPattern.parse("/org/admin/{object_type:.*}/get")
+        assertThat(p.pattern.toString()).isEqualTo("\\Q/org/admin/\\E([^/]*)\\Q/get\\E")
+        assertThat(p.numSegments).isEqualTo(4)
+        assertThat(p.numRegexVariables).isEqualTo(1)
+        assertThat(p.matchesWildcardPath).isFalse()
+        assertThat(p.variableNames).containsExactly("object_type")
+
+        assertThat(p.pattern.matcher("/org/admin/users/get").matches()).isTrue()
+        assertThat(p.pattern.matcher("/org/admin/get").matches()).isFalse()
+        assertThat(p.pattern.matcher("/org/admin/users/floozers").matches()).isFalse()
+    }
+
+    @Test
+    fun ordering() {
+        val p1 = PathPattern.parse("/org/{folder}/{type}")
+        val p2 = PathPattern.parse("/org/admin/{type}")
+        val p3 = PathPattern.parse("/org/admin/users")
+        val p4 = PathPattern.parse("/org/admin/{path:.*}")
+        val p5 = PathPattern.parse("/org/admin/{type:.*}/values")
+
+        val patterns = mutableListOf(p1, p2, p3, p4, p5)
+        shuffle(patterns)
+
+        val sortedBySpecificity = patterns.sorted()
+        assertThat(sortedBySpecificity).containsExactly(p5, p3, p2, p1, p4)
     }
 }
 

--- a/misk/src/test/kotlin/misk/web/mediatype/MediaRangeTest.kt
+++ b/misk/src/test/kotlin/misk/web/mediatype/MediaRangeTest.kt
@@ -6,6 +6,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.data.Offset
 import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Test
+import java.util.Collections.shuffle
 
 internal class MediaRangeTest {
     @Test
@@ -17,7 +18,6 @@ internal class MediaRangeTest {
         assertThat(mediaRange.extensions).isEmpty()
         assertThat(mediaRange.parameters).isEmpty()
         assertThat(mediaRange.qualityFactor).isCloseTo(1.0, Offset.offset(0.01))
-        assertThat(mediaRange.wildcardCount).isEqualTo(2)
     }
 
     @Test
@@ -29,7 +29,6 @@ internal class MediaRangeTest {
         assertThat(mediaRange.extensions).isEmpty()
         assertThat(mediaRange.parameters).isEmpty()
         assertThat(mediaRange.qualityFactor).isCloseTo(1.0, Offset.offset(0.01))
-        assertThat(mediaRange.wildcardCount).isEqualTo(1)
     }
 
     @Test
@@ -41,7 +40,6 @@ internal class MediaRangeTest {
         assertThat(mediaRange.extensions).isEmpty()
         assertThat(mediaRange.parameters).isEmpty()
         assertThat(mediaRange.qualityFactor).isCloseTo(1.0, Offset.offset(0.01))
-        assertThat(mediaRange.wildcardCount).isEqualTo(0)
     }
 
     @Test
@@ -53,7 +51,6 @@ internal class MediaRangeTest {
         assertThat(mediaRange.extensions).isEmpty()
         assertThat(mediaRange.parameters).containsExactly("level" to "1", "strict" to "true")
         assertThat(mediaRange.qualityFactor).isCloseTo(1.0, Offset.offset(0.01))
-        assertThat(mediaRange.wildcardCount).isEqualTo(0)
     }
 
     @Test
@@ -65,7 +62,6 @@ internal class MediaRangeTest {
         assertThat(mediaRange.extensions).isEmpty()
         assertThat(mediaRange.parameters).containsExactly("level" to "1", "strict" to "true")
         assertThat(mediaRange.qualityFactor).isCloseTo(1.0, Offset.offset(0.01))
-        assertThat(mediaRange.wildcardCount).isEqualTo(0)
     }
 
     @Test
@@ -78,7 +74,6 @@ internal class MediaRangeTest {
         assertThat(mediaRange.extensions).isEmpty()
         assertThat(mediaRange.parameters).containsExactly("level" to "1", "strict" to "true")
         assertThat(mediaRange.qualityFactor).isCloseTo(0.45, Offset.offset(0.01))
-        assertThat(mediaRange.wildcardCount).isEqualTo(0)
     }
 
     @Test
@@ -91,7 +86,6 @@ internal class MediaRangeTest {
         assertThat(mediaRange.extensions).containsExactly("ext1" to "79", "ext2" to "blerp")
         assertThat(mediaRange.parameters).containsExactly("level" to "1", "strict" to "true")
         assertThat(mediaRange.qualityFactor).isCloseTo(0.45, Offset.offset(0.01))
-        assertThat(mediaRange.wildcardCount).isEqualTo(0)
     }
 
     @Test
@@ -211,5 +205,21 @@ internal class MediaRangeTest {
 
         assertThat(matcher).isNotNull()
         assertThat(matcher!!.matchesCharset).isTrue()
+    }
+
+    @Test
+    fun compareTo() {
+        val r1 = MediaRange.parse("*/*")
+        val r2 = MediaRange.parse("text/*")
+        val r3 = MediaRange.parse("text/html")
+        val r4 = MediaRange.parse("text/html;charset=utf-8;level=1")
+        val r5 = MediaRange.parse("text/html;charset=utf-8;level=1;q=0.5;ext1=one")
+        val r6 = MediaRange.parse("text/html;charset=utf-8;level=1;f=zed")
+
+        val unsorted = mutableListOf(r1, r2, r3, r4, r5, r6)
+        shuffle(unsorted)
+
+        val sorted = unsorted.sorted()
+        assertThat(sorted).containsExactly(r6, r5, r4, r3, r2, r1)
     }
 }


### PR DESCRIPTION
Choose the action with the most specific path and content-types to
handle a request, regrdless of the order in which the actions were
installed