### PR TITLE
Misk config usability changes

### DIFF
--- a/exemplar/src/main/kotlin/com/squareup/exemplar/ExemplarConfig.kt
+++ b/exemplar/src/main/kotlin/com/squareup/exemplar/ExemplarConfig.kt
@@ -3,4 +3,4 @@ package com.squareup.exemplar
 import misk.config.Config
 import misk.web.WebConfig
 
-data class ExemplarConfig(val web_config: WebConfig) : Config
+data class ExemplarConfig(val web: WebConfig) : Config

--- a/exemplar/src/main/resources/exemplar-common.yaml
+++ b/exemplar/src/main/resources/exemplar-common.yaml
@@ -1,3 +1,3 @@
-web_config:
+web:
   port: 8080
   idle_timeout: 30000

--- a/misk/src/main/kotlin/misk/config/ConfigModule.kt
+++ b/misk/src/main/kotlin/misk/config/ConfigModule.kt
@@ -1,5 +1,7 @@
 package misk.config
 
+import com.google.common.base.CaseFormat.LOWER_UNDERSCORE
+import com.google.common.base.CaseFormat.UPPER_CAMEL
 import com.google.inject.TypeLiteral
 import com.google.inject.name.Names
 import misk.inject.KAbstractModule
@@ -36,8 +38,10 @@ class ConfigModule(
             val subConfigTypeLiteral = TypeLiteral.get(
                     property.returnType.javaType) as TypeLiteral<Any?>
 
-            val subConfigTypeName = subConfigTypeLiteral.rawType.simpleName.toLowerCase()
-            if (property.name == subConfigTypeName.substringBefore("config")) {
+            val subConfigTypeName = subConfigTypeLiteral.rawType.simpleName
+            val defaultSubConfigFieldName = UPPER_CAMEL.to(LOWER_UNDERSCORE, subConfigTypeName)
+
+            if (property.name == defaultSubConfigFieldName.substringBefore("_config")) {
                 // The property is the name of the config type, without the unnecessary Config suffix.
                 // This is the default binding for the config type, so bind it without requiring
                 // a name annotation

--- a/misk/src/main/kotlin/misk/config/ConfigModule.kt
+++ b/misk/src/main/kotlin/misk/config/ConfigModule.kt
@@ -13,8 +13,8 @@ import kotlin.reflect.full.isSubtypeOf
 import kotlin.reflect.jvm.javaType
 
 class ConfigModule(
-    private val configClass: Class<out Config>,
-    private val appName: String
+        private val configClass: Class<out Config>,
+        private val appName: String
 ) : KAbstractModule() {
     @Suppress("UNCHECKED_CAST")
     override fun configure() {
@@ -29,21 +29,31 @@ class ConfigModule(
             if (!property.returnType.isSubtypeOf(Config::class.createType())) {
                 continue
             }
-            bindConfigClassRecursively(property.returnType.typeLiteral().rawType as Class<out Config>)
-            val subConfigProvider = SubConfigProvider(getProvider(configClass), property as KProperty1<Config, Any?>)
-            val subConfigTypeLiteral = TypeLiteral.get(property.returnType.javaType) as TypeLiteral<Any?>
+            bindConfigClassRecursively(
+                    property.returnType.typeLiteral().rawType as Class<out Config>)
+            val subConfigProvider = SubConfigProvider(getProvider(configClass),
+                    property as KProperty1<Config, Any?>)
+            val subConfigTypeLiteral = TypeLiteral.get(
+                    property.returnType.javaType) as TypeLiteral<Any?>
 
-            if (subConfigTypeLiteral.rawType.simpleName.toLowerCase() == property.name.replace("_", "").toLowerCase()) {
+            val subConfigTypeName = subConfigTypeLiteral.rawType.simpleName.toLowerCase()
+            if (property.name == subConfigTypeName.substringBefore("config")) {
+                // The property is the name of the config type, without the unnecessary Config suffix.
+                // This is the default binding for the config type, so bind it without requiring
+                // a name annotation
                 bind(subConfigTypeLiteral).toProvider(subConfigProvider).asSingleton()
             } else {
-                bind(subConfigTypeLiteral).annotatedWith(Names.named(property.name)).toProvider(subConfigProvider).asSingleton()
+                // The property differs from the name of the config type, so it is being explicitly
+                // qualified.
+                bind(subConfigTypeLiteral).annotatedWith(Names.named(property.name))
+                        .toProvider(subConfigProvider).asSingleton()
             }
         }
     }
 
     internal class SubConfigProvider(
-        private val configProvider: Provider<out Config>,
-        private val subconfigGetter: KProperty1<Config, Any?>
+            private val configProvider: Provider<out Config>,
+            private val subconfigGetter: KProperty1<Config, Any?>
     ) : Provider<Any?> {
         override fun get(): Any? {
             return subconfigGetter.get(configProvider.get())
@@ -52,6 +62,6 @@ class ConfigModule(
 
     companion object {
         inline fun <reified T : Config> create(appName: String) =
-            ConfigModule(T::class.java, appName)
+                ConfigModule(T::class.java, appName)
     }
 }

--- a/misk/src/test/kotlin/misk/config/ConfigTest.kt
+++ b/misk/src/test/kotlin/misk/config/ConfigTest.kt
@@ -26,21 +26,30 @@ class ConfigTest {
     @Inject
     private lateinit var testConfig: TestConfig
 
+
     @field:[Inject Named("consumer_a")]
     lateinit var consumerA: ConsumerConfig
 
     @field:[Inject Named("consumer_b")]
     lateinit var consumerB: ConsumerConfig
 
+    @field:[Inject]
+    lateinit var webConfig: WebConfig
+
     @Test
-    fun testConfigIsProperlyParsed() {
+    fun configIsProperlyParsed() {
         assertThat(testConfig.web).isEqualTo(WebConfig(5678, 30_000))
         assertThat(testConfig.consumer_a).isEqualTo(ConsumerConfig(0, 1))
         assertThat(testConfig.consumer_b).isEqualTo(ConsumerConfig(1, 2))
     }
 
     @Test
-    fun subConfigsAreNamedProperly() {
+    fun subConfigsWithDefaultNamesAreBoundUnqualified() {
+        assertThat(webConfig).isEqualTo(WebConfig(5678, 30_000))
+    }
+
+    @Test
+    fun subConfigsWithCustomNamesAreBoundWithNamedQualifiers() {
         assertThat(consumerA).isEqualTo(ConsumerConfig(0, 1))
         assertThat(consumerB).isEqualTo(ConsumerConfig(1, 2))
     }

--- a/misk/src/test/kotlin/misk/config/ConfigTest.kt
+++ b/misk/src/test/kotlin/misk/config/ConfigTest.kt
@@ -19,32 +19,33 @@ class ConfigTest {
             EnvironmentModule(TESTING)
     )
 
-    @Inject lateinit var test_config: TestConfig
+    @Inject
+    private lateinit var testConfig: TestConfig
 
-    @field:[Inject Named("consumer_a")] lateinit var consumer_a_config: ConsumerConfig
+    @field:[Inject Named("consumer_a")] lateinit var consumerA: ConsumerConfig
 
-    @field:[Inject Named("consumer_b")] lateinit var consumer_b_config: ConsumerConfig
+    @field:[Inject Named("consumer_b")] lateinit var consumerB: ConsumerConfig
 
     @Test
     fun testConfigIsProperlyParsed() {
-        assertThat(test_config.web_config).isEqualTo(WebConfig(5678, 30_000))
-        assertThat(test_config.consumer_a).isEqualTo(ConsumerConfig(0, 1))
-        assertThat(test_config.consumer_b).isEqualTo(ConsumerConfig(1, 2))
+        assertThat(testConfig.web).isEqualTo(WebConfig(5678, 30_000))
+        assertThat(testConfig.consumer_a).isEqualTo(ConsumerConfig(0, 1))
+        assertThat(testConfig.consumer_b).isEqualTo(ConsumerConfig(1, 2))
     }
 
     @Test
     fun subConfigsAreNamedProperly() {
-        assertThat(consumer_a_config).isEqualTo(ConsumerConfig(0, 1))
-        assertThat(consumer_b_config).isEqualTo(ConsumerConfig(1, 2))
+        assertThat(consumerA).isEqualTo(ConsumerConfig(0, 1))
+        assertThat(consumerB).isEqualTo(ConsumerConfig(1, 2))
     }
 
     @Test
     fun environmentConfigOverridesCommon() {
-        assertThat(test_config.web_config.port).isEqualTo(5678)
+        assertThat(testConfig.web.port).isEqualTo(5678)
     }
 
     @Test
     fun defaultValuesAreUsed() {
-        assertThat(test_config.consumer_a.min_items).isEqualTo(0)
+        assertThat(testConfig.consumer_a.min_items).isEqualTo(0)
     }
 }

--- a/misk/src/test/kotlin/misk/config/TestConfig.kt
+++ b/misk/src/test/kotlin/misk/config/TestConfig.kt
@@ -3,7 +3,7 @@ package misk.config
 import misk.web.WebConfig
 
 data class TestConfig(
-    val web_config: WebConfig,
+    val web: WebConfig,
     val consumer_a: ConsumerConfig,
     val consumer_b: ConsumerConfig
 ) : Config

--- a/misk/src/test/resources/partial_test_app-common.yaml
+++ b/misk/src/test/resources/partial_test_app-common.yaml
@@ -1,0 +1,4 @@
+web:
+  port: 1234
+  idle_timeout: 30000
+

--- a/misk/src/test/resources/test_app-common.yaml
+++ b/misk/src/test/resources/test_app-common.yaml
@@ -1,4 +1,4 @@
-web_config:
+web:
   port: 1234
   idle_timeout: 30000
 

--- a/misk/src/test/resources/test_app-testing.yaml
+++ b/misk/src/test/resources/test_app-testing.yaml
@@ -1,2 +1,2 @@
-web_config:
+web:
   port: 5678

--- a/misk/src/test/resources/unparsable-common.yaml
+++ b/misk/src/test/resources/unparsable-common.yaml
@@ -1,0 +1,10 @@
+w eb:
+  port: 1234
+  idle_timeout: 30000
+
+consu mer_a: {
+  max_ items: 1
+
+consumer_b:
+  min_items: 1
+  max_items: 2


### PR DESCRIPTION
Based on annoyances while trying to write a service with non-trivial configuration:

- Provide friendlier error messages when configuration files are missing, unparsable, or fail to map all required configuration properties

- Don't require redundant `_config` suffixes on all top-level configuration properties

- Use proper snake-case conversion for configuration property names, vs simply lower-casing the Java camel cased names
