### PR TITLE
Update exemplar README.md due to shading

### DIFF
--- a/exemplar/README.md
+++ b/exemplar/README.md
@@ -6,7 +6,7 @@ of this repository.
 Build exemplar:
 
 ```
-  $ ./gradlew clean jar
+  $ ./gradlew clean assemble
 ```  
 
 ## Docker


### PR DESCRIPTION
Now that we are using the shading plugin, it's no longer enough to run
gradle jar to produce an executable jar; you now must run gradle
assemble to produce the final executable shaded jar.