### PR TITLE
Fix Dockerfile to run the correct file name

### DIFF
--- a/exemplar/Dockerfile
+++ b/exemplar/Dockerfile
@@ -1,4 +1,4 @@
 FROM gcr.io/google-appengine/openjdk
 COPY ./build/libs /usr/local/exemplar
 WORKDIR /usr/local/exemplar
-CMD ["java", "-jar", "/usr/local/exemplar/exemplar.jar"]
+CMD ["java", "-jar", "/usr/local/exemplar/exemplar-0.1.1-SNAPSHOT.jar"]


### PR DESCRIPTION
I assume we want the Dockerfile to work without modification? If so, then it has to be in sync with the `gradle.properties` file. 

Maybe there's a better way to do this to avoid having to manage both?