### PR TITLE
Upgrade to Gradle 4.5 to support Java 9; add Java 9 to test matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: java
 
 jdk:
   - oraclejdk8
+  - oraclejdk9
 
 script:
   - ./gradlew test

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.5-rc-2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.5-bin.zip

--- a/misk/src/main/kotlin/misk/scope/ActionScope.kt
+++ b/misk/src/main/kotlin/misk/scope/ActionScope.kt
@@ -3,6 +3,9 @@ package misk.scope
 import com.google.inject.Key
 import com.google.inject.Provider
 import java.util.concurrent.Callable
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.ConcurrentMap
+import java.util.concurrent.ConcurrentSkipListMap
 import javax.inject.Inject
 import javax.inject.Singleton
 import kotlin.reflect.KFunction


### PR DESCRIPTION
Something changed in Java 9 that had the `LinkedHashMap` in `ActionScope` throwing `ConcurrentModificationException`s. @mmihic was there a specific reason you used a `LinkedHashMap`, did you need ordering guarantees?