### PR TITLE
Expand upon routing rules for MediaRanges

### DIFF
--- a/misk/src/main/kotlin/misk/web/BoundAction.kt
+++ b/misk/src/main/kotlin/misk/web/BoundAction.kt
@@ -54,9 +54,9 @@ internal class BoundAction<A : WebAction, out R>(
         return result
     }
 
-    fun match(jettyRequest: HttpServletRequest): RequestMatch? {
+    fun match(jettyRequest: HttpServletRequest, url: HttpUrl): RequestMatch? {
         // Confirm the path and method matches
-        val pathMatcher = pathMatcher(jettyRequest.httpUrl()) ?: return null
+        val pathMatcher = pathMatcher(url) ?: return null
         if (jettyRequest.method != httpMethod.name) return null
 
         // Confirm the request content type matches the types we accept, and pick the most specific
@@ -72,7 +72,7 @@ internal class BoundAction<A : WebAction, out R>(
                 responseContentType?.closestMediaRangeMatch(jettyRequest.accepts())
         if (responseContentType != null && responseContentTypeMatch == null) return null
 
-        return RequestMatch(this, pathMatcher, requestContentTypeMatch, responseContentTypeMatch)
+        return RequestMatch(this, pathMatcher, responseContentTypeMatch)
     }
 
     internal fun handle(request: Request, pathMather: Matcher): Response<ResponseBody> {
@@ -103,8 +103,8 @@ internal class BoundAction<A : WebAction, out R>(
 
 private fun HttpServletRequest.accepts(): List<MediaRange> {
     // TODO(mmihic): Don't blow up if one of the accept headers can't be parsed
-    val accepts = getHeaders("Accept")?.toList()?.map {
-        MediaRange.parse(it)
+    val accepts = getHeaders("Accept")?.toList()?.flatMap {
+        MediaRange.parseRanges(it)
     }
 
     return if (accepts == null || accepts.isEmpty()) {
@@ -117,51 +117,27 @@ private fun HttpServletRequest.accepts(): List<MediaRange> {
 /** Matches a request to an action. Can be sorted to pick the most specific match amongst a set of candidates */
 internal class RequestMatch(
         val action: BoundAction<*, *>,
-        val pathMatcher: Matcher,
-        val requestContentTypeMatch: MediaRange.Matcher?,
-        val responseContentTypeMatch: MediaRange.Matcher?
+        private val pathMatcher: Matcher,
+        private val responseContentTypeMatch: MediaRange.Matcher?
 ) : Comparable<RequestMatch> {
     override fun compareTo(other: RequestMatch): Int {
         val patternDiff = action.pathPattern.compareTo(other.action.pathPattern)
         if (patternDiff != 0) return patternDiff
+
+        if (responseContentTypeMatch != null && other.responseContentTypeMatch == null) return -1
+        if (responseContentTypeMatch == null && other.responseContentTypeMatch != null) return 1
+        if (responseContentTypeMatch != null && other.responseContentTypeMatch != null) {
+            return responseContentTypeMatch.compareTo(other.responseContentTypeMatch)
+        }
+
         return 0
     }
 
-    fun handle(jettyRequest: HttpServletRequest, jettyResponse: HttpServletResponse) {
-        val result = action.handle(jettyRequest.asRequest(), pathMatcher)
+    fun handle(request: Request, jettyResponse: HttpServletResponse) {
+        val result = action.handle(request, pathMatcher)
         result.writeToJettyResponse(jettyResponse)
     }
 }
 
 private fun MediaType.closestMediaRangeMatch(ranges: List<MediaRange>) =
         ranges.mapNotNull { it.matcher(this) }.sorted().firstOrNull()
-
-private fun HttpServletRequest.headers(): Headers {
-    val headersBuilder = Headers.Builder()
-    val headerNames = headerNames
-    for (headerName in headerNames) {
-        val headerValues = getHeaders(headerName)
-        for (headerValue in headerValues) {
-            headersBuilder.add(headerName, headerValue)
-        }
-    }
-    return headersBuilder.build()
-}
-
-private fun HttpServletRequest.httpUrl(): HttpUrl {
-    val urlString = requestURL.toString() +
-            if (queryString != null) "?" + queryString
-            else ""
-    return HttpUrl.parse(urlString)!!
-}
-
-private fun HttpServletRequest.httpMethod() = HttpMethod.valueOf(method)
-
-private fun HttpServletRequest.bufferedSource() = Okio.buffer(Okio.source(inputStream))
-
-internal fun HttpServletRequest.asRequest() = Request(
-        httpUrl(),
-        httpMethod(),
-        headers(),
-        bufferedSource()
-)

--- a/misk/src/main/kotlin/misk/web/WebActionModule.kt
+++ b/misk/src/main/kotlin/misk/web/WebActionModule.kt
@@ -82,8 +82,8 @@ class WebActionModule<A : WebAction> private constructor(
 }
 
 private val KFunction<*>.acceptedContentTypes: List<MediaRange>
-    get() = findAnnotation<RequestContentType>()?.value?.map {
-        MediaRange.parse(it)
+    get() = findAnnotation<RequestContentType>()?.value?.flatMap {
+        MediaRange.parseRanges(it)
     }?.toList() ?: listOf(MediaRange.ALL_MEDIA)
 
 private val KFunction<*>.responseContentType: MediaType?

--- a/misk/src/main/kotlin/misk/web/jetty/WebActionsServlet.kt
+++ b/misk/src/main/kotlin/misk/web/jetty/WebActionsServlet.kt
@@ -6,7 +6,10 @@ import misk.scope.ActionScope
 import misk.web.BoundAction
 import misk.web.Request
 import misk.web.actions.WebAction
-import misk.web.asRequest
+import okhttp3.Headers
+import okhttp3.HttpUrl
+import okio.Okio
+import org.eclipse.jetty.http.HttpMethod
 import javax.inject.Inject
 import javax.inject.Singleton
 import javax.servlet.http.HttpServlet
@@ -29,17 +32,37 @@ internal class WebActionsServlet @Inject constructor(
     }
 
     private fun handleCall(request: HttpServletRequest, response: HttpServletResponse) {
+        val asRequest = request.asRequest()
         val seedData = mapOf(
                 keyOf<HttpServletRequest>() to request,
-                keyOf<Request>() to request.asRequest())
+                keyOf<Request>() to asRequest)
 
         scope.enter(seedData).use {
-            val candidateActions = boundActions.mapNotNull { it.match(request) }
+            val candidateActions = boundActions.mapNotNull { it.match(request, asRequest.url) }
             val bestAction = candidateActions.sorted().firstOrNull()
-            if (bestAction != null) {
-                bestAction.handle(request, response)
-                logger.debug("Request handled by WebActionServlet")
-            }
+            bestAction?.handle(asRequest, response)
+            logger.debug {"Request handled by WebActionServlet" }
         }
     }
+}
+
+internal fun HttpServletRequest.asRequest(): Request {
+    val urlString = requestURL.toString() +
+            if (queryString != null) "?" + queryString
+            else ""
+
+    val headersBuilder = Headers.Builder()
+    val headerNames = headerNames
+    for (headerName in headerNames) {
+        val headerValues = getHeaders(headerName)
+        for (headerValue in headerValues) {
+            headersBuilder.add(headerName, headerValue)
+        }
+    }
+    return Request(
+            HttpUrl.parse(urlString)!!,
+            HttpMethod.valueOf(method),
+            headersBuilder.build(),
+            Okio.buffer(Okio.source(inputStream))
+    )
 }

--- a/misk/src/main/kotlin/misk/web/mediatype/MediaRange.kt
+++ b/misk/src/main/kotlin/misk/web/mediatype/MediaRange.kt
@@ -11,7 +11,7 @@ data class MediaRange(
         val qualityFactor: Double = 1.0,
         val parameters: Map<String, String> = mapOf(),
         val extensions: Map<String, String> = mapOf()
-) : Comparable<MediaRange>{
+) : Comparable<MediaRange> {
     override fun compareTo(other: MediaRange): Int {
         if (type == WILDCARD && other.type != WILDCARD) return 1
         if (type != WILDCARD && other.type == WILDCARD) return -1
@@ -27,8 +27,6 @@ data class MediaRange(
 
         return 0
     }
-
-    fun matches(mediaType: MediaType) = matcher(mediaType) != null
 
     fun matcher(mediaType: MediaType): Matcher? {
         val typeMatches = type == mediaType.type() || type == WILDCARD
@@ -51,14 +49,26 @@ data class MediaRange(
         return Matcher(this, true)
     }
 
-    data class Matcher(val mediaRange: MediaRange, val matchesCharset: Boolean = false)
+    data class Matcher(private val mediaRange: MediaRange, val matchesCharset: Boolean = false)
         : Comparable<Matcher> {
-        override fun compareTo(other: Matcher) = mediaRange.compareTo(other.mediaRange)
+        override fun compareTo(other: Matcher): Int {
+            val mediaRangeComparison = mediaRange.compareTo(other.mediaRange)
+            if (mediaRangeComparison != 0) return mediaRangeComparison
+
+            if (matchesCharset && !other.matchesCharset) return -1
+            if (!matchesCharset && other.matchesCharset) return 1
+
+            return 0
+        }
     }
 
     companion object {
         const val WILDCARD = "*"
         val ALL_MEDIA = MediaRange(WILDCARD, WILDCARD)
+
+        fun parseRanges(s: String): List<MediaRange> {
+            return s.split(',').map { parse(it) }
+        }
 
         fun parse(s: String): MediaRange {
             val typeParametersAndExtensions = s.split(';')
@@ -124,13 +134,6 @@ data class MediaRange(
             require(!name.isEmpty()) { "$s is not a valid name/value pair" }
             require(!value.isEmpty()) { "$s is not a valid name/value pair" }
             return name to value
-        }
-
-        private fun computeWildcardCount(type: String, subtype: String): Int {
-            var count = 0
-            if (type == Companion.WILDCARD) count++
-            if (subtype == Companion.WILDCARD) count++
-            return count
         }
     }
 }

--- a/misk/src/test/kotlin/misk/web/mediatype/MediaRangeTest.kt
+++ b/misk/src/test/kotlin/misk/web/mediatype/MediaRangeTest.kt
@@ -222,4 +222,22 @@ internal class MediaRangeTest {
         val sorted = unsorted.sorted()
         assertThat(sorted).containsExactly(r6, r5, r4, r3, r2, r1)
     }
+
+    // From https://developer.mozilla.org/en-US/docs/Web/HTTP/Content_negotiation/List_of_default_Accept_values
+    @Test
+    fun parsesDefaultBrowserValues() {
+        MediaRange.parseRanges("text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8")
+
+        MediaRange.parseRanges(
+                "application/xml,application/xhtml+xml,text/html;q=0.9, text/plain;q=0.8,image/png,*/*;q=0.5"
+        )
+        MediaRange.parseRanges("text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8")
+        MediaRange.parseRanges(
+                "image/jpeg, application/x-ms-application, image/gif, application/xaml+xml, image/pjpeg, application/x-ms-xbap, application/x-shockwave-flash, application/msword, */*"
+        )
+        MediaRange.parseRanges("text/html, application/xhtml+xml, image/jxr, */*")
+        MediaRange.parseRanges(
+                "text/html, application/xml;q=0.9, application/xhtml+xml, image/png, image/webp, image/jpeg, image/gif, image/x-xbitmap, */*;q=0.1"
+        )
+    }
 }


### PR DESCRIPTION
Prior to this change if we had two routes with the same path
the one returned was arbitrary, even if one was the clear choice
in regards to content type. We now attempt to choose the route which
matches the desired content type.

We also attempt to route based, in some cases, on whether or not
the specified charset matches our route.

Along with this comes two small fixes:
  - Allow multiple media ranges to be specified in the accept header
  - Parse the URL only once per request