### PR TITLE
Allow customized exception mappings

### DIFF
--- a/misk/src/main/kotlin/misk/exceptions/Exceptions.kt
+++ b/misk/src/main/kotlin/misk/exceptions/Exceptions.kt
@@ -1,0 +1,46 @@
+package misk.exceptions
+
+/** Common status codes for actions */
+enum class StatusCode(val code: Int) {
+    BAD_REQUEST(400),
+    NOT_FOUND(404),
+    UNAUTHENTICATED(401),
+    FORBIDDEN(403),
+    NOT_ACCEPTABLE(406),
+    ENHANCE_YOUR_CALM(420),
+    UNPROCESSABLE_ENTITY(429),
+    INTERNAL_SERVER_ERROR(500),
+    SERVICE_UNAVAILABLE(503);
+
+    val isClientError = code in (400..499)
+    val isServerError = code in (500..599)
+}
+
+/** Base class for exceptions thrown by actions, translated into responses */
+open class ActionException(
+        val statusCode: StatusCode,
+        message: String = statusCode.name,
+        cause: Throwable? = null
+) : Exception(message, cause)
+
+/** Base exception for when resources are not found */
+open class NotFoundException(message: String = "", cause: Throwable? = null) :
+        ActionException(StatusCode.NOT_FOUND, message, cause)
+
+/** Base exception for when authentication fails */
+open class UnauthenticatedException(message: String = "", cause: Throwable? = null) :
+        ActionException(StatusCode.UNAUTHENTICATED, message, cause)
+
+/** Base exception for when authenticated credentials lack access to a resource */
+open class UnauthorizedException(message: String = "", cause: Throwable? = null) :
+        ActionException(StatusCode.FORBIDDEN, message, cause)
+
+/** Base exception for when a resource is unavailable */
+open class ResourceUnavailableException(message: String = "", cause: Throwable? = null) :
+        ActionException(StatusCode.SERVICE_UNAVAILABLE, message, cause)
+
+/** Base exception for bad client requests */
+open class BadRequestException(message: String = "", cause: Throwable? = null) :
+        ActionException(StatusCode.BAD_REQUEST, message, cause)
+
+

--- a/misk/src/main/kotlin/misk/logging/Logging.kt
+++ b/misk/src/main/kotlin/misk/logging/Logging.kt
@@ -2,7 +2,28 @@ package misk.logging
 
 import mu.KLogger
 import mu.KotlinLogging
+import org.slf4j.event.Level
 
-inline fun <reified T> getLogger() : KLogger {
+inline fun <reified T> getLogger(): KLogger {
     return KotlinLogging.logger(T::class.qualifiedName!!)
+}
+
+fun KLogger.log(level: Level, message: String) {
+    when (level) {
+        Level.ERROR -> error(message)
+        Level.WARN -> warn(message)
+        Level.INFO -> info(message)
+        Level.DEBUG -> debug(message)
+        Level.TRACE -> trace(message)
+    }
+}
+
+fun KLogger.log(level: Level, th: Throwable, message: () -> Any?) {
+    when (level) {
+        Level.ERROR -> error(th, message)
+        Level.INFO -> info(th, message)
+        Level.WARN -> warn(th, message)
+        Level.DEBUG -> debug(th, message)
+        Level.TRACE -> trace(th, message)
+    }
 }

--- a/misk/src/main/kotlin/misk/web/WebModule.kt
+++ b/misk/src/main/kotlin/misk/web/WebModule.kt
@@ -7,6 +7,9 @@ import misk.inject.addMultibinderBinding
 import misk.inject.addMultibinderBindingWithAnnotation
 import misk.inject.to
 import misk.scope.ActionScopedProviderModule
+import misk.web.exceptions.ActionExceptionMapper
+import misk.web.exceptions.ExceptionHandlingInterceptor
+import misk.web.exceptions.ExceptionMapperModule
 import misk.web.extractors.HeadersParameterExtractorFactory
 import misk.web.extractors.ParameterExtractor
 import misk.web.extractors.PathPatternParameterExtractorFactory
@@ -17,12 +20,12 @@ import misk.web.interceptors.MarshallerInterceptor
 import misk.web.interceptors.MetricsInterceptor
 import misk.web.interceptors.RequestLoggingInterceptor
 import misk.web.jetty.JettyModule
-import javax.servlet.http.HttpServletRequest
 import misk.web.marshal.JsonMarshaller
 import misk.web.marshal.JsonUnmarshaller
 import misk.web.marshal.MarshallerModule
 import misk.web.marshal.PlainTextMarshaller
 import misk.web.marshal.UnmarshallerModule
+import javax.servlet.http.HttpServletRequest
 
 class WebModule : KAbstractModule() {
     override fun configure() {
@@ -42,12 +45,30 @@ class WebModule : KAbstractModule() {
         // Create an empty set binder of interceptor factories that can be added to by users.
         newSetBinder<Interceptor.Factory>()
 
-        // Register built-in interceptors
+        // Register built-in interceptors. Interceptors run in the order in which they are
+        // installed, and the order of these interceptors is critical.
+
+        // Handle all unexpected errors that occur during dispatch
         binder().addMultibinderBindingWithAnnotation<Interceptor.Factory, MiskDefault>().to<InternalErrorInterceptorFactory>()
+
+        // Optionally log request and response details
         binder().addMultibinderBindingWithAnnotation<Interceptor.Factory, MiskDefault>().to<RequestLoggingInterceptor.Factory>()
+
+        // Collect metrics on the status of results and response times of requests
         binder().addMultibinderBindingWithAnnotation<Interceptor.Factory, MiskDefault>().to<MetricsInterceptor.Factory>()
+
+        // Convert and log application level exceptions into their appropriate response format
+        binder().addMultibinderBindingWithAnnotation<Interceptor.Factory, MiskDefault>().to<ExceptionHandlingInterceptor.Factory>()
+
+        // Convert typed responses into a ResponseBody that can marshal the response according to
+        // the client's requested content-typ
         binder().addMultibinderBindingWithAnnotation<Interceptor.Factory, MiskDefault>().to<MarshallerInterceptor.Factory>()
+
+        // Wrap "raw" responses with a Response object
         binder().addMultibinderBindingWithAnnotation<Interceptor.Factory, MiskDefault>().to<BoxResponseInterceptorFactory>()
+
+        // Register build-in exception mappers
+        install(ExceptionMapperModule.create<ActionExceptionMapper>())
 
         // Register built-in parameter extractors
         binder().addMultibinderBinding<ParameterExtractor.Factory>()

--- a/misk/src/main/kotlin/misk/web/exceptions/ActionExceptionMapper.kt
+++ b/misk/src/main/kotlin/misk/web/exceptions/ActionExceptionMapper.kt
@@ -1,0 +1,36 @@
+package misk.web.exceptions
+
+import misk.exceptions.ActionException
+import misk.web.Response
+import misk.web.ResponseBody
+import misk.web.marshal.StringResponseBody
+import misk.web.mediatype.MediaTypes
+import okhttp3.Headers
+import org.slf4j.event.Level
+
+/**
+ * Maps [ActionException]s into the appropriate status code. [ActionException]s corresponding
+ * to client-errors (bad requests, resource not found, etc) are returned with full messages
+ * allowing the client to deterine what went wrong; exceptions representing server errors
+ * are returned with just a status code and minimal messaging, to avoid leaking internal
+ * implementation details and possible vulnerabilities
+ */
+internal class ActionExceptionMapper : ExceptionMapper<ActionException> {
+    override fun toResponse(th: ActionException): Response<ResponseBody> {
+        val message = if (th.statusCode.isClientError) th.message ?: th.statusCode.name
+        else th.statusCode.name
+        return Response(StringResponseBody(message), HEADERS, statusCode = th.statusCode.code)
+    }
+
+    override fun canHandle(th: Throwable): Boolean = th is ActionException
+
+    override fun loggingLevel(th: ActionException) =
+            if (th.statusCode.isClientError) Level.WARN
+            else Level.ERROR
+
+    private companion object {
+        val HEADERS: Headers =
+                Headers.of(listOf("Content-Type" to MediaTypes.TEXT_PLAIN_UTF8).toMap())
+    }
+}
+

--- a/misk/src/main/kotlin/misk/web/exceptions/ExceptionHandlingInterceptor.kt
+++ b/misk/src/main/kotlin/misk/web/exceptions/ExceptionHandlingInterceptor.kt
@@ -1,0 +1,70 @@
+package misk.web.exceptions
+
+import com.google.common.util.concurrent.UncheckedExecutionException
+import misk.Action
+import misk.Chain
+import misk.Interceptor
+import misk.exceptions.StatusCode
+import misk.logging.getLogger
+import misk.logging.log
+import misk.web.Response
+import misk.web.marshal.StringResponseBody
+import misk.web.mediatype.MediaTypes
+import okhttp3.Headers
+import java.lang.reflect.InvocationTargetException
+import java.util.concurrent.ExecutionException
+import javax.inject.Inject
+
+/**
+ * Converts and logs application and component level dispatch exceptions into the appropriate
+ * response format. Allows application and component code to control how exceptions are
+ * represented to clients; for example by setting the status code appropriately, or by returning
+ * a specialized response format specific to the error. Components can control how exceptions are
+ * mapped by installing [ExceptionMapper] via the [ExceptionMapperModule]
+ */
+class ExceptionHandlingInterceptor(
+        private val actionName: String,
+        private val mappers: Set<ExceptionMapper<*>>
+) : Interceptor {
+
+    override fun intercept(chain: Chain): Any? = try {
+        chain.proceed(chain.args)
+    } catch (th: Throwable) {
+        toResponse(th)
+    }
+
+    private fun toResponse(th: Throwable): Response<*> = when (th) {
+        is ExecutionException -> toResponse(th.cause!!)
+        is InvocationTargetException -> toResponse(th.targetException)
+        is UncheckedExecutionException -> toResponse(th.cause!!)
+        else -> mapperFor(th)?.let {
+            log.log(it.loggingLevel(th), th) { "exception dispatching to $actionName" }
+            it.toResponse(th)
+        } ?: toInternalServerError(th)
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun mapperFor(th: Throwable): ExceptionMapper<Throwable>? = mappers.firstOrNull {
+        it.canHandle(th)
+    } as ExceptionMapper<Throwable>?
+
+    private fun toInternalServerError(th: Throwable): Response<*> {
+        log.error(th) { "unexpected error dispatching to $actionName" }
+        return INTERNAL_SERVER_ERROR_RESPONSE
+    }
+
+    class Factory @Inject internal constructor(
+            private val mappers: MutableSet<ExceptionMapper<*>>
+    ) : Interceptor.Factory {
+        override fun create(action: Action) = ExceptionHandlingInterceptor(action.name, mappers)
+    }
+
+    private companion object {
+        val log = getLogger<ExceptionHandlingInterceptor>()
+
+        val INTERNAL_SERVER_ERROR_RESPONSE = Response(StringResponseBody("internal server error"),
+                Headers.of(listOf("Content-Type" to MediaTypes.TEXT_PLAIN_UTF8).toMap()),
+                StatusCode.INTERNAL_SERVER_ERROR.code
+        )
+    }
+}

--- a/misk/src/main/kotlin/misk/web/exceptions/ExceptionMapper.kt
+++ b/misk/src/main/kotlin/misk/web/exceptions/ExceptionMapper.kt
@@ -1,0 +1,28 @@
+package misk.web.exceptions
+
+import misk.web.Response
+import misk.web.ResponseBody
+import org.slf4j.event.Level
+
+/** Maps an exception to a [Response] */
+interface ExceptionMapper<in T : Throwable> {
+    /** @return true if the [ExceptionMapper] can handle the given exception */
+    fun canHandle(th: Throwable): Boolean
+
+    /** @return the [Response] corresponding to the exception. */
+    // TODO(mmihic): Allow control of marshalling based on content type. Ideally we could
+    // return a Response<*> and then content negotiation would control how that * gets mapped.
+    // Right now however the marshalling interceptor works off the static return type of the
+    // action method, so it blows up when we return a different type from here. This is a general
+    // issue; interceptors should be able to return responses that are of a different structure
+    // then the action method return value
+    fun toResponse(th: T): Response<ResponseBody>
+
+    /**
+     * @return the level at which the given exception should be logged. defaults to ERROR but can
+     * be overriden by the mapper for the given exception
+     */
+    fun loggingLevel(th: T): Level = Level.ERROR
+
+}
+

--- a/misk/src/main/kotlin/misk/web/exceptions/ExceptionMapperModule.kt
+++ b/misk/src/main/kotlin/misk/web/exceptions/ExceptionMapperModule.kt
@@ -1,0 +1,20 @@
+package misk.web.exceptions
+
+import com.google.inject.TypeLiteral
+import com.google.inject.multibindings.Multibinder
+import misk.inject.KAbstractModule
+import kotlin.reflect.KClass
+
+class ExceptionMapperModule<T : ExceptionMapper<*>>(
+        private val kclass: KClass<T>
+) : KAbstractModule() {
+    override fun configure() {
+        Multibinder.newSetBinder(binder(), exceptionMapperTypeLiteral).addBinding().to(kclass.java)
+    }
+
+    companion object {
+        inline fun <reified T : ExceptionMapper<*>> create() = ExceptionMapperModule(T::class)
+
+        private val exceptionMapperTypeLiteral = object : TypeLiteral<ExceptionMapper<*>>() {}
+    }
+}

--- a/misk/src/main/kotlin/misk/web/marshal/StringResponseBody.kt
+++ b/misk/src/main/kotlin/misk/web/marshal/StringResponseBody.kt
@@ -1,0 +1,11 @@
+package misk.web.marshal
+
+import misk.web.ResponseBody
+import okio.BufferedSink
+
+/** A [ResponseBody] that writes the value out as a string */
+class StringResponseBody(val obj: Any) : ResponseBody {
+    override fun writeTo(sink: BufferedSink) {
+        sink.writeUtf8(obj.toString())
+    }
+}

--- a/misk/src/test/kotlin/misk/web/exceptions/ExceptionMapperTest.kt
+++ b/misk/src/test/kotlin/misk/web/exceptions/ExceptionMapperTest.kt
@@ -1,0 +1,99 @@
+package misk.web.exceptions
+
+import com.google.inject.util.Modules
+import com.squareup.moshi.Moshi
+import misk.MiskModule
+import misk.exceptions.ActionException
+import misk.exceptions.StatusCode
+import misk.inject.KAbstractModule
+import misk.testing.MiskTest
+import misk.testing.MiskTestModule
+import misk.testing.TestWebModule
+import misk.web.Get
+import misk.web.PathParam
+import misk.web.ResponseContentType
+import misk.web.WebActionModule
+import misk.web.WebModule
+import misk.web.actions.WebAction
+import misk.web.jetty.JettyService
+import misk.web.mediatype.MediaTypes
+import okhttp3.HttpUrl
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import javax.inject.Inject
+
+@MiskTest(startService = true)
+internal class ExceptionMapperTest {
+
+    @MiskTestModule
+    val module = Modules.combine(
+            MiskModule(),
+            WebModule(),
+            TestWebModule(),
+            TestModule())
+
+    @Inject
+    lateinit var moshi: Moshi
+
+    @Inject
+    lateinit var jettyService: JettyService
+
+    private fun serverUrlBuilder(): HttpUrl.Builder {
+        return jettyService.serverUrl.newBuilder()
+    }
+
+    @Test
+    fun masksMessageOnServerError() {
+        val response = get("/throws/action/SERVICE_UNAVAILABLE")
+        assertThat(response.code()).isEqualTo(StatusCode.SERVICE_UNAVAILABLE.code)
+        assertThat(response.body()?.string()).isEqualTo(StatusCode.SERVICE_UNAVAILABLE.name)
+    }
+
+    @Test
+    fun returnsMessageOnClientErrors() {
+        val response = get("/throws/action/FORBIDDEN")
+        assertThat(response.code()).isEqualTo(StatusCode.FORBIDDEN.code)
+        assertThat(response.body()?.string()).isEqualTo("you asked for an error")
+    }
+
+    @Test
+    fun handlesUnmappedErrorsAsInternalServerError() {
+        val response = get("/throws/unmapped-error")
+        assertThat(response.code()).isEqualTo(StatusCode.INTERNAL_SERVER_ERROR.code)
+        assertThat(response.body()?.string()).isEqualTo("internal server error")
+    }
+
+    fun get(path: String): okhttp3.Response {
+        val httpClient = OkHttpClient()
+        val request = Request.Builder()
+                .get()
+                .url(serverUrlBuilder().encodedPath(path).build())
+                .build()
+        return httpClient.newCall(request).execute()
+    }
+
+    class ThrowsActionException : WebAction {
+        @Get("/throws/action/{statusCode}")
+        @ResponseContentType(MediaTypes.TEXT_PLAIN_UTF8)
+        fun throwsActionException(@PathParam statusCode: StatusCode): Nothing {
+            throw ActionException(statusCode, "you asked for an error")
+        }
+    }
+
+    class ThrowsUnmappedError : WebAction {
+        @Get("/throws/unmapped-error")
+        @ResponseContentType(MediaTypes.TEXT_PLAIN_UTF8)
+        fun throwsUnmappedException() {
+            throw AssertionError("this was bad")
+        }
+    }
+
+    class TestModule : KAbstractModule() {
+        override fun configure() {
+            install(WebActionModule.create<ThrowsActionException>())
+            install(WebActionModule.create<ThrowsUnmappedError>())
+        }
+    }
+}


### PR DESCRIPTION
Typically applications and component will want some level of control
over how specific exceptions get reported to clients; for example
IllegalArgumentExceptions and other client presented problems should be
returned with a 4xx response code rather than the usual 500. This change
adds the ability to register ExceptionMappers, which converts exceptions
thrown by the action into the appropriate Response format. It is
currently limited to only returning text/plain responses; a future
commit will allow for more encoding, for example allowing errors to be
returned in a specific JSON format.

Also introduces an ActionException base type, allowing actions to throw
exceptions that explicitly return a specific status code.