### PR TITLE
Add support for commands

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,7 @@ ext {
           junitParams          : 'org.junit.jupiter:junit-jupiter-params:5.0.2',
           junitEngine          : 'org.junit.jupiter:junit-jupiter-engine:5.0.2',
           gcpCloudStorage      : 'com.google.cloud:google-cloud-storage:1.15.0',
+          jCommander           : 'com.beust:jcommander:1.72',
   ]
 
   isCi = "true".equals(System.getenv('CI'))

--- a/exemplar/src/main/java/com/squareup/exemplar/ExemplarJavaApp.java
+++ b/exemplar/src/main/java/com/squareup/exemplar/ExemplarJavaApp.java
@@ -19,6 +19,6 @@ public class ExemplarJavaApp {
         new ExemplarJavaModule(),
         new ExemplarJavaConfigModule(),
         EnvironmentModule.fromEnvironmentVariable()
-    ).startAndAwaitStopped();
+    ).run(args);
   }
 }

--- a/exemplar/src/main/kotlin/com/squareup/exemplar/ExemplarService.kt
+++ b/exemplar/src/main/kotlin/com/squareup/exemplar/ExemplarService.kt
@@ -16,5 +16,5 @@ fun main(args: Array<String>) {
             ExemplarModule(),
             ExemplarConfigModule(),
             EnvironmentModule.fromEnvironmentVariable()
-    ).startAndAwaitStopped()
+    ).run(args)
 }

--- a/misk/build.gradle
+++ b/misk/build.gradle
@@ -39,6 +39,7 @@ dependencies {
   compile dep.gcpDatastore
   compile dep.gcpKms
   compile dep.gcpCloudStorage
+  compile dep.jCommander
 
   testCompile project(':misk/testing')
 }

--- a/misk/src/main/kotlin/misk/MiskApplication.kt
+++ b/misk/src/main/kotlin/misk/MiskApplication.kt
@@ -1,24 +1,99 @@
 package misk
 
+import com.beust.jcommander.JCommander
+import com.beust.jcommander.ParameterException
+import com.google.common.annotations.VisibleForTesting
 import com.google.common.util.concurrent.ServiceManager
 import com.google.inject.Guice
 import com.google.inject.Module
+import misk.inject.KAbstractModule
 import misk.inject.getInstance
+import misk.logging.getLogger
 
-class MiskApplication(private vararg val modules: Module) {
-    fun startAndAwaitStopped() {
-        val injector = Guice.createInjector(*modules)
-        val serviceManager = injector.getInstance<ServiceManager>()
+/** The entry point for misk applications */
+class MiskApplication(private val modules: List<Module>, commands: List<MiskCommand> = listOf()) {
 
-        Runtime.getRuntime().addShutdownHook(object : Thread() {
-            override fun run() {
-                serviceManager.stopAsync()
-                serviceManager.awaitStopped()
+    constructor(vararg modules: Module) : this(modules.toList())
+    constructor(vararg commands: MiskCommand) : this(listOf(), commands.toList())
+
+    private val commands = commands.map { it.name to it }.toMap()
+    private val jc: JCommander
+
+    init {
+        // TODO(mmihic): program name
+        val jcBuilder = JCommander.newBuilder()
+        commands.forEach { jcBuilder.addCommand(it.name, it) }
+        jc = jcBuilder.build()
+    }
+
+    /**
+     * Runs the application, finding and executing the appropriate command based on the
+     * provided command line arguments
+     */
+    fun run(args: Array<String>) {
+        try {
+            doRun(args)
+        } catch (e: CliException) {
+            log.info(e.message)
+        }
+    }
+
+    /**
+     * Runs the application, raising a [CliException] if an error occurs. used for testing,
+     * to ensure that properly friendly error message are printed when command line parsing
+     * fails or when command preconditions (required arguments etc) are not met
+     *
+     * If no command line arguments are specified, the service starts and blocks until terminated
+     */
+    @VisibleForTesting
+    internal fun doRun(args: Array<String>) {
+        if (args.isEmpty()) {
+            startServiceAndAwaitTermination()
+        }
+
+        try {
+            jc.parse(*args)
+            val command = commands[jc.parsedCommand]
+                    ?: throw ParameterException("unknown command ${jc.parsedCommand}")
+
+            val injector = Guice.createInjector(object : KAbstractModule() {
+                override fun configure() {
+                    bind<JCommander>().toInstance(jc)
+                }
+            }, *command.modules.toTypedArray())
+
+            injector.injectMembers(command)
+            command.run()
+        } catch (e: ParameterException) {
+            val sb = StringBuilder().append('\n')
+            e.message?.let { sb.append(it).append("\n\n") }
+            if (e.jCommander?.parsedCommand != null) {
+                jc.usage(e.jCommander.parsedCommand, sb)
+            } else {
+                jc.usage(sb)
             }
-        })
+            throw CliException(sb.toString())
+        }
+    }
+
+    private fun startServiceAndAwaitTermination() {
+        val injector = Guice.createInjector(modules)
+        val serviceManager = injector.getInstance<ServiceManager>()
+        Runtime.getRuntime().addShutdownHook(object : Thread() {
+                    override fun run() {
+                        serviceManager.stopAsync()
+                        serviceManager.awaitStopped()
+                    }
+                })
 
         serviceManager.startAsync()
         serviceManager.awaitHealthy()
         serviceManager.awaitStopped()
     }
+
+    private companion object {
+        val log = getLogger<MiskApplication>()
+    }
+
+    internal class CliException(message: String) : RuntimeException(message)
 }

--- a/misk/src/main/kotlin/misk/MiskCommand.kt
+++ b/misk/src/main/kotlin/misk/MiskCommand.kt
@@ -1,0 +1,33 @@
+package misk
+
+import com.beust.jcommander.JCommander
+import com.beust.jcommander.ParameterException
+import com.google.inject.Module
+import javax.inject.Inject
+
+/**
+ * A command to run from the command line. Each command has an associated name and
+ * the list of modules to use in initializing the command. Commands can specify
+ * optional and required arguments via JCommander annotations. The command line will
+ * pick the appropriate command based on the name, create an injector based on that
+ * command's modules, use the injector to initialize the command, and then run the command.
+ */
+abstract class MiskCommand(internal val name: String, internal val modules: List<Module>) : Runnable {
+    constructor(name: String, vararg modules: Module) : this(name, modules.toList())
+
+    @Inject
+    private lateinit var jc: JCommander
+
+    /**
+     * Confirms that the given precondition is true, otherwise throws a [ParameterException]
+     * with the supplied message
+     * */
+    fun requireCli(value: Boolean, lazyMessage: () -> String) {
+        if (!value) {
+            val exception = ParameterException(lazyMessage())
+            exception.jCommander = jc
+            throw exception
+        }
+    }
+}
+

--- a/misk/src/test/kotlin/misk/MiskApplicationTest.kt
+++ b/misk/src/test/kotlin/misk/MiskApplicationTest.kt
@@ -1,0 +1,170 @@
+package misk
+
+import com.beust.jcommander.Parameter
+import misk.inject.KAbstractModule
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Test
+import javax.inject.Inject
+
+internal class MiskApplicationTest {
+    class WithRequiredArguments : MiskCommand("with-required-args") {
+        @Parameter(names = ["-f", "--file"], required = true)
+        var filename: String? = null
+
+        var run: Boolean = false
+
+        override fun run() {
+            run = true
+        }
+    }
+
+    class WithPreconditions : MiskCommand("with-preconditions") {
+        @Parameter(names = ["-f", "--file"])
+        var filename: String? = null
+
+        @Parameter(names = ["-d", "--dir"])
+        var directory: String? = null
+
+        var run: Boolean = false
+        var preconditionsMet: Boolean = false
+
+        override fun run() {
+            run = true
+            requireCli(filename != null || directory != null) {
+                "one of -f or -d must be specified"
+            }
+            preconditionsMet = true
+        }
+    }
+
+    class WithModule : MiskCommand("with-module", AppNameModule()) {
+        @Inject
+        lateinit
+        var injectedValue: MyInjectedValue
+
+        var run: Boolean = false
+
+        override fun run() {
+            run = true
+        }
+
+        data class MyInjectedValue(val message: String)
+
+        class AppNameModule : KAbstractModule() {
+            override fun configure() {
+                bind<MyInjectedValue>().toInstance(MyInjectedValue("foo"))
+            }
+        }
+    }
+
+    class Commands {
+        val withRequiredArguments = WithRequiredArguments()
+        val withPreconditions = WithPreconditions()
+        val withModule = WithModule()
+        val all = arrayOf(withRequiredArguments, withPreconditions, withModule)
+    }
+
+    @Test
+    fun withModule() {
+        val commands = Commands()
+        MiskApplication(*commands.all).doRun(arrayOf("with-module"))
+        assertThat(commands.withModule.run).isTrue()
+        assertThat(commands.withModule.injectedValue.message).isEqualTo("foo")
+    }
+
+    @Test
+    fun withRequiredArguments() {
+        val commands = Commands()
+        MiskApplication(*commands.all).doRun(arrayOf("with-required-args", "-f", "my-file"))
+        assertThat(commands.withRequiredArguments.run).isTrue()
+        assertThat(commands.withRequiredArguments.filename).isEqualTo("my-file")
+    }
+
+    @Test
+    fun withPreconditions() {
+        val commands = Commands()
+        MiskApplication(*commands.all).doRun(arrayOf("with-preconditions", "-f", "my-file"))
+        assertThat(commands.withPreconditions.run).isTrue()
+        assertThat(commands.withPreconditions.preconditionsMet).isTrue()
+        assertThat(commands.withPreconditions.filename).isEqualTo("my-file")
+    }
+
+    @Test
+    fun missingRequiredArgument() {
+        val exception = assertThrows(MiskApplication.CliException::class.java) {
+            val commands = Commands()
+            MiskApplication(*commands.all).doRun(arrayOf("with-required-args", "-f"))
+        }
+
+        // Error message should be specific to the command
+        assertThat(exception.message).isEqualTo(
+"""
+Expected a value after parameter -f
+
+Usage: with-required-args [options]
+  Options:
+  * -f, --file
+
+"""
+        )
+    }
+
+    @Test
+    fun unknownCommand() {
+        val exception = assertThrows(MiskApplication.CliException::class.java) {
+            val commands = Commands()
+            MiskApplication(*commands.all).doRun(arrayOf("unknown"))
+        }
+
+        // Error message should include the entire usage
+        assertThat(exception.message).isEqualTo(
+"""
+Expected a command, got unknown
+
+Usage: <main class> [command] [command options]
+  Commands:
+    with-required-args      null
+      Usage: with-required-args [options]
+        Options:
+        * -f, --file
+
+
+    with-preconditions      null
+      Usage: with-preconditions [options]
+        Options:
+          -d, --dir
+
+          -f, --file
+
+
+    with-module      null
+      Usage: with-module
+
+"""
+        )
+    }
+
+    @Test
+    fun commandPreconditionsNotMet() {
+        val exception = assertThrows(MiskApplication.CliException::class.java) {
+            val commands = Commands()
+            MiskApplication(*commands.all).doRun(arrayOf("with-preconditions"))
+        }
+
+        // Error message should be specific to the command
+        assertThat(exception.message).isEqualTo(
+"""
+one of -f or -d must be specified
+
+Usage: with-preconditions [options]
+  Options:
+    -d, --dir
+
+    -f, --file
+
+"""
+        )
+
+    }
+}


### PR DESCRIPTION
Allows applications to register additional commands that can be run
directly from the jar, typically used for utility commands. For example,
an application might register commands allowing for interaction with the
service from the command line, supporting scripting of administrative or
operational tasks.

If no command is specified on the command line, the service is started
and blocks until terminated (consistent with the prior behavior of
running the jar)
