### PR TITLE
Extends misk testing framework

### DIFF
--- a/exemplar/src/test/kotlin/com/squareup/exemplar/HelloWebActionTest.kt
+++ b/exemplar/src/test/kotlin/com/squareup/exemplar/HelloWebActionTest.kt
@@ -1,12 +1,12 @@
 package com.squareup.exemplar
 
 import org.assertj.core.api.Assertions.assertThat
-import misk.testing.ActionTest
+import misk.testing.MiskTest
 import okhttp3.Headers
 import org.junit.jupiter.api.Test
 import javax.inject.Inject
 
-@ActionTest
+@MiskTest
 class HelloWebActionTest {
     @Inject lateinit var helloWebAction: HelloWebAction
 

--- a/misk/src/test/kotlin/misk/config/ConfigTest.kt
+++ b/misk/src/test/kotlin/misk/config/ConfigTest.kt
@@ -4,16 +4,16 @@ import org.assertj.core.api.Assertions.assertThat
 import com.google.inject.util.Modules
 import misk.environment.Environment.TESTING
 import misk.environment.EnvironmentModule
-import misk.testing.ActionTest
-import misk.testing.ActionTestModule
+import misk.testing.MiskTest
+import misk.testing.MiskTestModule
 import misk.web.WebConfig
 import org.junit.jupiter.api.Test
 import javax.inject.Inject
 import javax.inject.Named
 
-@ActionTest
+@MiskTest
 class ConfigTest {
-    @ActionTestModule
+    @MiskTestModule
     val module = Modules.combine(
             ConfigModule.create<TestConfig>("test_app"),
             EnvironmentModule(TESTING)

--- a/misk/src/test/kotlin/misk/metrics/backends/stackdriver/StackDriverReporterTest.kt
+++ b/misk/src/test/kotlin/misk/metrics/backends/stackdriver/StackDriverReporterTest.kt
@@ -10,8 +10,8 @@ import misk.config.AppName
 import misk.environment.InstanceMetadata
 import misk.metrics.Metrics
 import misk.metrics.MetricsModule
-import misk.testing.ActionTest
-import misk.testing.ActionTestModule
+import misk.testing.MiskTest
+import misk.testing.MiskTestModule
 import misk.time.FakeClock
 import misk.time.FakeClockModule
 import org.assertj.core.api.Assertions.assertThat
@@ -23,7 +23,7 @@ import java.util.concurrent.TimeUnit
 import javax.inject.Inject
 import javax.inject.Singleton
 
-@ActionTest
+@MiskTest
 internal class StackDriverReporterTest {
     companion object {
         val APP_NAME = "my_app"
@@ -58,7 +58,7 @@ internal class StackDriverReporterTest {
         }
     }
 
-    @ActionTestModule
+    @MiskTestModule
     val module = Modules.combine(
             MetricsModule(),
             FakeClockModule(),

--- a/misk/src/test/kotlin/misk/metrics/web/MetricsJsonActionTest.kt
+++ b/misk/src/test/kotlin/misk/metrics/web/MetricsJsonActionTest.kt
@@ -2,16 +2,16 @@ package misk.metrics.web
 
 import misk.metrics.Metrics
 import misk.metrics.MetricsModule
-import misk.testing.ActionTest
-import misk.testing.ActionTestModule
+import misk.testing.MiskTest
+import misk.testing.MiskTestModule
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import java.util.concurrent.TimeUnit
 import javax.inject.Inject
 
-@ActionTest
+@MiskTest
 internal class MetricsJsonActionTest {
-    @ActionTestModule
+    @MiskTestModule
     val module = MetricsModule()
 
     @Inject internal lateinit var metrics: Metrics

--- a/misk/src/test/kotlin/misk/web/ActionScopedWebDispatchTest.kt
+++ b/misk/src/test/kotlin/misk/web/ActionScopedWebDispatchTest.kt
@@ -6,8 +6,8 @@ import misk.inject.KAbstractModule
 import misk.scope.ActionScoped
 import misk.scope.ActionScopedProvider
 import misk.scope.ActionScopedProviderModule
-import misk.testing.ActionTest
-import misk.testing.ActionTestModule
+import misk.testing.MiskTest
+import misk.testing.MiskTestModule
 import misk.testing.TestWebModule
 import misk.web.actions.WebAction
 import misk.web.jetty.JettyService
@@ -19,9 +19,9 @@ import java.security.Principal
 import javax.inject.Inject
 import javax.inject.Singleton
 
-@ActionTest(startService = true)
+@MiskTest(startService = true)
 internal class ActionScopedWebDispatchTest {
-    @ActionTestModule
+    @MiskTestModule
     val module = Modules.combine(
             MiskModule(),
             WebModule(),

--- a/misk/src/test/kotlin/misk/web/ContentBasedDispatchTest.kt
+++ b/misk/src/test/kotlin/misk/web/ContentBasedDispatchTest.kt
@@ -4,8 +4,8 @@ import com.google.inject.util.Modules
 import com.squareup.moshi.Moshi
 import misk.MiskModule
 import misk.inject.KAbstractModule
-import misk.testing.ActionTest
-import misk.testing.ActionTestModule
+import misk.testing.MiskTest
+import misk.testing.MiskTestModule
 import misk.testing.TestWebModule
 import misk.web.actions.WebAction
 import misk.web.jetty.JettyService
@@ -19,9 +19,9 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import javax.inject.Inject
 
-@ActionTest(startService = true)
+@MiskTest(startService = true)
 internal class ContentBasedDispatchTest {
-    @ActionTestModule
+    @MiskTestModule
     val module = Modules.combine(
             MiskModule(),
             WebModule(),

--- a/misk/src/test/kotlin/misk/web/DeterministicRoutingTest.kt
+++ b/misk/src/test/kotlin/misk/web/DeterministicRoutingTest.kt
@@ -3,8 +3,8 @@ package misk.web
 import com.google.inject.util.Modules
 import misk.MiskModule
 import misk.inject.KAbstractModule
-import misk.testing.ActionTest
-import misk.testing.ActionTestModule
+import misk.testing.MiskTest
+import misk.testing.MiskTestModule
 import misk.testing.TestWebModule
 import misk.web.actions.WebAction
 import misk.web.jetty.JettyService
@@ -16,9 +16,9 @@ import org.junit.jupiter.api.Test
 import java.util.Collections.shuffle
 import javax.inject.Inject
 
-@ActionTest(startService = true)
+@MiskTest(startService = true)
 internal class DeterministicRoutingTest {
-    @ActionTestModule
+    @MiskTestModule
     val module = Modules.combine(
             MiskModule(),
             WebModule(),

--- a/misk/src/test/kotlin/misk/web/WebDispatchTest.kt
+++ b/misk/src/test/kotlin/misk/web/WebDispatchTest.kt
@@ -5,8 +5,8 @@ import com.google.inject.util.Modules
 import com.squareup.moshi.Moshi
 import misk.MiskModule
 import misk.inject.KAbstractModule
-import misk.testing.ActionTest
-import misk.testing.ActionTestModule
+import misk.testing.MiskTest
+import misk.testing.MiskTestModule
 import misk.testing.TestWebModule
 import misk.web.actions.WebAction
 import misk.web.jetty.JettyService
@@ -17,9 +17,9 @@ import okhttp3.Request
 import org.junit.jupiter.api.Test
 import javax.inject.Inject
 
-@ActionTest(startService = true)
+@MiskTest(startService = true)
 internal class WebDispatchTest {
-    @ActionTestModule
+    @MiskTestModule
     val module = Modules.combine(
             MiskModule(),
             WebModule(),

--- a/misk/src/test/kotlin/misk/web/actions/LivenessCheckActionTest.kt
+++ b/misk/src/test/kotlin/misk/web/actions/LivenessCheckActionTest.kt
@@ -5,14 +5,14 @@ import com.google.common.util.concurrent.ServiceManager
 import com.google.inject.util.Modules
 import misk.MiskModule
 import misk.services.FakeServiceModule
-import misk.testing.ActionTest
-import misk.testing.ActionTestModule
+import misk.testing.MiskTest
+import misk.testing.MiskTestModule
 import org.junit.jupiter.api.Test
 import javax.inject.Inject
 
-@ActionTest
+@MiskTest
 class LivenessCheckActionTest {
-    @ActionTestModule
+    @MiskTestModule
     val module = Modules.combine(
             MiskModule(),
             FakeServiceModule()

--- a/misk/src/test/kotlin/misk/web/actions/NotFoundActionTest.kt
+++ b/misk/src/test/kotlin/misk/web/actions/NotFoundActionTest.kt
@@ -1,12 +1,12 @@
 package misk.web.actions
 
 import org.assertj.core.api.Assertions.assertThat
-import misk.testing.ActionTest
+import misk.testing.MiskTest
 import misk.web.Response
 import org.junit.jupiter.api.Test
 import javax.inject.Inject
 
-@ActionTest
+@MiskTest
 class NotFoundActionTest {
     @Inject lateinit var notFoundAction: NotFoundAction
 

--- a/misk/src/test/kotlin/misk/web/actions/ReadinessCheckActionTest.kt
+++ b/misk/src/test/kotlin/misk/web/actions/ReadinessCheckActionTest.kt
@@ -7,14 +7,14 @@ import misk.MiskModule
 import misk.healthchecks.FakeHealthCheck
 import misk.healthchecks.FakeHealthCheckModule
 import misk.services.FakeServiceModule
-import misk.testing.ActionTest
-import misk.testing.ActionTestModule
+import misk.testing.MiskTest
+import misk.testing.MiskTestModule
 import org.junit.jupiter.api.Test
 import javax.inject.Inject
 
-@ActionTest
+@MiskTest
 class ReadinessCheckActionTest {
-    @ActionTestModule
+    @MiskTestModule
     val module = Modules.combine(
             MiskModule(),
             FakeServiceModule(),

--- a/misk/src/test/kotlin/misk/web/interceptors/MetricsInterceptorTest.kt
+++ b/misk/src/test/kotlin/misk/web/interceptors/MetricsInterceptorTest.kt
@@ -4,8 +4,8 @@ import org.assertj.core.api.Assertions.assertThat
 import misk.asAction
 import misk.metrics.Metrics
 import misk.metrics.MetricsModule
-import misk.testing.ActionTest
-import misk.testing.ActionTestModule
+import misk.testing.MiskTest
+import misk.testing.MiskTestModule
 import misk.web.Get
 import misk.web.Response
 import misk.web.actions.WebAction
@@ -14,9 +14,9 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import javax.inject.Inject
 
-@ActionTest
+@MiskTest
 class MetricsInterceptorTest {
-    @ActionTestModule
+    @MiskTestModule
     val module = MetricsModule()
 
     @Inject internal lateinit var metricsInterceptorFactory: MetricsInterceptor.Factory

--- a/misk/src/test/kotlin/misk/web/marshal/JsonRequestTest.kt
+++ b/misk/src/test/kotlin/misk/web/marshal/JsonRequestTest.kt
@@ -4,8 +4,8 @@ import com.google.inject.util.Modules
 import com.squareup.moshi.Moshi
 import misk.MiskModule
 import misk.inject.KAbstractModule
-import misk.testing.ActionTest
-import misk.testing.ActionTestModule
+import misk.testing.MiskTest
+import misk.testing.MiskTestModule
 import misk.testing.TestWebModule
 import misk.web.Post
 import misk.web.RequestBody
@@ -25,11 +25,11 @@ import org.junit.jupiter.api.Test
 import java.io.ByteArrayInputStream
 import javax.inject.Inject
 
-@ActionTest(startService = true)
+@MiskTest(startService = true)
 internal class JsonRequestTest {
     data class Packet(val message: String)
 
-    @ActionTestModule
+    @MiskTestModule
     val module = Modules.combine(
             MiskModule(),
             WebModule(),

--- a/misk/src/test/kotlin/misk/web/marshal/JsonResponseTest.kt
+++ b/misk/src/test/kotlin/misk/web/marshal/JsonResponseTest.kt
@@ -4,8 +4,8 @@ import com.google.inject.util.Modules
 import com.squareup.moshi.Moshi
 import misk.MiskModule
 import misk.inject.KAbstractModule
-import misk.testing.ActionTest
-import misk.testing.ActionTestModule
+import misk.testing.MiskTest
+import misk.testing.MiskTestModule
 import misk.testing.TestWebModule
 import misk.web.Get
 import misk.web.Response
@@ -24,11 +24,11 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import javax.inject.Inject
 
-@ActionTest(startService = true)
+@MiskTest(startService = true)
 internal class JsonResponseTest {
     data class Packet(val message: String)
 
-    @ActionTestModule
+    @MiskTestModule
     val module = Modules.combine(
             MiskModule(),
             WebModule(),

--- a/misk/src/test/kotlin/misk/web/marshal/PlainTextRequestTest.kt
+++ b/misk/src/test/kotlin/misk/web/marshal/PlainTextRequestTest.kt
@@ -3,8 +3,8 @@ package misk.web.marshal
 import com.google.inject.util.Modules
 import misk.MiskModule
 import misk.inject.KAbstractModule
-import misk.testing.ActionTest
-import misk.testing.ActionTestModule
+import misk.testing.MiskTest
+import misk.testing.MiskTestModule
 import misk.testing.TestWebModule
 import misk.web.Post
 import misk.web.RequestBody
@@ -22,9 +22,9 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import javax.inject.Inject
 
-@ActionTest(startService = true)
+@MiskTest(startService = true)
 internal class PlainTextRequestTest {
-    @ActionTestModule
+    @MiskTestModule
     val module = Modules.combine(
             MiskModule(),
             WebModule(),

--- a/misk/src/test/kotlin/misk/web/marshal/PlainTextResponseTest.kt
+++ b/misk/src/test/kotlin/misk/web/marshal/PlainTextResponseTest.kt
@@ -3,8 +3,8 @@ package misk.web.marshal
 import com.google.inject.util.Modules
 import misk.MiskModule
 import misk.inject.KAbstractModule
-import misk.testing.ActionTest
-import misk.testing.ActionTestModule
+import misk.testing.MiskTest
+import misk.testing.MiskTestModule
 import misk.testing.TestWebModule
 import misk.web.Get
 import misk.web.Response
@@ -23,9 +23,9 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import javax.inject.Inject
 
-@ActionTest(startService = true)
+@MiskTest(startService = true)
 internal class PlainTextResponseTest {
-    @ActionTestModule
+    @MiskTestModule
     val module = Modules.combine(
             MiskModule(),
             WebModule(),

--- a/misk/testing/src/main/kotlin/misk/testing/AfterEachExtensionModule.kt
+++ b/misk/testing/src/main/kotlin/misk/testing/AfterEachExtensionModule.kt
@@ -7,7 +7,7 @@ import org.junit.jupiter.api.extension.AfterEachCallback
 import org.junit.jupiter.api.extension.BeforeEachCallback
 import kotlin.reflect.KClass
 
-/** Module registering a callback that fires before each test */
+/** Module registering a callback that fires after each test */
 class AfterEachExtensionModule<T : AfterEachCallback> constructor(
         private val kclass: KClass<T>
 ) : KAbstractModule() {

--- a/misk/testing/src/main/kotlin/misk/testing/AfterEachExtensionModule.kt
+++ b/misk/testing/src/main/kotlin/misk/testing/AfterEachExtensionModule.kt
@@ -1,0 +1,23 @@
+package misk.testing
+
+import com.google.inject.Module
+import misk.inject.KAbstractModule
+import misk.inject.addMultibinderBinding
+import org.junit.jupiter.api.extension.AfterEachCallback
+import org.junit.jupiter.api.extension.BeforeEachCallback
+import kotlin.reflect.KClass
+
+/** Module registering a callback that fires before each test */
+class AfterEachExtensionModule<T : AfterEachCallback> constructor(
+        private val kclass: KClass<T>
+) : KAbstractModule() {
+
+    override fun configure() {
+        binder().addMultibinderBinding<AfterEachCallback>().to(kclass.java)
+    }
+
+    companion object{
+        inline fun <reified T: AfterEachCallback> create() : Module =
+                AfterEachExtensionModule(T::class)
+    }
+}

--- a/misk/testing/src/main/kotlin/misk/testing/BeforeEachExtensionModule.kt
+++ b/misk/testing/src/main/kotlin/misk/testing/BeforeEachExtensionModule.kt
@@ -1,0 +1,22 @@
+package misk.testing
+
+import com.google.inject.Module
+import misk.inject.KAbstractModule
+import misk.inject.addMultibinderBinding
+import org.junit.jupiter.api.extension.BeforeEachCallback
+import kotlin.reflect.KClass
+
+/** Module registering a callback that fires before each test */
+class BeforeEachExtensionModule<T : BeforeEachCallback> constructor(
+        private val kclass: KClass<T>
+) : KAbstractModule() {
+
+    override fun configure() {
+        binder().addMultibinderBinding<BeforeEachCallback>().to(kclass.java)
+    }
+
+    companion object{
+        inline fun <reified T: BeforeEachCallback> create() : Module =
+                BeforeEachExtensionModule(T::class)
+    }
+}

--- a/misk/testing/src/main/kotlin/misk/testing/ExtensionContextExtensions.kt
+++ b/misk/testing/src/main/kotlin/misk/testing/ExtensionContextExtensions.kt
@@ -1,0 +1,16 @@
+package misk.testing
+
+import org.junit.jupiter.api.extension.ExtensionContext
+
+/** Stores an object scoped to the test class on the context */
+fun <T> ExtensionContext.store(name: String, value: T) {
+    val namespace = ExtensionContext.Namespace.create(requiredTestClass)
+    getStore(namespace).put(name, value)
+}
+
+/** @return A previously stored object scoped to the test class */
+inline fun <reified T> ExtensionContext.retrieve(name: String): T {
+    val namespace = ExtensionContext.Namespace.create(requiredTestClass)
+    return getStore(namespace)[name, T::class.java]
+}
+

--- a/misk/testing/src/main/kotlin/misk/testing/MiskTest.kt
+++ b/misk/testing/src/main/kotlin/misk/testing/MiskTest.kt
@@ -6,12 +6,13 @@ import org.junit.jupiter.api.extension.ExtendWith
 
 @Target(AnnotationTarget.CLASS)
 @ExtendWith(MiskTestExtension::class)
+
 /**
- * Annotate your test classes with `@ActionTest` to have fields annotated with `@Inject` initialized.
+ * Annotate your test classes with `@MiskTest` to have fields annotated with `@Inject` initialized.
  * Provide modules to be installed by annotating a [Module] field in your test class with
- * [ActionTestModule]. This can be a compound module, composed using [Modules.combine].
+ * [MiskTestModule]. This can be a compound module, composed using [Modules.combine].
  */
-annotation class ActionTest(val startService: Boolean = false)
+annotation class MiskTest(val startService: Boolean = false)
 
 @Target(AnnotationTarget.FIELD)
-annotation class ActionTestModule
+annotation class MiskTestModule

--- a/misk/testing/src/main/kotlin/misk/testing/MiskTestExtension.kt
+++ b/misk/testing/src/main/kotlin/misk/testing/MiskTestExtension.kt
@@ -4,38 +4,81 @@ import com.google.common.util.concurrent.ServiceManager
 import com.google.inject.Guice
 import com.google.inject.Injector
 import com.google.inject.Module
+import com.google.inject.util.Modules
+import misk.inject.getInstance
 import misk.inject.uninject
+import misk.testing.store
+import misk.testing.retrieve
 import org.junit.jupiter.api.extension.AfterEachCallback
 import org.junit.jupiter.api.extension.BeforeEachCallback
 import org.junit.jupiter.api.extension.ExtensionContext
 import java.util.concurrent.TimeUnit
+import javax.inject.Inject
 
-internal class MiskTestExtension: BeforeEachCallback, AfterEachCallback {
+internal class MiskTestExtension : BeforeEachCallback, AfterEachCallback {
     override fun beforeEach(context: ExtensionContext) {
-        val modules = context.getActionTestModules()
+        val testModules = context.getActionTestModules().asSequence().toList().toTypedArray()
+        val callbackModules = if (context.startService()) serviceManagementModules else arrayOf()
+        val modules = Modules.combine(MiskTestingModule(), *callbackModules, *testModules)
 
         val injector = Guice.createInjector(modules)
         injector.injectMembers(context.requiredTestInstance)
         context.store("injector", injector)
 
-        if (context.startService()) {
-            // Start service
-            val serviceManager = injector.getInstance(ServiceManager::class.java)
-            serviceManager.startAsync()
-            serviceManager.awaitHealthy(5, TimeUnit.SECONDS)
-        }
+        injector.getInstance<Callbacks>().beforeEach(context)
     }
 
     override fun afterEach(context: ExtensionContext) {
-        if (context.startService()) {
-            // Stop service
-            val injector = context.retrieve<Injector>("injector")
-            val serviceManager = injector.getInstance(ServiceManager::class.java)
-            serviceManager.stopAsync()
-            serviceManager.awaitStopped(5, TimeUnit.SECONDS)
+        val injector = context.retrieve<Injector>("injector")
+
+        injector.getInstance<Callbacks>().afterEach(context)
+        uninject(context.requiredTestInstance)
+    }
+
+    class StartServicesBeforeEach : BeforeEachCallback {
+        @Inject
+        lateinit var serviceManager: ServiceManager
+
+        override fun beforeEach(context: ExtensionContext) {
+            if (context.startService()) {
+                serviceManager.startAsync()
+                serviceManager.awaitHealthy(5, TimeUnit.SECONDS)
+            }
+        }
+    }
+
+    class StopServicesAfterEach : AfterEachCallback {
+        @Inject
+        lateinit var serviceManager: ServiceManager
+
+        override fun afterEach(context: ExtensionContext) {
+            if (context.startService()) {
+                serviceManager.stopAsync()
+            }
+        }
+    }
+
+    private val serviceManagementModules = arrayOf(
+            BeforeEachExtensionModule.create<StartServicesBeforeEach>(),
+            AfterEachExtensionModule.create<StopServicesAfterEach>()
+    )
+
+    class Callbacks : BeforeEachCallback, AfterEachCallback {
+        @Inject
+        @JvmSuppressWildcards
+        lateinit var beforeEachCallbacks: Set<BeforeEachCallback>
+
+        @Inject
+        @JvmSuppressWildcards
+        lateinit var afterEachCallbacks : Set<AfterEachCallback>
+
+        override fun afterEach(context: ExtensionContext) {
+            afterEachCallbacks.forEach { it.afterEach(context) }
         }
 
-        uninject(context.requiredTestInstance)
+        override fun beforeEach(context: ExtensionContext) {
+            beforeEachCallbacks.forEach { it.beforeEach(context) }
+        }
     }
 }
 
@@ -45,16 +88,6 @@ private fun ExtensionContext.startService(): Boolean {
     return getStore(namespace).getOrComputeIfAbsent("startService",
             { requiredTestClass.getAnnotationsByType(ActionTest::class.java)[0].startService },
             Boolean::class.java)
-}
-
-private fun <T> ExtensionContext.store(name: String, value: T) {
-    val namespace = ExtensionContext.Namespace.create(requiredTestClass)
-    getStore(namespace).put(name, value)
-}
-
-private inline fun <reified T> ExtensionContext.retrieve(name: String): T {
-    val namespace = ExtensionContext.Namespace.create(requiredTestClass)
-    return getStore(namespace)[name, T::class.java]
 }
 
 private fun ExtensionContext.getActionTestModules(): Iterable<Module> {

--- a/misk/testing/src/main/kotlin/misk/testing/MiskTestExtension.kt
+++ b/misk/testing/src/main/kotlin/misk/testing/MiskTestExtension.kt
@@ -86,7 +86,7 @@ private fun ExtensionContext.startService(): Boolean {
     val namespace = ExtensionContext.Namespace.create(requiredTestClass)
     // First check the context cache
     return getStore(namespace).getOrComputeIfAbsent("startService",
-            { requiredTestClass.getAnnotationsByType(ActionTest::class.java)[0].startService },
+            { requiredTestClass.getAnnotationsByType(MiskTest::class.java)[0].startService },
             Boolean::class.java)
 }
 
@@ -100,7 +100,7 @@ private fun ExtensionContext.getActionTestModules(): Iterable<Module> {
 
 private fun ExtensionContext.modulesViaReflection(): Iterable<Module> {
     return requiredTestClass.declaredFields
-            .filter { it.isAnnotationPresent(ActionTestModule::class.java) }
+            .filter { it.isAnnotationPresent(MiskTestModule::class.java) }
             .map {
                 it.isAccessible = true
                 it.get(requiredTestInstance) as Module

--- a/misk/testing/src/main/kotlin/misk/testing/MiskTestingModule.kt
+++ b/misk/testing/src/main/kotlin/misk/testing/MiskTestingModule.kt
@@ -1,0 +1,14 @@
+package misk.testing
+
+import misk.inject.KAbstractModule
+import misk.inject.newMultibinder
+import org.junit.jupiter.api.extension.AfterEachCallback
+import org.junit.jupiter.api.extension.BeforeEachCallback
+
+/** Ensures there is always a binding for extension callbacks, even if none are registered */
+internal class MiskTestingModule : KAbstractModule() {
+    override fun configure() {
+        binder().newMultibinder<BeforeEachCallback>()
+        binder().newMultibinder<AfterEachCallback>()
+    }
+}


### PR DESCRIPTION
- Renames ``ActionTest`` to ``MiskTest`` - most of the time this annotation is used for testing things other than actions

- Allows registering ``BeforeEachCallback`` and ``AfterEachCallback`` extensions which get initialized via the Misk test injector, to support extensions that interact with objects in the Misk binding context (e.g. that perform seed data initialization before tests, or register background services, or setup preconditions in internal Misk services)