### PR TITLE
Reformat all the code to match the latest SQ codestyle

### DIFF
--- a/exemplar/src/main/java/com/squareup/exemplar/ExemplarJavaApp.java
+++ b/exemplar/src/main/java/com/squareup/exemplar/ExemplarJavaApp.java
@@ -4,7 +4,6 @@ import misk.MiskApplication;
 import misk.MiskModule;
 import misk.environment.EnvironmentModule;
 import misk.hibernate.HibernateModule;
-import misk.moshi.MoshiModule;
 import misk.web.WebModule;
 
 public class ExemplarJavaApp {

--- a/exemplar/src/main/kotlin/com/squareup/exemplar/ExemplarConfigModule.kt
+++ b/exemplar/src/main/kotlin/com/squareup/exemplar/ExemplarConfigModule.kt
@@ -4,7 +4,7 @@ import com.google.inject.AbstractModule
 import misk.config.ConfigModule
 
 class ExemplarConfigModule : AbstractModule() {
-    override fun configure() {
-        install(ConfigModule.create<ExemplarConfig>("exemplar"))
-    }
+  override fun configure() {
+    install(ConfigModule.create<ExemplarConfig>("exemplar"))
+  }
 }

--- a/exemplar/src/main/kotlin/com/squareup/exemplar/ExemplarModule.kt
+++ b/exemplar/src/main/kotlin/com/squareup/exemplar/ExemplarModule.kt
@@ -3,19 +3,19 @@ package com.squareup.exemplar
 import com.google.inject.AbstractModule
 import misk.metrics.web.MetricsJsonAction
 import misk.web.WebActionModule
-import misk.web.actions.ReadinessCheckAction
 import misk.web.actions.InternalErrorAction
 import misk.web.actions.LivenessCheckAction
 import misk.web.actions.NotFoundAction
+import misk.web.actions.ReadinessCheckAction
 
 class ExemplarModule : AbstractModule() {
-    override fun configure() {
-        install(WebActionModule.create<HelloWebAction>())
-        install(WebActionModule.create<HelloWebPostAction>())
-        install(WebActionModule.create<MetricsJsonAction>())
-        install(WebActionModule.create<InternalErrorAction>())
-        install(WebActionModule.create<ReadinessCheckAction>())
-        install(WebActionModule.create<LivenessCheckAction>())
-        install(WebActionModule.create<NotFoundAction>())
-    }
+  override fun configure() {
+    install(WebActionModule.create<HelloWebAction>())
+    install(WebActionModule.create<HelloWebPostAction>())
+    install(WebActionModule.create<MetricsJsonAction>())
+    install(WebActionModule.create<InternalErrorAction>())
+    install(WebActionModule.create<ReadinessCheckAction>())
+    install(WebActionModule.create<LivenessCheckAction>())
+    install(WebActionModule.create<NotFoundAction>())
+  }
 }

--- a/exemplar/src/main/kotlin/com/squareup/exemplar/ExemplarService.kt
+++ b/exemplar/src/main/kotlin/com/squareup/exemplar/ExemplarService.kt
@@ -7,14 +7,14 @@ import misk.hibernate.HibernateModule
 import misk.web.WebModule
 
 fun main(args: Array<String>) {
-    MiskApplication(
-            MiskModule(),
+  MiskApplication(
+      MiskModule(),
 
-            WebModule(),
+      WebModule(),
 
-            HibernateModule(),
-            ExemplarModule(),
-            ExemplarConfigModule(),
-            EnvironmentModule.fromEnvironmentVariable()
-    ).run(args)
+      HibernateModule(),
+      ExemplarModule(),
+      ExemplarConfigModule(),
+      EnvironmentModule.fromEnvironmentVariable()
+  ).run(args)
 }

--- a/exemplar/src/main/kotlin/com/squareup/exemplar/HelloWebAction.kt
+++ b/exemplar/src/main/kotlin/com/squareup/exemplar/HelloWebAction.kt
@@ -12,18 +12,22 @@ import javax.inject.Singleton
 
 @Singleton
 class HelloWebAction : WebAction {
-    @Get("/hello/{name}")
-    @ResponseContentType(MediaTypes.APPLICATION_JSON)
-    fun hello(
-            @PathParam name: String,
-            @RequestHeaders headers: Headers,
-            @QueryParam nickName: String?,
-            @QueryParam greetings: List<String>?
-    ): HelloResponse {
-        return HelloResponse(
-                greetings?.joinToString(separator = " ") ?: "YO",
-                nickName?.toUpperCase() ?: name.toUpperCase())
-    }
+  @Get("/hello/{name}")
+  @ResponseContentType(MediaTypes.APPLICATION_JSON)
+  fun hello(
+      @PathParam name: String,
+      @RequestHeaders headers: Headers,
+      @QueryParam nickName: String?,
+      @QueryParam greetings: List<String>?
+  ): HelloResponse {
+    return HelloResponse(
+        greetings?.joinToString(separator = " ") ?: "YO",
+        nickName?.toUpperCase() ?: name.toUpperCase()
+    )
+  }
 }
 
-data class HelloResponse(val greeting: String, val name: String)
+data class HelloResponse(
+    val greeting: String,
+    val name: String
+)

--- a/exemplar/src/main/kotlin/com/squareup/exemplar/HelloWebPostAction.kt
+++ b/exemplar/src/main/kotlin/com/squareup/exemplar/HelloWebPostAction.kt
@@ -11,14 +11,17 @@ import javax.inject.Singleton
 
 @Singleton
 class HelloWebPostAction : WebAction {
-    @Post("/hello/{name}")
-    @RequestContentType(MediaTypes.APPLICATION_JSON)
-    @ResponseContentType(MediaTypes.APPLICATION_JSON)
-    fun hello(@PathParam name: String, @RequestBody body: PostBody): HelloPostResponse {
-        return HelloPostResponse(body.greeting, name.toUpperCase())
-    }
+  @Post("/hello/{name}")
+  @RequestContentType(MediaTypes.APPLICATION_JSON)
+  @ResponseContentType(MediaTypes.APPLICATION_JSON)
+  fun hello(@PathParam name: String, @RequestBody body: PostBody): HelloPostResponse {
+    return HelloPostResponse(body.greeting, name.toUpperCase())
+  }
 }
 
-data class HelloPostResponse(val greeting: String, val name: String)
+data class HelloPostResponse(
+    val greeting: String,
+    val name: String
+)
 
 data class PostBody(val greeting: String)

--- a/exemplar/src/test/kotlin/com/squareup/exemplar/HelloWebActionTest.kt
+++ b/exemplar/src/test/kotlin/com/squareup/exemplar/HelloWebActionTest.kt
@@ -1,8 +1,8 @@
 package com.squareup.exemplar
 
-import org.assertj.core.api.Assertions.assertThat
 import misk.testing.MiskTest
 import okhttp3.Headers
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import javax.inject.Inject
 

--- a/misk/src/main/kotlin/misk/Actions.kt
+++ b/misk/src/main/kotlin/misk/Actions.kt
@@ -5,16 +5,17 @@ import kotlin.reflect.KFunction
 import kotlin.reflect.full.instanceParameter
 
 fun KFunction<*>.asAction(): Action {
-    val instanceParameter = this.instanceParameter
-            ?: throw IllegalArgumentException("only methods may be actions")
+  val instanceParameter = this.instanceParameter
+      ?: throw IllegalArgumentException("only methods may be actions")
 
-    val parameterTypes = parameters.drop(1).map { it.type }
-    val name = instanceParameter.type.classifier?.let {
-        when (it) {
-            is KClass<*> -> it.simpleName
-            else -> this.name
-        }
-    } ?: this.name
+  val parameterTypes = parameters.drop(1)
+      .map { it.type }
+  val name = instanceParameter.type.classifier?.let {
+    when (it) {
+      is KClass<*> -> it.simpleName
+      else -> this.name
+    }
+  } ?: this.name
 
-    return Action(name, this, parameterTypes, returnType)
+  return Action(name, this, parameterTypes, returnType)
 }

--- a/misk/src/main/kotlin/misk/Chain.kt
+++ b/misk/src/main/kotlin/misk/Chain.kt
@@ -4,8 +4,8 @@ import misk.web.actions.WebAction
 import kotlin.reflect.KFunction
 
 interface Chain {
-    val action: WebAction
-    val args: List<Any?>
-    val function: KFunction<*>
-    fun proceed(args: List<Any?>): Any?
+  val action: WebAction
+  val args: List<Any?>
+  val function: KFunction<*>
+  fun proceed(args: List<Any?>): Any?
 }

--- a/misk/src/main/kotlin/misk/Interceptor.kt
+++ b/misk/src/main/kotlin/misk/Interceptor.kt
@@ -1,9 +1,9 @@
 package misk
 
 interface Interceptor {
-    fun intercept(chain: Chain): Any?
+  fun intercept(chain: Chain): Any?
 
-    interface Factory {
-        fun create(action: Action): Interceptor?
-    }
+  interface Factory {
+    fun create(action: Action): Interceptor?
+  }
 }

--- a/misk/src/main/kotlin/misk/MiskApplication.kt
+++ b/misk/src/main/kotlin/misk/MiskApplication.kt
@@ -11,89 +11,97 @@ import misk.inject.getInstance
 import misk.logging.getLogger
 
 /** The entry point for misk applications */
-class MiskApplication(private val modules: List<Module>, commands: List<MiskCommand> = listOf()) {
+class MiskApplication(
+    private val modules: List<Module>,
+    commands: List<MiskCommand> = listOf()
+) {
 
-    constructor(vararg modules: Module) : this(modules.toList())
-    constructor(vararg commands: MiskCommand) : this(listOf(), commands.toList())
+  constructor(vararg modules: Module) : this(modules.toList())
+  constructor(vararg commands: MiskCommand) : this(listOf(), commands.toList())
 
-    private val commands = commands.map { it.name to it }.toMap()
-    private val jc: JCommander
+  private val commands = commands.map { it.name to it }
+      .toMap()
+  private val jc: JCommander
 
-    init {
-        // TODO(mmihic): program name
-        val jcBuilder = JCommander.newBuilder()
-        commands.forEach { jcBuilder.addCommand(it.name, it) }
-        jc = jcBuilder.build()
+  init {
+    // TODO(mmihic): program name
+    val jcBuilder = JCommander.newBuilder()
+    commands.forEach { jcBuilder.addCommand(it.name, it) }
+    jc = jcBuilder.build()
+  }
+
+  /**
+   * Runs the application, finding and executing the appropriate command based on the
+   * provided command line arguments
+   */
+  fun run(args: Array<String>) {
+    try {
+      doRun(args)
+    } catch (e: CliException) {
+      log.info(e.message)
+    }
+  }
+
+  /**
+   * Runs the application, raising a [CliException] if an error occurs. used for testing,
+   * to ensure that properly friendly error message are printed when command line parsing
+   * fails or when command preconditions (required arguments etc) are not met
+   *
+   * If no command line arguments are specified, the service starts and blocks until terminated
+   */
+  @VisibleForTesting
+  internal fun doRun(args: Array<String>) {
+    if (args.isEmpty()) {
+      startServiceAndAwaitTermination()
     }
 
-    /**
-     * Runs the application, finding and executing the appropriate command based on the
-     * provided command line arguments
-     */
-    fun run(args: Array<String>) {
-        try {
-            doRun(args)
-        } catch (e: CliException) {
-            log.info(e.message)
+    try {
+      jc.parse(*args)
+      val command = commands[jc.parsedCommand]
+          ?: throw ParameterException("unknown command ${jc.parsedCommand}")
+
+      val injector = Guice.createInjector(object : KAbstractModule() {
+        override fun configure() {
+          bind<JCommander>().toInstance(jc)
         }
+      }, *command.modules.toTypedArray())
+
+      injector.injectMembers(command)
+      command.run()
+    } catch (e: ParameterException) {
+      val sb = StringBuilder().append('\n')
+      e.message?.let {
+        sb.append(it)
+            .append("\n\n")
+      }
+      if (e.jCommander?.parsedCommand != null) {
+        jc.usage(e.jCommander.parsedCommand, sb)
+      } else {
+        jc.usage(sb)
+      }
+      throw CliException(sb.toString())
     }
+  }
 
-    /**
-     * Runs the application, raising a [CliException] if an error occurs. used for testing,
-     * to ensure that properly friendly error message are printed when command line parsing
-     * fails or when command preconditions (required arguments etc) are not met
-     *
-     * If no command line arguments are specified, the service starts and blocks until terminated
-     */
-    @VisibleForTesting
-    internal fun doRun(args: Array<String>) {
-        if (args.isEmpty()) {
-            startServiceAndAwaitTermination()
-        }
+  private fun startServiceAndAwaitTermination() {
+    val injector = Guice.createInjector(modules)
+    val serviceManager = injector.getInstance<ServiceManager>()
+    Runtime.getRuntime()
+        .addShutdownHook(object : Thread() {
+          override fun run() {
+            serviceManager.stopAsync()
+            serviceManager.awaitStopped()
+          }
+        })
 
-        try {
-            jc.parse(*args)
-            val command = commands[jc.parsedCommand]
-                    ?: throw ParameterException("unknown command ${jc.parsedCommand}")
+    serviceManager.startAsync()
+    serviceManager.awaitHealthy()
+    serviceManager.awaitStopped()
+  }
 
-            val injector = Guice.createInjector(object : KAbstractModule() {
-                override fun configure() {
-                    bind<JCommander>().toInstance(jc)
-                }
-            }, *command.modules.toTypedArray())
+  private companion object {
+    val log = getLogger<MiskApplication>()
+  }
 
-            injector.injectMembers(command)
-            command.run()
-        } catch (e: ParameterException) {
-            val sb = StringBuilder().append('\n')
-            e.message?.let { sb.append(it).append("\n\n") }
-            if (e.jCommander?.parsedCommand != null) {
-                jc.usage(e.jCommander.parsedCommand, sb)
-            } else {
-                jc.usage(sb)
-            }
-            throw CliException(sb.toString())
-        }
-    }
-
-    private fun startServiceAndAwaitTermination() {
-        val injector = Guice.createInjector(modules)
-        val serviceManager = injector.getInstance<ServiceManager>()
-        Runtime.getRuntime().addShutdownHook(object : Thread() {
-                    override fun run() {
-                        serviceManager.stopAsync()
-                        serviceManager.awaitStopped()
-                    }
-                })
-
-        serviceManager.startAsync()
-        serviceManager.awaitHealthy()
-        serviceManager.awaitStopped()
-    }
-
-    private companion object {
-        val log = getLogger<MiskApplication>()
-    }
-
-    internal class CliException(message: String) : RuntimeException(message)
+  internal class CliException(message: String) : RuntimeException(message)
 }

--- a/misk/src/main/kotlin/misk/MiskCommand.kt
+++ b/misk/src/main/kotlin/misk/MiskCommand.kt
@@ -12,22 +12,31 @@ import javax.inject.Inject
  * pick the appropriate command based on the name, create an injector based on that
  * command's modules, use the injector to initialize the command, and then run the command.
  */
-abstract class MiskCommand(internal val name: String, internal val modules: List<Module>) : Runnable {
-    constructor(name: String, vararg modules: Module) : this(name, modules.toList())
+abstract class MiskCommand(
+    internal val name: String,
+    internal val modules: List<Module>
+) : Runnable {
+  constructor(
+      name: String,
+      vararg modules: Module
+  ) : this(name, modules.toList())
 
-    @Inject
-    private lateinit var jc: JCommander
+  @Inject
+  private lateinit var jc: JCommander
 
-    /**
-     * Confirms that the given precondition is true, otherwise throws a [ParameterException]
-     * with the supplied message
-     * */
-    fun requireCli(value: Boolean, lazyMessage: () -> String) {
-        if (!value) {
-            val exception = ParameterException(lazyMessage())
-            exception.jCommander = jc
-            throw exception
-        }
+  /**
+   * Confirms that the given precondition is true, otherwise throws a [ParameterException]
+   * with the supplied message
+   * */
+  fun requireCli(
+      value: Boolean,
+      lazyMessage: () -> String
+  ) {
+    if (!value) {
+      val exception = ParameterException(lazyMessage())
+      exception.jCommander = jc
+      throw exception
     }
+  }
 }
 

--- a/misk/src/main/kotlin/misk/MiskDefault.kt
+++ b/misk/src/main/kotlin/misk/MiskDefault.kt
@@ -11,8 +11,9 @@ import kotlin.annotation.AnnotationRetention.RUNTIME
 @Qualifier
 @Retention(RUNTIME)
 @Target(
-        AnnotationTarget.CLASS,
-        AnnotationTarget.VALUE_PARAMETER,
-        AnnotationTarget.FIELD,
-        AnnotationTarget.TYPE)
+    AnnotationTarget.CLASS,
+    AnnotationTarget.VALUE_PARAMETER,
+    AnnotationTarget.FIELD,
+    AnnotationTarget.TYPE
+)
 internal annotation class MiskDefault

--- a/misk/src/main/kotlin/misk/MiskModule.kt
+++ b/misk/src/main/kotlin/misk/MiskModule.kt
@@ -12,20 +12,20 @@ import misk.time.ClockModule
 import javax.inject.Singleton
 
 class MiskModule : AbstractModule() {
-    override fun configure() {
-        install(HealthChecksModule())
-        install(MetricsModule())
-        install(ClockModule())
-        install(MoshiModule())
+  override fun configure() {
+    install(HealthChecksModule())
+    install(MetricsModule())
+    install(ClockModule())
+    install(MoshiModule())
 
-        // Always make sure List<Service> is bound, even if there
-        // are no services registered (mostly for testing)
-        binder().newMultibinder<Service>()
-    }
+    // Always make sure List<Service> is bound, even if there
+    // are no services registered (mostly for testing)
+    binder().newMultibinder<Service>()
+  }
 
-    @Provides
-    @Singleton
-    fun provideServiceManager(services: List<Service>): ServiceManager {
-        return ServiceManager(services)
-    }
+  @Provides
+  @Singleton
+  fun provideServiceManager(services: List<Service>): ServiceManager {
+    return ServiceManager(services)
+  }
 }

--- a/misk/src/main/kotlin/misk/cloud/aws/environment/AwsInstanceMetadataModule.kt
+++ b/misk/src/main/kotlin/misk/cloud/aws/environment/AwsInstanceMetadataModule.kt
@@ -6,9 +6,9 @@ import javax.inject.Singleton
 
 /** Retrieves instance metadata for applications running on AWS */
 class AwsInstanceMetadataModule : KAbstractModule() {
-    override fun configure() {
-        bind<InstanceMetadata>()
-                .toProvider(AwsInstanceMetadataProvider::class.java)
-                .`in`(Singleton::class.java)
-    }
+  override fun configure() {
+    bind<InstanceMetadata>()
+        .toProvider(AwsInstanceMetadataProvider::class.java)
+        .`in`(Singleton::class.java)
+  }
 }

--- a/misk/src/main/kotlin/misk/cloud/aws/environment/AwsInstanceMetadataProvider.kt
+++ b/misk/src/main/kotlin/misk/cloud/aws/environment/AwsInstanceMetadataProvider.kt
@@ -6,29 +6,31 @@ import okhttp3.Request
 import javax.inject.Provider
 
 internal class AwsInstanceMetadataProvider(
-        val serverUrl: String = AWS_INSTANCE_METADATA_SERVER
+    val serverUrl: String = AWS_INSTANCE_METADATA_SERVER
 ) : Provider<InstanceMetadata> {
 
-    companion object {
-        val AWS_INSTANCE_METADATA_SERVER = "http://169.254.169.254"
-        val AWS_INSTANCE_METADATA_PATH = "latest/meta-data"
-    }
+  companion object {
+    val AWS_INSTANCE_METADATA_SERVER = "http://169.254.169.254"
+    val AWS_INSTANCE_METADATA_PATH = "latest/meta-data"
+  }
 
-    override fun get(): InstanceMetadata {
-        val instanceName = getMetadata("instance-id")
-        val zone = getMetadata("placement/availability-zone")
-        return InstanceMetadata(instanceName, zone)
-    }
+  override fun get(): InstanceMetadata {
+    val instanceName = getMetadata("instance-id")
+    val zone = getMetadata("placement/availability-zone")
+    return InstanceMetadata(instanceName, zone)
+  }
 
-    private fun getMetadata(metadataCategory: String): String {
-        val httpClient = OkHttpClient()
-        val request = Request.Builder()
-                .get()
-                .url("$serverUrl/$AWS_INSTANCE_METADATA_PATH/$metadataCategory")
-                .build()
+  private fun getMetadata(metadataCategory: String): String {
+    val httpClient = OkHttpClient()
+    val request = Request.Builder()
+        .get()
+        .url("$serverUrl/$AWS_INSTANCE_METADATA_PATH/$metadataCategory")
+        .build()
 
-        val response = httpClient.newCall(request).execute().body()
-        return response?.string()
-                ?: throw IllegalStateException("could not retrieve $metadataCategory")
-    }
+    val response = httpClient.newCall(request)
+        .execute()
+        .body()
+    return response?.string()
+        ?: throw IllegalStateException("could not retrieve $metadataCategory")
+  }
 }

--- a/misk/src/main/kotlin/misk/cloud/gcp/GoogleCloudModule.kt
+++ b/misk/src/main/kotlin/misk/cloud/gcp/GoogleCloudModule.kt
@@ -25,77 +25,88 @@ import javax.inject.Inject
 
 /** Installs support for talking to real GCP services, either direct or via emulator */
 class GoogleCloudModule : KAbstractModule() {
-    override fun configure() {
-        binder().addMultibinderBinding<Service>().to<GoogleCloud>()
+  override fun configure() {
+    binder().addMultibinderBinding<Service>()
+        .to<GoogleCloud>()
+  }
+
+  @Provides
+  @Singleton
+  fun provideServiceCredentials(env: Environment): Credentials =
+      if (env == Environment.DEVELOPMENT) NoCredentials.getInstance()
+      else ServiceAccountCredentials.getApplicationDefault()
+
+  @Provides
+  @Singleton
+  fun provideCloudDatastore(
+      credentials: Credentials,
+      config: DatastoreConfig
+  ): Datastore =
+      DatastoreOptions.newBuilder()
+          .setCredentials(credentials)
+          .setHost(config.transport.host)
+          .setTransportOptions(
+              HttpTransportOptions.newBuilder()
+                  .setConnectTimeout(config.transport.connect_timeout_ms)
+                  .setReadTimeout(config.transport.read_timeout_ms)
+                  .build()
+          )
+          .build()
+          .service
+
+  @Provides
+  @Singleton
+  fun provideCloudStorage(
+      credentials: Credentials,
+      config: StorageConfig
+  ): Storage {
+    if (config.use_local_storage) {
+      val localStorageConfig = config.local_storage
+          ?: throw IllegalArgumentException(
+              "if use_local_storage is true, local_storage.data_dir must be set"
+          )
+
+      val dataDir = localStorageConfig.data_dir
+      require(dataDir.isNotBlank()) {
+        "if use_local_storage is true, local_storage.data_dir must be set"
+      }
+
+      val localStorageRpc = LocalStorageRpc(Paths.get(dataDir))
+      return StorageOptions.newBuilder()
+          .setCredentials(NoCredentials.getInstance())
+          .setServiceRpcFactory { _ -> localStorageRpc }
+          .build()
+          .service
+    } else {
+      return StorageOptions.newBuilder()
+          .setCredentials(credentials)
+          .setHost(config.transport.host)
+          .setTransportOptions(
+              HttpTransportOptions.newBuilder()
+                  .setConnectTimeout(config.transport.connect_timeout_ms)
+                  .setReadTimeout(config.transport.read_timeout_ms)
+                  .build()
+          )
+          .build()
+          .service
     }
-
-    @Provides
-    @Singleton
-    fun provideServiceCredentials(env: Environment): Credentials =
-            if (env == Environment.DEVELOPMENT) NoCredentials.getInstance()
-            else ServiceAccountCredentials.getApplicationDefault()
-
-    @Provides
-    @Singleton
-    fun provideCloudDatastore(credentials: Credentials, config: DatastoreConfig): Datastore =
-            DatastoreOptions.newBuilder()
-                    .setCredentials(credentials)
-                    .setHost(config.transport.host)
-                    .setTransportOptions(HttpTransportOptions.newBuilder()
-                            .setConnectTimeout(config.transport.connect_timeout_ms)
-                            .setReadTimeout(config.transport.read_timeout_ms)
-                            .build())
-                    .build()
-                    .service
-
-    @Provides
-    @Singleton
-    fun provideCloudStorage(credentials: Credentials, config: StorageConfig): Storage {
-        if (config.use_local_storage) {
-            val localStorageConfig = config.local_storage
-                    ?: throw IllegalArgumentException(
-                            "if use_local_storage is true, local_storage.data_dir must be set"
-                    )
-
-            val dataDir = localStorageConfig.data_dir
-            require(dataDir.isNotBlank()) {
-                "if use_local_storage is true, local_storage.data_dir must be set"
-            }
-
-            val localStorageRpc = LocalStorageRpc(Paths.get(dataDir))
-            return StorageOptions.newBuilder()
-                    .setCredentials(NoCredentials.getInstance())
-                    .setServiceRpcFactory { _ -> localStorageRpc }
-                    .build()
-                    .service
-        } else {
-            return StorageOptions.newBuilder()
-                    .setCredentials(credentials)
-                    .setHost(config.transport.host)
-                    .setTransportOptions(HttpTransportOptions.newBuilder()
-                            .setConnectTimeout(config.transport.connect_timeout_ms)
-                            .setReadTimeout(config.transport.read_timeout_ms)
-                            .build())
-                    .build()
-                    .service
-        }
-    }
+  }
 }
 
 /** Logs cloud configuration on startup */
 private class GoogleCloud @Inject internal constructor(
-        private val datastore: Datastore,
-        private val storage: Storage
+    private val datastore: Datastore,
+    private val storage: Storage
 ) : AbstractIdleService() {
-    override fun startUp() {
-        log.info { "running as project ${datastore.options.projectId}" }
-        log.info { "connected to datastore on ${datastore.options.host}" }
-        log.info { "connected to GCS as ${storage.options.rpc.javaClass.simpleName} on ${storage.options.host}" }
-    }
+  override fun startUp() {
+    log.info { "running as project ${datastore.options.projectId}" }
+    log.info { "connected to datastore on ${datastore.options.host}" }
+    log.info { "connected to GCS as ${storage.options.rpc.javaClass.simpleName} on ${storage.options.host}" }
+  }
 
-    override fun shutDown() {}
+  override fun shutDown() {}
 
-    companion object {
-        private val log = getLogger<GoogleCloud>()
-    }
+  companion object {
+    private val log = getLogger<GoogleCloud>()
+  }
 }

--- a/misk/src/main/kotlin/misk/cloud/gcp/TransportConfig.kt
+++ b/misk/src/main/kotlin/misk/cloud/gcp/TransportConfig.kt
@@ -2,7 +2,7 @@ package misk.cloud.gcp
 
 /** Transport configuration for GCP services. */
 data class TransportConfig(
-        val connect_timeout_ms: Int = -1,
-        val read_timeout_ms: Int = -1,
-        val host: String? = null
+    val connect_timeout_ms: Int = -1,
+    val read_timeout_ms: Int = -1,
+    val host: String? = null
 )

--- a/misk/src/main/kotlin/misk/cloud/gcp/datastore/DatastoreConfig.kt
+++ b/misk/src/main/kotlin/misk/cloud/gcp/datastore/DatastoreConfig.kt
@@ -5,5 +5,5 @@ import misk.config.Config
 
 /** Configuration for talking to Google datastore */
 data class DatastoreConfig(
-        val transport: TransportConfig = TransportConfig()
+    val transport: TransportConfig = TransportConfig()
 ) : Config

--- a/misk/src/main/kotlin/misk/cloud/gcp/datastore/DatastoreExtensions.kt
+++ b/misk/src/main/kotlin/misk/cloud/gcp/datastore/DatastoreExtensions.kt
@@ -12,18 +12,32 @@ fun Blob.toByteString(): ByteString = ByteString.of(asReadOnlyByteBuffer())
 
 fun Entity.getByteString(name: String) = getBlob(name).toByteString()
 
-fun <T> Entity.getProto(name: String, protoAdapter: ProtoAdapter<T>): T =
-        protoAdapter.decode(getByteString(name))
+fun <T> Entity.getProto(
+    name: String,
+    protoAdapter: ProtoAdapter<T>
+): T =
+    protoAdapter.decode(getByteString(name))
 
-fun Entity.Builder.set(name: String, bytes: ByteString) : Entity.Builder =
-        set(name, Blob.copyFrom(bytes.asByteBuffer()))
+fun Entity.Builder.set(
+    name: String,
+    bytes: ByteString
+): Entity.Builder =
+    set(name, Blob.copyFrom(bytes.asByteBuffer()))
 
 fun <T> QueryResults<T>.asList(): List<T> = asSequence().toList()
 
 object Keys {
-    fun newKey(projectId: String, kind: String, id: Long): Key =
-            Key.newBuilder(projectId, kind, id).build()
+  fun newKey(
+      projectId: String,
+      kind: String,
+      id: Long
+  ): Key =
+      Key.newBuilder(projectId, kind, id).build()
 
-    fun newKey(projectId: String, kind: String, name: String): Key =
-            Key.newBuilder(projectId, kind, name).build()
+  fun newKey(
+      projectId: String,
+      kind: String,
+      name: String
+  ): Key =
+      Key.newBuilder(projectId, kind, name).build()
 }

--- a/misk/src/main/kotlin/misk/cloud/gcp/environment/GcpInstanceMetadataModule.kt
+++ b/misk/src/main/kotlin/misk/cloud/gcp/environment/GcpInstanceMetadataModule.kt
@@ -6,9 +6,9 @@ import javax.inject.Singleton
 
 /** Retrieves instance metadata for applications running on GCP */
 class GcpInstanceMetadataModule : KAbstractModule() {
-    override fun configure() {
-        bind<InstanceMetadata>()
-                .toProvider(GcpInstanceMetadataProvider::class.java)
-                .`in`(Singleton::class.java)
-    }
+  override fun configure() {
+    bind<InstanceMetadata>()
+        .toProvider(GcpInstanceMetadataProvider::class.java)
+        .`in`(Singleton::class.java)
+  }
 }

--- a/misk/src/main/kotlin/misk/cloud/gcp/environment/GcpInstanceMetadataProvider.kt
+++ b/misk/src/main/kotlin/misk/cloud/gcp/environment/GcpInstanceMetadataProvider.kt
@@ -7,34 +7,37 @@ import javax.inject.Inject
 import javax.inject.Provider
 
 internal class GcpInstanceMetadataProvider @Inject internal constructor(
-        val serverUrl: String = GCP_INSTANCE_METADATA_SERVER
+    val serverUrl: String = GCP_INSTANCE_METADATA_SERVER
 ) : Provider<InstanceMetadata> {
 
-    companion object {
-        val GCP_INSTANCE_METADATA_SERVER = "http://metadata.google.internal"
-        val GCP_INSTANCE_METADATA_PATH = "computeMetadata/v1/instance"
+  companion object {
+    val GCP_INSTANCE_METADATA_SERVER = "http://metadata.google.internal"
+    val GCP_INSTANCE_METADATA_PATH = "computeMetadata/v1/instance"
+  }
+
+  override fun get(): InstanceMetadata {
+    var instanceName = getMetadata("name")
+    if (instanceName.isBlank()) {
+      instanceName = getMetadata("id")
     }
 
-    override fun get(): InstanceMetadata {
-        var instanceName = getMetadata("name")
-        if (instanceName.isBlank()) {
-            instanceName = getMetadata("id")
-        }
+    val zone = getMetadata("zone").split('/')
+        .last()
+    return InstanceMetadata(instanceName, zone)
+  }
 
-        val zone = getMetadata("zone").split('/').last()
-        return InstanceMetadata(instanceName, zone)
-    }
+  fun getMetadata(metadataCategory: String): String {
+    val httpClient = OkHttpClient()
+    val request = Request.Builder()
+        .get()
+        .url("$serverUrl/$GCP_INSTANCE_METADATA_PATH/$metadataCategory")
+        .build()
 
-    fun getMetadata(metadataCategory: String): String {
-        val httpClient = OkHttpClient()
-        val request = Request.Builder()
-                .get()
-                .url("$serverUrl/$GCP_INSTANCE_METADATA_PATH/$metadataCategory")
-                .build()
-
-        val response = httpClient.newCall(request).execute().body()
-        return response?.string()
-                ?: throw IllegalStateException("could not retrieve $metadataCategory")
-    }
+    val response = httpClient.newCall(request)
+        .execute()
+        .body()
+    return response?.string()
+        ?: throw IllegalStateException("could not retrieve $metadataCategory")
+  }
 
 }

--- a/misk/src/main/kotlin/misk/cloud/gcp/security/keys/GcpKeyManagementModule.kt
+++ b/misk/src/main/kotlin/misk/cloud/gcp/security/keys/GcpKeyManagementModule.kt
@@ -11,15 +11,16 @@ import misk.security.keys.KeyService
 import javax.inject.Singleton
 
 class GcpKeyManagementModule : KAbstractModule() {
-    override fun configure() {
-        bind<KeyService>().to<GcpKeyService>().asSingleton()
-    }
+  override fun configure() {
+    bind<KeyService>().to<GcpKeyService>()
+        .asSingleton()
+  }
 
-    @Provides
-    @Singleton
-    fun providesKms(@AppName appName: String): CloudKMS =
-            CloudKMS.Builder(newTrustedTransport(), JacksonFactory(), null)
-                    .setApplicationName(appName)
-                    .build()
+  @Provides
+  @Singleton
+  fun providesKms(@AppName appName: String): CloudKMS =
+      CloudKMS.Builder(newTrustedTransport(), JacksonFactory(), null)
+          .setApplicationName(appName)
+          .build()
 
 }

--- a/misk/src/main/kotlin/misk/cloud/gcp/security/keys/GcpKeyService.kt
+++ b/misk/src/main/kotlin/misk/cloud/gcp/security/keys/GcpKeyService.kt
@@ -9,26 +9,37 @@ import java.nio.ByteBuffer
 import javax.inject.Inject
 
 internal class GcpKeyService @Inject internal constructor(
-        kms: CloudKMS,
-        val config: GcpKmsConfig
+    kms: CloudKMS,
+    val config: GcpKmsConfig
 ) : KeyService {
-    val cryptoKeys = kms.projects().locations().keyRings().cryptoKeys()
+  val cryptoKeys = kms.projects()
+      .locations()
+      .keyRings()
+      .cryptoKeys()
 
-    override fun encrypt(keyAlias: String, plainText: ByteString): ByteString {
-        val keyLocation = config.key_locations[keyAlias]
-                ?: throw IllegalArgumentException("no location for keyAlias $keyAlias")
-        val resource = "projects/${config.project_id}/${keyLocation.path}"
-        val request = EncryptRequest().encodePlaintext(plainText.toByteArray())
-        val response = cryptoKeys.encrypt(resource, request).execute()
-        return ByteString.of(ByteBuffer.wrap(response.decodeCiphertext()))
-    }
+  override fun encrypt(
+      keyAlias: String,
+      plainText: ByteString
+  ): ByteString {
+    val keyLocation = config.key_locations[keyAlias]
+        ?: throw IllegalArgumentException("no location for keyAlias $keyAlias")
+    val resource = "projects/${config.project_id}/${keyLocation.path}"
+    val request = EncryptRequest().encodePlaintext(plainText.toByteArray())
+    val response = cryptoKeys.encrypt(resource, request)
+        .execute()
+    return ByteString.of(ByteBuffer.wrap(response.decodeCiphertext()))
+  }
 
-    override fun decrypt(keyAlias: String, cipherText: ByteString): ByteString {
-        val keyLocation = config.key_locations[keyAlias]
-                ?: throw IllegalArgumentException("no location for key $keyAlias")
-        val resource = "projects/${config.project_id}/${keyLocation.path}"
-        val request = DecryptRequest().encodeCiphertext(cipherText.toByteArray())
-        val response = cryptoKeys.decrypt(resource, request).execute()
-        return ByteString.of(ByteBuffer.wrap(response.decodePlaintext()))
-    }
+  override fun decrypt(
+      keyAlias: String,
+      cipherText: ByteString
+  ): ByteString {
+    val keyLocation = config.key_locations[keyAlias]
+        ?: throw IllegalArgumentException("no location for key $keyAlias")
+    val resource = "projects/${config.project_id}/${keyLocation.path}"
+    val request = DecryptRequest().encodeCiphertext(cipherText.toByteArray())
+    val response = cryptoKeys.decrypt(resource, request)
+        .execute()
+    return ByteString.of(ByteBuffer.wrap(response.decodePlaintext()))
+  }
 }

--- a/misk/src/main/kotlin/misk/cloud/gcp/security/keys/GcpKmsConfig.kt
+++ b/misk/src/main/kotlin/misk/cloud/gcp/security/keys/GcpKmsConfig.kt
@@ -3,10 +3,14 @@ package misk.cloud.gcp.security.keys
 import misk.config.Config
 
 data class GcpKmsConfig(
-        val project_id: String,
-        val key_locations: Map<String, GcpKeyLocation>
+    val project_id: String,
+    val key_locations: Map<String, GcpKeyLocation>
 ) : Config
 
-data class GcpKeyLocation(val location: String, val key_ring: String, val key_name: String) {
-    val path = "locations/$location/keyRings/$key_ring/cryptoKeys/$key_name"
+data class GcpKeyLocation(
+    val location: String,
+    val key_ring: String,
+    val key_name: String
+) {
+  val path = "locations/$location/keyRings/$key_ring/cryptoKeys/$key_name"
 }

--- a/misk/src/main/kotlin/misk/cloud/gcp/storage/BaseCustomStorageRpc.kt
+++ b/misk/src/main/kotlin/misk/cloud/gcp/storage/BaseCustomStorageRpc.kt
@@ -17,152 +17,203 @@ import com.google.cloud.storage.spi.v1.StorageRpc
  * only those minimal methods requiring implementation are left abstract.
  */
 abstract class BaseCustomStorageRpc : StorageRpc {
-    override fun get(bucket: Bucket, options: Map<StorageRpc.Option, *>): Bucket? {
-        throw UnsupportedOperationException()
-    }
+  override fun get(
+      bucket: Bucket,
+      options: Map<StorageRpc.Option, *>
+  ): Bucket? {
+    throw UnsupportedOperationException()
+  }
 
-    override fun patch(bucket: Bucket, options: Map<StorageRpc.Option, *>): Bucket? {
-        throw UnsupportedOperationException()
-    }
+  override fun patch(
+      bucket: Bucket,
+      options: Map<StorageRpc.Option, *>
+  ): Bucket? {
+    throw UnsupportedOperationException()
+  }
 
-    override fun patch(obj: StorageObject, options: Map<StorageRpc.Option, *>): StorageObject? {
-        throw UnsupportedOperationException()
-    }
+  override fun patch(
+      obj: StorageObject,
+      options: Map<StorageRpc.Option, *>
+  ): StorageObject? {
+    throw UnsupportedOperationException()
+  }
 
-    override fun delete(bucket: Bucket, options: Map<StorageRpc.Option, *>): Boolean {
-        throw UnsupportedOperationException()
-    }
+  override fun delete(
+      bucket: Bucket,
+      options: Map<StorageRpc.Option, *>
+  ): Boolean {
+    throw UnsupportedOperationException()
+  }
 
-    override fun create(bucket: Bucket, options: Map<StorageRpc.Option, *>): Bucket {
-        throw UnsupportedOperationException()
-    }
+  override fun create(
+      bucket: Bucket,
+      options: Map<StorageRpc.Option, *>
+  ): Bucket {
+    throw UnsupportedOperationException()
+  }
 
-    override fun list(options: Map<StorageRpc.Option, *>?): Tuple<String, Iterable<Bucket>> {
-        throw UnsupportedOperationException()
-    }
+  override fun list(options: Map<StorageRpc.Option, *>?): Tuple<String, Iterable<Bucket>> {
+    throw UnsupportedOperationException()
+  }
 
-    override fun createAcl(acl: BucketAccessControl?, options: Map<StorageRpc.Option, *>?)
-            : BucketAccessControl {
-        throw UnsupportedOperationException()
-    }
+  override fun createAcl(
+      acl: BucketAccessControl?,
+      options: Map<StorageRpc.Option, *>?
+  )
+      : BucketAccessControl {
+    throw UnsupportedOperationException()
+  }
 
-    override fun createAcl(acl: ObjectAccessControl?): ObjectAccessControl {
-        throw UnsupportedOperationException()
-    }
+  override fun createAcl(acl: ObjectAccessControl?): ObjectAccessControl {
+    throw UnsupportedOperationException()
+  }
 
-    override fun getIamPolicy(bucket: String?, options: Map<StorageRpc.Option, *>?): Policy {
-        throw UnsupportedOperationException()
-    }
+  override fun getIamPolicy(
+      bucket: String?,
+      options: Map<StorageRpc.Option, *>?
+  ): Policy {
+    throw UnsupportedOperationException()
+  }
 
-    override fun patchAcl(acl: BucketAccessControl?, options: Map<StorageRpc.Option, *>?)
-            : BucketAccessControl {
-        throw UnsupportedOperationException()
-    }
+  override fun patchAcl(
+      acl: BucketAccessControl?,
+      options: Map<StorageRpc.Option, *>?
+  )
+      : BucketAccessControl {
+    throw UnsupportedOperationException()
+  }
 
-    override fun patchAcl(acl: ObjectAccessControl?): ObjectAccessControl {
-        throw UnsupportedOperationException()
-    }
+  override fun patchAcl(acl: ObjectAccessControl?): ObjectAccessControl {
+    throw UnsupportedOperationException()
+  }
 
-    override fun getServiceAccount(projectId: String?): ServiceAccount {
-        throw UnsupportedOperationException()
-    }
+  override fun getServiceAccount(projectId: String?): ServiceAccount {
+    throw UnsupportedOperationException()
+  }
 
-    override fun getAcl(
-            bucket: String?,
-            entity: String?,
-            options: Map<StorageRpc.Option, *>?
-    ): BucketAccessControl {
-        throw UnsupportedOperationException()
-    }
+  override fun getAcl(
+      bucket: String?,
+      entity: String?,
+      options: Map<StorageRpc.Option, *>?
+  ): BucketAccessControl {
+    throw UnsupportedOperationException()
+  }
 
-    override fun getAcl(
-            bucket: String?,
-            obj: String?,
-            generation: Long?,
-            entity: String?
-    ): ObjectAccessControl {
-        throw UnsupportedOperationException()
-    }
+  override fun getAcl(
+      bucket: String?,
+      obj: String?,
+      generation: Long?,
+      entity: String?
+  ): ObjectAccessControl {
+    throw UnsupportedOperationException()
+  }
 
-    override fun listDefaultAcls(bucket: String?): MutableList<ObjectAccessControl> {
-        throw UnsupportedOperationException()
-    }
+  override fun listDefaultAcls(bucket: String?): MutableList<ObjectAccessControl> {
+    throw UnsupportedOperationException()
+  }
 
-    override fun testIamPermissions(
-            bucket: String,
-            permissions: List<String>,
-            options: Map<StorageRpc.Option, *>
-    ): TestIamPermissionsResponse {
-        throw UnsupportedOperationException()
-    }
+  override fun testIamPermissions(
+      bucket: String,
+      permissions: List<String>,
+      options: Map<StorageRpc.Option, *>
+  ): TestIamPermissionsResponse {
+    throw UnsupportedOperationException()
+  }
 
-    override fun continueRewrite(previousResponse: StorageRpc.RewriteResponse)
-            : StorageRpc.RewriteResponse {
-        throw UnsupportedOperationException()
-    }
+  override fun continueRewrite(previousResponse: StorageRpc.RewriteResponse)
+      : StorageRpc.RewriteResponse {
+    throw UnsupportedOperationException()
+  }
 
-    override fun createBatch(): RpcBatch {
-        throw UnsupportedOperationException()
-    }
+  override fun createBatch(): RpcBatch {
+    throw UnsupportedOperationException()
+  }
 
-    override fun createNotification(bucket: String?, notification: Notification?): Notification {
-        throw UnsupportedOperationException()
-    }
+  override fun createNotification(
+      bucket: String?,
+      notification: Notification?
+  ): Notification {
+    throw UnsupportedOperationException()
+  }
 
-    override fun listAcls(bucket: String?,
-            options: Map<StorageRpc.Option, *>?): List<BucketAccessControl> {
-        throw UnsupportedOperationException()
-    }
+  override fun listAcls(
+      bucket: String?,
+      options: Map<StorageRpc.Option, *>?
+  ): List<BucketAccessControl> {
+    throw UnsupportedOperationException()
+  }
 
-    override fun listAcls(
-            bucket: String?,
-            obj: String?,
-            generation: Long?
-    ): List<ObjectAccessControl> {
-        throw UnsupportedOperationException()
-    }
+  override fun listAcls(
+      bucket: String?,
+      obj: String?,
+      generation: Long?
+  ): List<ObjectAccessControl> {
+    throw UnsupportedOperationException()
+  }
 
-    override fun getDefaultAcl(bucket: String?, entity: String?): ObjectAccessControl {
-        throw UnsupportedOperationException()
-    }
+  override fun getDefaultAcl(
+      bucket: String?,
+      entity: String?
+  ): ObjectAccessControl {
+    throw UnsupportedOperationException()
+  }
 
-    override fun deleteAcl(bucket: String?, entity: String?,
-            options: Map<StorageRpc.Option, *>?): Boolean {
-        throw UnsupportedOperationException()
-    }
+  override fun deleteAcl(
+      bucket: String?,
+      entity: String?,
+      options: Map<StorageRpc.Option, *>?
+  ): Boolean {
+    throw UnsupportedOperationException()
+  }
 
-    override fun deleteAcl(bucket: String?, `object`: String?, generation: Long?,
-            entity: String?): Boolean {
-        throw UnsupportedOperationException()
-    }
+  override fun deleteAcl(
+      bucket: String?,
+      `object`: String?,
+      generation: Long?,
+      entity: String?
+  ): Boolean {
+    throw UnsupportedOperationException()
+  }
 
-    override fun compose(sources: Iterable<StorageObject>?, target: StorageObject?,
-            targetOptions: Map<StorageRpc.Option, *>?): StorageObject {
-        throw UnsupportedOperationException()
-    }
+  override fun compose(
+      sources: Iterable<StorageObject>?,
+      target: StorageObject?,
+      targetOptions: Map<StorageRpc.Option, *>?
+  ): StorageObject {
+    throw UnsupportedOperationException()
+  }
 
-    override fun setIamPolicy(bucket: String?, policy: Policy?,
-            options: Map<StorageRpc.Option, *>?): Policy {
-        throw UnsupportedOperationException()
-    }
+  override fun setIamPolicy(
+      bucket: String?,
+      policy: Policy?,
+      options: Map<StorageRpc.Option, *>?
+  ): Policy {
+    throw UnsupportedOperationException()
+  }
 
-    override fun deleteDefaultAcl(bucket: String?, entity: String?): Boolean {
-        throw UnsupportedOperationException()
-    }
+  override fun deleteDefaultAcl(
+      bucket: String?,
+      entity: String?
+  ): Boolean {
+    throw UnsupportedOperationException()
+  }
 
-    override fun patchDefaultAcl(acl: ObjectAccessControl?): ObjectAccessControl {
-        throw UnsupportedOperationException()
-    }
+  override fun patchDefaultAcl(acl: ObjectAccessControl?): ObjectAccessControl {
+    throw UnsupportedOperationException()
+  }
 
-    override fun createDefaultAcl(acl: ObjectAccessControl?): ObjectAccessControl {
-        throw UnsupportedOperationException()
-    }
+  override fun createDefaultAcl(acl: ObjectAccessControl?): ObjectAccessControl {
+    throw UnsupportedOperationException()
+  }
 
-    override fun listNotifications(bucket: String?): List<Notification> {
-        throw UnsupportedOperationException()
-    }
+  override fun listNotifications(bucket: String?): List<Notification> {
+    throw UnsupportedOperationException()
+  }
 
-    override fun deleteNotification(bucket: String?, notification: String?): Boolean {
-        throw UnsupportedOperationException()
-    }
+  override fun deleteNotification(
+      bucket: String?,
+      notification: String?
+  ): Boolean {
+    throw UnsupportedOperationException()
+  }
 }

--- a/misk/src/main/kotlin/misk/cloud/gcp/storage/LocalStorageRpc.kt
+++ b/misk/src/main/kotlin/misk/cloud/gcp/storage/LocalStorageRpc.kt
@@ -92,483 +92,535 @@ import kotlin.streams.asSequence
  * as the etag value.
  *
  */
-class LocalStorageRpc(root: Path, moshi: Moshi = Moshi.Builder().build()) : BaseCustomStorageRpc() {
-    // Handles in-process synchronization; cross-process synchronization is handled by file locks
-    private val internalLock = ReentrantReadWriteLock()
-    private val locksRoot = root.resolve("locks")
-    private val metadataRoot = root.resolve("metadata")
-    private val contentRoot = root.resolve("content")
-    private val uploadRoot = root.resolve("uploads")
-    private val metadataAdapter = moshi.adapter<BlobMetadata>()
-    private val uploads = mutableMapOf<String, Upload>()
+class LocalStorageRpc(
+    root: Path,
+    moshi: Moshi = Moshi.Builder().build()
+) : BaseCustomStorageRpc() {
+  // Handles in-process synchronization; cross-process synchronization is handled by file locks
+  private val internalLock = ReentrantReadWriteLock()
+  private val locksRoot = root.resolve("locks")
+  private val metadataRoot = root.resolve("metadata")
+  private val contentRoot = root.resolve("content")
+  private val uploadRoot = root.resolve("uploads")
+  private val metadataAdapter = moshi.adapter<BlobMetadata>()
+  private val uploads = mutableMapOf<String, Upload>()
 
-    override fun create(
-            obj: StorageObject,
-            content: InputStream,
-            options: Map<StorageRpc.Option, *>
-    ): StorageObject? {
-        try {
-            val upload = beginUpload(obj, options)
-            var destOffset: Long = 0
-            val source = Okio.buffer(Okio.source(content))
-            source.forEachBlock(1024) { buffer, bytesRead ->
-                write(upload.id, buffer, 0, destOffset, bytesRead, false)
-                destOffset += bytesRead
-            }
-            endUpload(upload)
+  override fun create(
+      obj: StorageObject,
+      content: InputStream,
+      options: Map<StorageRpc.Option, *>
+  ): StorageObject? {
+    try {
+      val upload = beginUpload(obj, options)
+      var destOffset: Long = 0
+      val source = Okio.buffer(Okio.source(content))
+      source.forEachBlock(1024) { buffer, bytesRead ->
+        write(upload.id, buffer, 0, destOffset, bytesRead, false)
+        destOffset += bytesRead
+      }
+      endUpload(upload)
 
-            return upload.targetMetadata.toStorageObject(obj.bucket, obj.name, destOffset)
-        } catch (e: IOException) {
-            throw StorageException(e)
-        }
-    }
-
-    override fun list(
-            bucket: String,
-            options: Map<StorageRpc.Option, *>
-    ): Tuple<String, Iterable<StorageObject>> {
-        try {
-            val delimiter = options[StorageRpc.Option.DELIMITER]?.toString()
-            val prefix = options[StorageRpc.Option.PREFIX]?.toString()?.trimStart('/') ?: ""
-            val prefixElements = prefix.split(delimiter ?: "/").toTypedArray()
-            val parentFolderElements = prefixElements.dropLast(1).toTypedArray()
-            val parentMetadataFolder =
-                    metadataRoot.resolve(Paths.get(bucket, *parentFolderElements))
-            val bucketRoot = metadataRoot.resolve(Paths.get(bucket))
-            val filePrefix = prefixElements.last().trim()
-
-            val (folderPaths, filePaths) = if (delimiter != null) {
-                // We want to find just the files + subfolders in the current folder
-                Files.list(parentMetadataFolder).asSequence()
-                        .filter {
-                            filePrefix.isEmpty() || it.fileName.toString().startsWith(filePrefix)
-                        }
-                        .partition { Files.isDirectory(it) }
-            } else {
-                // We want to find all of the files beneath this sub-folder
-                listOf<Path>() to parentMetadataFolder.listRecursively().filter {
-                    filePrefix.isEmpty() || it.getName(parentMetadataFolder.nameCount).toString()
-                            .startsWith(filePrefix)
-                }
-            }
-
-            val folders = folderPaths
-                    .map { bucketRoot.toBlobId(it) }
-                    .map {
-                        StorageObject()
-                                .setBucket(it.bucket)
-                                .setName(it.name)
-                    }
-
-            val files = filePaths
-                    .map { bucketRoot.toBlobId(it) }
-                    .mapNotNull { blobId ->
-                        withReadLock(blobId) {
-                            readMetadata(blobId)?.let {
-                                val contentPath = contentRoot.resolve(blobId.toPath(it.generation))
-                                val contentSize = getContentSize(contentPath)
-                                it.toStorageObject(blobId, contentSize)
-                            }
-                        }
-                    }
-
-            return Tuple.of("", files + folders)
-        } catch (e: IOException) {
-            throw StorageException(e)
-        }
-    }
-
-    override fun get(obj: StorageObject, options: Map<StorageRpc.Option, *>): StorageObject? = try {
-        withReadLock(obj.blobId) {
-            getMetadataForReading(obj.blobId, options)?.let { metadata ->
-                val contentPath = contentRoot.resolve(obj.blobId.toPath(metadata.generation))
-                val size = getContentSize(contentPath)
-                metadata.toStorageObject(obj.bucket, obj.name, size)
-            }
-        }
+      return upload.targetMetadata.toStorageObject(obj.bucket, obj.name, destOffset)
     } catch (e: IOException) {
-        throw StorageException(e)
+      throw StorageException(e)
     }
+  }
 
-    override fun delete(obj: StorageObject, options: Map<StorageRpc.Option, *>): Boolean {
-        try {
-            return withWriteLock(obj.blobId) {
-                // Check metadata constraints. This will throw a StorageException if a
-                // constraint fails, which we catch and turn into false return code
-                getMetadataForReading(obj.blobId, options)?.let {
-                    // NB(mmihic): Delete metadata first, this makes the contents inaccessible
-                    // even if the content file is left in place
-                    Files.deleteIfExists(metadataRoot.resolve(obj.blobId.toPath()))
-                    Files.deleteIfExists(contentRoot.resolve(obj.blobId.toPath(it.generation)))
-                } ?: false
+  override fun list(
+      bucket: String,
+      options: Map<StorageRpc.Option, *>
+  ): Tuple<String, Iterable<StorageObject>> {
+    try {
+      val delimiter = options[StorageRpc.Option.DELIMITER]?.toString()
+      val prefix = options[StorageRpc.Option.PREFIX]?.toString()?.trimStart('/') ?: ""
+      val prefixElements = prefix.split(delimiter ?: "/")
+          .toTypedArray()
+      val parentFolderElements = prefixElements.dropLast(1)
+          .toTypedArray()
+      val parentMetadataFolder =
+          metadataRoot.resolve(Paths.get(bucket, *parentFolderElements))
+      val bucketRoot = metadataRoot.resolve(Paths.get(bucket))
+      val filePrefix = prefixElements.last()
+          .trim()
+
+      val (folderPaths, filePaths) = if (delimiter != null) {
+        // We want to find just the files + subfolders in the current folder
+        Files.list(parentMetadataFolder)
+            .asSequence()
+            .filter {
+              filePrefix.isEmpty() || it.fileName.toString().startsWith(filePrefix)
             }
-        } catch (e: StorageException) {
-            // One of the metadata constraint checks failed
-            return false
-        } catch (e: IOException) {
-            throw StorageException(e)
+            .partition { Files.isDirectory(it) }
+      } else {
+        // We want to find all of the files beneath this sub-folder
+        listOf<Path>() to parentMetadataFolder.listRecursively().filter {
+          filePrefix.isEmpty() || it.getName(parentMetadataFolder.nameCount).toString()
+              .startsWith(filePrefix)
         }
-    }
+      }
 
-    override fun load(obj: StorageObject, options: Map<StorageRpc.Option, *>): ByteArray = try {
-        withReadLock(obj.blobId) {
-            val metadata = getMetadataForReading(obj.blobId, options)
-                    ?: throw StorageException(404, "${obj.blobId.fullName} not found")
+      val folders = folderPaths
+          .map { bucketRoot.toBlobId(it) }
+          .map {
+            StorageObject()
+                .setBucket(it.bucket)
+                .setName(it.name)
+          }
 
-            Files.readAllBytes(contentRoot.resolve(obj.blobId.toPath(metadata.generation)))
-        }
+      val files = filePaths
+          .map { bucketRoot.toBlobId(it) }
+          .mapNotNull { blobId ->
+            withReadLock(blobId) {
+              readMetadata(blobId)?.let {
+                val contentPath = contentRoot.resolve(blobId.toPath(it.generation))
+                val contentSize = getContentSize(contentPath)
+                it.toStorageObject(blobId, contentSize)
+              }
+            }
+          }
+
+      return Tuple.of("", files + folders)
     } catch (e: IOException) {
-        throw StorageException(e)
+      throw StorageException(e)
     }
+  }
 
-    override fun read(
-            from: StorageObject,
-            options: Map<StorageRpc.Option, *>,
-            zposition: Long,
-            zbytes: Int
-    ): Tuple<String, ByteArray> = try {
-        withReadLock(from.blobId) {
-            val metadata = getMetadataForReading(from.blobId, options)
-                    ?: throw StorageException(404, "${from.blobId.fullName} not found")
+  override fun get(
+      obj: StorageObject,
+      options: Map<StorageRpc.Option, *>
+  ): StorageObject? = try {
+    withReadLock(obj.blobId) {
+      getMetadataForReading(obj.blobId, options)?.let { metadata ->
+        val contentPath = contentRoot.resolve(obj.blobId.toPath(metadata.generation))
+        val size = getContentSize(contentPath)
+        metadata.toStorageObject(obj.bucket, obj.name, size)
+      }
+    }
+  } catch (e: IOException) {
+    throw StorageException(e)
+  }
 
-            val contentPath = contentRoot.resolve(from.blobId.toPath(metadata.generation))
-            val contentChannel = Files.newByteChannel(contentPath, READ)
-            val contents = contentChannel.use {
-                val toRead = Math.min((it.size() - zposition).toInt(), zbytes)
-                val bytes = ByteArray(toRead)
-                it.position(zposition)
-                it.read(ByteBuffer.wrap(bytes))
-                bytes
-            }
-
-            Tuple.of(metadata.generation.toString(), contents)
-        }
+  override fun delete(
+      obj: StorageObject,
+      options: Map<StorageRpc.Option, *>
+  ): Boolean {
+    try {
+      return withWriteLock(obj.blobId) {
+        // Check metadata constraints. This will throw a StorageException if a
+        // constraint fails, which we catch and turn into false return code
+        getMetadataForReading(obj.blobId, options)?.let {
+          // NB(mmihic): Delete metadata first, this makes the contents inaccessible
+          // even if the content file is left in place
+          Files.deleteIfExists(metadataRoot.resolve(obj.blobId.toPath()))
+          Files.deleteIfExists(contentRoot.resolve(obj.blobId.toPath(it.generation)))
+        } ?: false
+      }
+    } catch (e: StorageException) {
+      // One of the metadata constraint checks failed
+      return false
     } catch (e: IOException) {
-        throw StorageException(e)
+      throw StorageException(e)
     }
+  }
 
-    override fun open(obj: StorageObject, options: Map<StorageRpc.Option, *>): String =
-            beginUpload(obj, options).id
+  override fun load(
+      obj: StorageObject,
+      options: Map<StorageRpc.Option, *>
+  ): ByteArray = try {
+    withReadLock(obj.blobId) {
+      val metadata = getMetadataForReading(obj.blobId, options)
+          ?: throw StorageException(404, "${obj.blobId.fullName} not found")
 
-    override fun write(
-            uploadId: String,
-            toWrite: ByteArray,
-            toWriteOffset: Int,
-            destOffset: Long,
-            length: Int,
-            last: Boolean
-    ) {
-        try {
-            val upload = continueUpload(uploadId, toWrite, toWriteOffset, destOffset, length)
-            if (last) {
-                endUpload(upload)
-            }
-        } catch (e: IOException) {
-            throw StorageException(e)
-        }
+      Files.readAllBytes(contentRoot.resolve(obj.blobId.toPath(metadata.generation)))
     }
+  } catch (e: IOException) {
+    throw StorageException(e)
+  }
 
-    override fun openRewrite(request: StorageRpc.RewriteRequest): StorageRpc.RewriteResponse {
-        return try {
-            // NB(mmihic): We have to lock both the source and target in deterministic order
-            // regardless of whether they are being used as the source or target, otherwise
-            // we risk running into deadlocks
-            val (source, target) = request.source to request.target
-            val (lock1, lock2) = arrayOf(source.blobId, target.blobId)
-                    .sortedWith(Comparator { b1, b2 -> b1.compareTo(b2) })
+  override fun read(
+      from: StorageObject,
+      options: Map<StorageRpc.Option, *>,
+      zposition: Long,
+      zbytes: Int
+  ): Tuple<String, ByteArray> = try {
+    withReadLock(from.blobId) {
+      val metadata = getMetadataForReading(from.blobId, options)
+          ?: throw StorageException(404, "${from.blobId.fullName} not found")
 
-            withWriteLock(lock1) {
-                withWriteLock(lock2) {
-                    val sourceMetadata = getMetadataForReading(source.blobId, request.sourceOptions)
-                            ?: throw StorageException(404, "${source.blobId.fullName} not found")
-                    val sourceContentFile =
-                            contentRoot.resolve(source.blobId.toPath(sourceMetadata.generation))
+      val contentPath = contentRoot.resolve(from.blobId.toPath(metadata.generation))
+      val contentChannel = Files.newByteChannel(contentPath, READ)
+      val contents = contentChannel.use {
+        val toRead = Math.min((it.size() - zposition).toInt(), zbytes)
+        val bytes = ByteArray(toRead)
+        it.position(zposition)
+        it.read(ByteBuffer.wrap(bytes))
+        bytes
+      }
 
-                    val existingTargetMetadata =
-                            getMetadataForWriting(target.blobId, request.targetOptions)
-                    val newTargetMetadata =
-                            request.target.nextGenerationMetadata(existingTargetMetadata)
-                    val targetContentFile =
-                            contentRoot.resolve(target.blobId.toPath(newTargetMetadata.generation))
-
-                    // Copy from source to a temporary file, then atomically move from the
-                    // temp file into the target target
-                    val tempFile = createTempUploadFile(target.blobId)
-                    Files.copy(sourceContentFile, tempFile, REPLACE_EXISTING)
-                    Files.move(tempFile, targetContentFile, ATOMIC_MOVE, REPLACE_EXISTING)
-                    writeMetadata(target.blobId, newTargetMetadata)
-
-                    existingTargetMetadata?.let {
-                        val oldTargetContentPath =
-                                contentRoot.resolve(target.blobId.toPath(it.generation))
-                        try {
-                            Files.deleteIfExists(oldTargetContentPath)
-                        } catch (_: IOException) {
-                            // This is ok
-                        }
-                    }
-
-                    val sourceContentSize = getContentSize(sourceContentFile)
-                    StorageRpc.RewriteResponse(
-                            request,
-                            request.target,
-                            sourceContentSize,
-                            true,
-                            "token",
-                            sourceContentSize)
-                }
-            }
-        } catch (e: IOException) {
-            throw StorageException(e)
-        }
+      Tuple.of(metadata.generation.toString(), contents)
     }
+  } catch (e: IOException) {
+    throw StorageException(e)
+  }
 
-    private fun writeMetadata(blobId: BlobId, metadata: BlobMetadata) {
-        // NB(mmihic): Must be called with a write lock
-        val metadataJson = metadataAdapter.toJson(metadata).toByteArray()
+  override fun open(
+      obj: StorageObject,
+      options: Map<StorageRpc.Option, *>
+  ): String =
+      beginUpload(obj, options).id
 
-        // Write as a temp file, and atomically move to the final destination. This way
-        // a failure of the process won't correupt the metadata file
-        val tempMetadataPath = uploadRoot.resolve("_metadata").resolve(blobId.toPath())
-        Files.createDirectories(tempMetadataPath.parent)
-        Files.write(tempMetadataPath, metadataJson, CREATE, WRITE, TRUNCATE_EXISTING)
-
-        val metadataPath = metadataRoot.resolve(blobId.toPath())
-        Files.createDirectories(metadataPath.parent)
-        Files.move(tempMetadataPath, metadataPath, ATOMIC_MOVE, REPLACE_EXISTING)
-    }
-
-    private fun readMetadata(blobId: BlobId): BlobMetadata? {
-        // NB(mmihic): Must be called with a read or write lock
-        val metadataPath = metadataRoot.resolve(blobId.toPath())
-        Files.createDirectories(metadataPath.parent)
-
-        return if (Files.exists(metadataPath)) {
-            val metadataContent = String(Files.readAllBytes(metadataPath))
-            metadataAdapter.fromJson(metadataContent)
-        } else null
-    }
-
-    private fun getContentSize(contentPath: Path) = try {
-        Files.newByteChannel(contentPath, READ).use { it.size() }
-    } catch (e: FileNotFoundException) {
-        0L
-    }
-
-    private fun getMetadataForWriting(
-            blobId: BlobId,
-            options: Map<StorageRpc.Option, *>
-    ): BlobMetadata? {
-        val existingMetadata = readMetadata(blobId)
-        options.generationMatch?.let {
-            when {
-                it == 0L && existingMetadata != null ->
-                    throw StorageException(401, "${blobId.fullName} already exists")
-                it != 0L && existingMetadata == null ->
-                    throw StorageException(404, "${blobId.fullName} does not exist")
-                it != 0L && existingMetadata != null && it != existingMetadata.generation ->
-                    throw StorageException(401,
-                            "generation mismatch: ${existingMetadata.generation} != $it")
-                else -> {
-                }
-            }
-        }
-
-        return existingMetadata
-    }
-
-    private fun getMetadataForReading(
-            blobId: BlobId,
-            options: Map<StorageRpc.Option, *>
-    ): BlobMetadata? {
-        val metadata = readMetadata(blobId) ?: return null
-        options.generationMatch?.let {
-            if (metadata.generation != it) {
-                throw StorageException(401, "generation mismatch: ${metadata.generation} != $it")
-            }
-        }
-
-        options.generationNotMatch?.let {
-            if (metadata.generation == it) {
-                throw StorageException(401, "generation mismatch: ${metadata.generation} == $it")
-            }
-        }
-
-        return metadata
-    }
-
-    private fun beginUpload(obj: StorageObject, options: Map<StorageRpc.Option, *>): Upload {
-        try {
-            val newMetadata = withReadLock(obj.blobId) {
-                // Check constraint on existing metadata and return the metadata that will
-                // apply once the upload has completed.
-                obj.nextGenerationMetadata(getMetadataForWriting(obj.blobId, options))
-            }
-
-            // Create a temporary file to hold the upload contents.
-            val uploadId = UUID.randomUUID().toString()
-            val uploadPath = createTempUploadFile(obj.blobId)
-
-            // Save off the upload information for subsequent writes
-            val upload = Upload(uploadId, obj.blobId, uploadPath, newMetadata)
-            internalLock.write {
-                uploads[uploadId] = upload
-            }
-
-            return upload
-        } catch (e: IOException) {
-            throw StorageException(e)
-        }
-    }
-
-    private fun continueUpload(
-            uploadId: String,
-            toWrite: ByteArray,
-            toWriteOffset: Int,
-            destOffset: Long,
-            length: Int
-    ): Upload = try {
-        // Copy bytes into the temporary file for this upload
-        internalLock.read {
-            val upload = uploads[uploadId]
-                    ?: throw StorageException(404, "no such upload $uploadId")
-            val buffer = ByteBuffer.wrap(toWrite, toWriteOffset, length)
-            val ch = Files.newByteChannel(upload.tempFile, CREATE, WRITE)
-            val position = Math.min(destOffset, ch.size())
-            ch.use {
-                it.position(position)
-                it.write(buffer)
-            }
-            upload
-        }
+  override fun write(
+      uploadId: String,
+      toWrite: ByteArray,
+      toWriteOffset: Int,
+      destOffset: Long,
+      length: Int,
+      last: Boolean
+  ) {
+    try {
+      val upload = continueUpload(uploadId, toWrite, toWriteOffset, destOffset, length)
+      if (last) {
+        endUpload(upload)
+      }
     } catch (e: IOException) {
-        throw StorageException(e)
+      throw StorageException(e)
     }
+  }
 
-    private fun endUpload(upload: Upload) {
-        try {
-            internalLock.write {
-                // Clear out the internal upload tracking
-                uploads.remove(upload.blobId.fullName)
+  override fun openRewrite(request: StorageRpc.RewriteRequest): StorageRpc.RewriteResponse {
+    return try {
+      // NB(mmihic): We have to lock both the source and target in deterministic order
+      // regardless of whether they are being used as the source or target, otherwise
+      // we risk running into deadlocks
+      val (source, target) = request.source to request.target
+      val (lock1, lock2) = arrayOf(source.blobId, target.blobId)
+          .sortedWith(Comparator { b1, b2 -> b1.compareTo(b2) })
+
+      withWriteLock(lock1) {
+        withWriteLock(lock2) {
+          val sourceMetadata = getMetadataForReading(source.blobId, request.sourceOptions)
+              ?: throw StorageException(404, "${source.blobId.fullName} not found")
+          val sourceContentFile =
+              contentRoot.resolve(source.blobId.toPath(sourceMetadata.generation))
+
+          val existingTargetMetadata =
+              getMetadataForWriting(target.blobId, request.targetOptions)
+          val newTargetMetadata =
+              request.target.nextGenerationMetadata(existingTargetMetadata)
+          val targetContentFile =
+              contentRoot.resolve(target.blobId.toPath(newTargetMetadata.generation))
+
+          // Copy from source to a temporary file, then atomically move from the
+          // temp file into the target target
+          val tempFile = createTempUploadFile(target.blobId)
+          Files.copy(sourceContentFile, tempFile, REPLACE_EXISTING)
+          Files.move(tempFile, targetContentFile, ATOMIC_MOVE, REPLACE_EXISTING)
+          writeMetadata(target.blobId, newTargetMetadata)
+
+          existingTargetMetadata?.let {
+            val oldTargetContentPath =
+                contentRoot.resolve(target.blobId.toPath(it.generation))
+            try {
+              Files.deleteIfExists(oldTargetContentPath)
+            } catch (_: IOException) {
+              // This is ok
             }
+          }
 
-            withWriteLock(upload.blobId) {
-                // Move the upload file into the content directory tagged with the new generation,
-                // overwriting any version that might've been left by a previously failed uplaod
-                val newGeneration = upload.targetMetadata.generation
-                val newContentPath = contentRoot.resolve(upload.blobId.toPath(newGeneration))
-                Files.createDirectories(newContentPath.parent)
-                Files.move(upload.tempFile, newContentPath, ATOMIC_MOVE, REPLACE_EXISTING)
-
-                // Update the metadata to point to the new generation. If we fail between the
-                // prior step and this one, there is no harm - the new content will have
-                // been laid down but won't be accessible because the metadata doesn't point
-                // to it, and the next upload will overwrite it
-                writeMetadata(upload.blobId, upload.targetMetadata)
-
-                // Delete the content file for the previous generation. If we fail between
-                // the prior step and this one, there is no harm - we'll leave old content
-                // files around, but won't use them since the metadata has advanced. We
-                // could clean these up via a garbage collection process somewhere down the line
-                val oldGeneration = upload.targetMetadata.generation - 1
-                val oldContentPath = contentRoot.resolve(upload.blobId.toPath(oldGeneration))
-                Files.deleteIfExists(oldContentPath)
-            }
-        } catch (e: IOException) {
-            throw StorageException(e)
+          val sourceContentSize = getContentSize(sourceContentFile)
+          StorageRpc.RewriteResponse(
+              request,
+              request.target,
+              sourceContentSize,
+              true,
+              "token",
+              sourceContentSize
+          )
         }
+      }
+    } catch (e: IOException) {
+      throw StorageException(e)
     }
+  }
 
-    private fun createTempUploadFile(blobId: BlobId): Path {
-        val blobPath = blobId.toPath()
-        val uploadFolder = uploadRoot.resolve(blobPath).parent
-        Files.createDirectories(uploadFolder)
+  private fun writeMetadata(
+      blobId: BlobId,
+      metadata: BlobMetadata
+  ) {
+    // NB(mmihic): Must be called with a write lock
+    val metadataJson = metadataAdapter.toJson(metadata)
+        .toByteArray()
 
-        val uploadPath = Files.createTempFile(uploadFolder, blobPath.fileName.toString(), "")
-        Files.createDirectories(uploadPath.parent)
-        return uploadPath
-    }
+    // Write as a temp file, and atomically move to the final destination. This way
+    // a failure of the process won't correupt the metadata file
+    val tempMetadataPath = uploadRoot.resolve("_metadata")
+        .resolve(blobId.toPath())
+    Files.createDirectories(tempMetadataPath.parent)
+    Files.write(tempMetadataPath, metadataJson, CREATE, WRITE, TRUNCATE_EXISTING)
 
-    private fun <T> withReadLock(blobId: BlobId, f: () -> T): T = internalLock.read {
-        withFileLock(blobId, true, f)
-    }
+    val metadataPath = metadataRoot.resolve(blobId.toPath())
+    Files.createDirectories(metadataPath.parent)
+    Files.move(tempMetadataPath, metadataPath, ATOMIC_MOVE, REPLACE_EXISTING)
+  }
 
-    private fun <T> withWriteLock(blobId: BlobId, f: () -> T): T = internalLock.write {
-        withFileLock(blobId, false, f)
-    }
+  private fun readMetadata(blobId: BlobId): BlobMetadata? {
+    // NB(mmihic): Must be called with a read or write lock
+    val metadataPath = metadataRoot.resolve(blobId.toPath())
+    Files.createDirectories(metadataPath.parent)
 
-    private fun <T> withFileLock(blobId: BlobId, shared: Boolean, f: () -> T): T {
-        val lockPath = locksRoot.resolve(blobId.toPath())
-        Files.createDirectories(lockPath.parent)
+    return if (Files.exists(metadataPath)) {
+      val metadataContent = String(Files.readAllBytes(metadataPath))
+      metadataAdapter.fromJson(metadataContent)
+    } else null
+  }
 
-        try {
-            Files.createFile(lockPath)
-        } catch (_: FileAlreadyExistsException) {
+  private fun getContentSize(contentPath: Path) = try {
+    Files.newByteChannel(contentPath, READ)
+        .use { it.size() }
+  } catch (e: FileNotFoundException) {
+    0L
+  }
+
+  private fun getMetadataForWriting(
+      blobId: BlobId,
+      options: Map<StorageRpc.Option, *>
+  ): BlobMetadata? {
+    val existingMetadata = readMetadata(blobId)
+    options.generationMatch?.let {
+      when {
+        it == 0L && existingMetadata != null ->
+          throw StorageException(401, "${blobId.fullName} already exists")
+        it != 0L && existingMetadata == null ->
+          throw StorageException(404, "${blobId.fullName} does not exist")
+        it != 0L && existingMetadata != null && it != existingMetadata.generation ->
+          throw StorageException(
+              401,
+              "generation mismatch: ${existingMetadata.generation} != $it"
+          )
+        else -> {
         }
-
-        return FileChannel.open(lockPath, if (shared) READ else WRITE).withLock(shared) { f() }
+      }
     }
 
-    private class BlobMetadata(
-            val generation: Long,
-            val metageneration: Long,
-            val userProperties: Map<String, String>,
-            val contentType: String?,
-            val contentEncoding: String?
-    ) {
-        fun toStorageObject(blobId: BlobId, size: Long = 0): StorageObject =
-                StorageObject()
-                        .setGeneration(generation)
-                        .setName(blobId.name)
-                        .setBucket(blobId.bucket)
-                        .setMetageneration(metageneration)
-                        .setContentType(contentType)
-                        .setContentEncoding(contentEncoding)
-                        .setSize(BigInteger.valueOf(size))
-                        .setMetadata(if (userProperties.isEmpty()) null else userProperties)
+    return existingMetadata
+  }
 
-        fun toStorageObject(bucket: String, name: String, size: Long = 0) =
-                toStorageObject(BlobId.of(bucket, name), size)
+  private fun getMetadataForReading(
+      blobId: BlobId,
+      options: Map<StorageRpc.Option, *>
+  ): BlobMetadata? {
+    val metadata = readMetadata(blobId) ?: return null
+    options.generationMatch?.let {
+      if (metadata.generation != it) {
+        throw StorageException(401, "generation mismatch: ${metadata.generation} != $it")
+      }
     }
 
-    private class Upload(
-            val id: String,
-            val blobId: BlobId,
-            val tempFile: Path,
-            val targetMetadata: BlobMetadata
+    options.generationNotMatch?.let {
+      if (metadata.generation == it) {
+        throw StorageException(401, "generation mismatch: ${metadata.generation} == $it")
+      }
+    }
+
+    return metadata
+  }
+
+  private fun beginUpload(
+      obj: StorageObject,
+      options: Map<StorageRpc.Option, *>
+  ): Upload {
+    try {
+      val newMetadata = withReadLock(obj.blobId) {
+        // Check constraint on existing metadata and return the metadata that will
+        // apply once the upload has completed.
+        obj.nextGenerationMetadata(getMetadataForWriting(obj.blobId, options))
+      }
+
+      // Create a temporary file to hold the upload contents.
+      val uploadId = UUID.randomUUID()
+          .toString()
+      val uploadPath = createTempUploadFile(obj.blobId)
+
+      // Save off the upload information for subsequent writes
+      val upload = Upload(uploadId, obj.blobId, uploadPath, newMetadata)
+      internalLock.write {
+        uploads[uploadId] = upload
+      }
+
+      return upload
+    } catch (e: IOException) {
+      throw StorageException(e)
+    }
+  }
+
+  private fun continueUpload(
+      uploadId: String,
+      toWrite: ByteArray,
+      toWriteOffset: Int,
+      destOffset: Long,
+      length: Int
+  ): Upload = try {
+    // Copy bytes into the temporary file for this upload
+    internalLock.read {
+      val upload = uploads[uploadId]
+          ?: throw StorageException(404, "no such upload $uploadId")
+      val buffer = ByteBuffer.wrap(toWrite, toWriteOffset, length)
+      val ch = Files.newByteChannel(upload.tempFile, CREATE, WRITE)
+      val position = Math.min(destOffset, ch.size())
+      ch.use {
+        it.position(position)
+        it.write(buffer)
+      }
+      upload
+    }
+  } catch (e: IOException) {
+    throw StorageException(e)
+  }
+
+  private fun endUpload(upload: Upload) {
+    try {
+      internalLock.write {
+        // Clear out the internal upload tracking
+        uploads.remove(upload.blobId.fullName)
+      }
+
+      withWriteLock(upload.blobId) {
+        // Move the upload file into the content directory tagged with the new generation,
+        // overwriting any version that might've been left by a previously failed uplaod
+        val newGeneration = upload.targetMetadata.generation
+        val newContentPath = contentRoot.resolve(upload.blobId.toPath(newGeneration))
+        Files.createDirectories(newContentPath.parent)
+        Files.move(upload.tempFile, newContentPath, ATOMIC_MOVE, REPLACE_EXISTING)
+
+        // Update the metadata to point to the new generation. If we fail between the
+        // prior step and this one, there is no harm - the new content will have
+        // been laid down but won't be accessible because the metadata doesn't point
+        // to it, and the next upload will overwrite it
+        writeMetadata(upload.blobId, upload.targetMetadata)
+
+        // Delete the content file for the previous generation. If we fail between
+        // the prior step and this one, there is no harm - we'll leave old content
+        // files around, but won't use them since the metadata has advanced. We
+        // could clean these up via a garbage collection process somewhere down the line
+        val oldGeneration = upload.targetMetadata.generation - 1
+        val oldContentPath = contentRoot.resolve(upload.blobId.toPath(oldGeneration))
+        Files.deleteIfExists(oldContentPath)
+      }
+    } catch (e: IOException) {
+      throw StorageException(e)
+    }
+  }
+
+  private fun createTempUploadFile(blobId: BlobId): Path {
+    val blobPath = blobId.toPath()
+    val uploadFolder = uploadRoot.resolve(blobPath)
+        .parent
+    Files.createDirectories(uploadFolder)
+
+    val uploadPath = Files.createTempFile(uploadFolder, blobPath.fileName.toString(), "")
+    Files.createDirectories(uploadPath.parent)
+    return uploadPath
+  }
+
+  private fun <T> withReadLock(
+      blobId: BlobId,
+      f: () -> T
+  ): T = internalLock.read {
+    withFileLock(blobId, true, f)
+  }
+
+  private fun <T> withWriteLock(
+      blobId: BlobId,
+      f: () -> T
+  ): T = internalLock.write {
+    withFileLock(blobId, false, f)
+  }
+
+  private fun <T> withFileLock(
+      blobId: BlobId,
+      shared: Boolean,
+      f: () -> T
+  ): T {
+    val lockPath = locksRoot.resolve(blobId.toPath())
+    Files.createDirectories(lockPath.parent)
+
+    try {
+      Files.createFile(lockPath)
+    } catch (_: FileAlreadyExistsException) {
+    }
+
+    return FileChannel.open(lockPath, if (shared) READ else WRITE)
+        .withLock(shared) { f() }
+  }
+
+  private class BlobMetadata(
+      val generation: Long,
+      val metageneration: Long,
+      val userProperties: Map<String, String>,
+      val contentType: String?,
+      val contentEncoding: String?
+  ) {
+    fun toStorageObject(
+        blobId: BlobId,
+        size: Long = 0
+    ): StorageObject =
+        StorageObject()
+            .setGeneration(generation)
+            .setName(blobId.name)
+            .setBucket(blobId.bucket)
+            .setMetageneration(metageneration)
+            .setContentType(contentType)
+            .setContentEncoding(contentEncoding)
+            .setSize(BigInteger.valueOf(size))
+            .setMetadata(if (userProperties.isEmpty()) null else userProperties)
+
+    fun toStorageObject(
+        bucket: String,
+        name: String,
+        size: Long = 0
+    ) =
+        toStorageObject(BlobId.of(bucket, name), size)
+  }
+
+  private class Upload(
+      val id: String,
+      val blobId: BlobId,
+      val tempFile: Path,
+      val targetMetadata: BlobMetadata
+  )
+
+  /** @return a new version of the given metadata, updated based on the storage object */
+  private fun StorageObject.nextGenerationMetadata(existing: BlobMetadata?): BlobMetadata {
+    val newContentType = contentType ?: existing?.contentType
+    val newContentEncoding = contentEncoding ?: existing?.contentEncoding
+    val newUserProperties = metadata ?: existing?.userProperties ?: mapOf()
+    val newGeneration = (existing?.generation ?: 0L) + 1
+    val newMetaGeneration = when {
+      existing == null -> 1
+      existing.userProperties != newUserProperties -> existing.metageneration + 1
+      else -> existing.metageneration
+    }
+
+    return BlobMetadata(
+        newGeneration,
+        newMetaGeneration,
+        newUserProperties,
+        newContentType,
+        newContentEncoding
     )
-
-    /** @return a new version of the given metadata, updated based on the storage object */
-    private fun StorageObject.nextGenerationMetadata(existing: BlobMetadata?): BlobMetadata {
-        val newContentType = contentType ?: existing?.contentType
-        val newContentEncoding = contentEncoding ?: existing?.contentEncoding
-        val newUserProperties = metadata ?: existing?.userProperties ?: mapOf()
-        val newGeneration = (existing?.generation ?: 0L) + 1
-        val newMetaGeneration = when {
-            existing == null -> 1
-            existing.userProperties != newUserProperties -> existing.metageneration + 1
-            else -> existing.metageneration
-        }
-
-        return BlobMetadata(
-                newGeneration,
-                newMetaGeneration,
-                newUserProperties,
-                newContentType,
-                newContentEncoding)
-    }
+  }
 }
 
 private val Map<StorageRpc.Option, *>.generationNotMatch
-    get() = (this[IF_GENERATION_NOT_MATCH] as? Number)?.toLong()
+  get() = (this[IF_GENERATION_NOT_MATCH] as? Number)?.toLong()
 
 private val Map<StorageRpc.Option, *>.generationMatch
-    get() = (this[IF_GENERATION_MATCH] as? Number)?.toLong()
+  get() = (this[IF_GENERATION_MATCH] as? Number)?.toLong()
 
 private val StorageObject.blobId get() = BlobId.of(bucket, name, generation)
 
 private fun BlobId.toPath(generation: Long) =
-        Paths.get(bucket, *parentPathElements, fileName(generation))
+    Paths.get(bucket, *parentPathElements, fileName(generation))
 
 private fun BlobId.toPath() = Paths.get(bucket, *pathElements)
 private val BlobId.parentPathElements get() = pathElements.dropLast(1).toTypedArray()
@@ -577,4 +629,4 @@ private fun BlobId.fileName(generation: Long = 1) = "${pathElements.last()}.$gen
 private val BlobId.fullName get() = "$bucket:$name"
 
 private fun Path.toBlobId(childPath: Path): BlobId =
-        BlobId.of(fileName.toString(), relativize(childPath).joinToString("/"))
+    BlobId.of(fileName.toString(), relativize(childPath).joinToString("/"))

--- a/misk/src/main/kotlin/misk/cloud/gcp/storage/StorageConfig.kt
+++ b/misk/src/main/kotlin/misk/cloud/gcp/storage/StorageConfig.kt
@@ -5,9 +5,9 @@ import misk.config.Config
 
 /** Configuration for talking to Google Cloud Storage */
 data class StorageConfig(
-        val use_local_storage: Boolean = false,
-        val local_storage: LocalStorageConfig? = null,
-        val transport : TransportConfig = TransportConfig()
+    val use_local_storage: Boolean = false,
+    val local_storage: LocalStorageConfig? = null,
+    val transport: TransportConfig = TransportConfig()
 ) : Config
 
 /** Configuration for local (emulated) storage */

--- a/misk/src/main/kotlin/misk/cloud/gcp/storage/StorageExtensions.kt
+++ b/misk/src/main/kotlin/misk/cloud/gcp/storage/StorageExtensions.kt
@@ -8,13 +8,13 @@ import java.nio.ByteBuffer
 
 /** @return compares one blob id to another; orders by bucket, then name, then generation */
 fun BlobId.compareTo(other: BlobId): Int {
-    val bucketCompare = bucket.compareTo(other.bucket)
-    if (bucketCompare != 0) return bucketCompare
+  val bucketCompare = bucket.compareTo(other.bucket)
+  if (bucketCompare != 0) return bucketCompare
 
-    val nameCompare = name.compareTo(other.name)
-    if (nameCompare != 0) return nameCompare
+  val nameCompare = name.compareTo(other.name)
+  if (nameCompare != 0) return nameCompare
 
-    return ((generation ?: 0) - (other.generation ?: 0)).toInt()
+  return ((generation ?: 0) - (other.generation ?: 0)).toInt()
 }
 
 /** @return a list containing all of the elements in this page */
@@ -24,19 +24,25 @@ fun <T> Page<T>.toList(): List<T> = values.asSequence().toList()
 val Page<Blob>.blobIds get() = toList().map { it.blobId }
 
 /** Runs the given block for each chunk on a given channel */
-fun ReadChannel.forEachChunk(buffer: ByteBuffer, action: (ByteBuffer, Int) -> Unit) {
-    setChunkSize(buffer.capacity())
-    buffer.clear()
+fun ReadChannel.forEachChunk(
+    buffer: ByteBuffer,
+    action: (ByteBuffer, Int) -> Unit
+) {
+  setChunkSize(buffer.capacity())
+  buffer.clear()
 
-    var bytesRead = read(buffer)
-    while (bytesRead != -1) {
-        buffer.position(0)
-        action(buffer, bytesRead)
-        buffer.clear()
-        bytesRead = read(buffer)
-    }
+  var bytesRead = read(buffer)
+  while (bytesRead != -1) {
+    buffer.position(0)
+    action(buffer, bytesRead)
+    buffer.clear()
+    bytesRead = read(buffer)
+  }
 }
 
-fun ReadChannel.forEachChunk(chunkSize: Int, action: (ByteBuffer, Int) -> Unit) {
-    forEachChunk(ByteBuffer.allocate(chunkSize), action)
+fun ReadChannel.forEachChunk(
+    chunkSize: Int,
+    action: (ByteBuffer, Int) -> Unit
+) {
+  forEachChunk(ByteBuffer.allocate(chunkSize), action)
 }

--- a/misk/src/main/kotlin/misk/concurrent/WrappingListeningExecutorService.kt
+++ b/misk/src/main/kotlin/misk/concurrent/WrappingListeningExecutorService.kt
@@ -11,46 +11,55 @@ import java.util.concurrent.TimeoutException
 
 /** [ListeningExecutorService] which wraps all calls */
 abstract class WrappingListeningExecutorService() : ForwardingListeningExecutorService() {
-    /** Wraps the specified callable and returns the new wrapped one. */
-    protected abstract fun <T> wrap(callable: Callable<T>): Callable<T>
+  /** Wraps the specified callable and returns the new wrapped one. */
+  protected abstract fun <T> wrap(callable: Callable<T>): Callable<T>
 
-    override fun <T> submit(callable: Callable<T>): ListenableFuture<T> {
-        val wrapped = wrap(callable)
-        return delegate().submit<T>(wrapped)
-    }
+  override fun <T> submit(callable: Callable<T>): ListenableFuture<T> {
+    val wrapped = wrap(callable)
+    return delegate().submit<T>(wrapped)
+  }
 
-    override fun <T> submit(runnable: Runnable, result: T): ListenableFuture<T> {
-        return submit<T>({ runnable.run(); result })
-    }
+  override fun <T> submit(
+      runnable: Runnable,
+      result: T
+  ): ListenableFuture<T> {
+    return submit<T>({ runnable.run(); result })
+  }
 
-    override fun submit(runnable: Runnable): ListenableFuture<*> {
-        val wrapped = wrap<Unit>(Callable { runnable.run() })
-        return delegate().submit(wrapped)
-    }
+  override fun submit(runnable: Runnable): ListenableFuture<*> {
+    val wrapped = wrap<Unit>(Callable { runnable.run() })
+    return delegate().submit(wrapped)
+  }
 
-    @Throws(InterruptedException::class)
-    override fun <T> invokeAll(callables: Collection<Callable<T>>): List<Future<T>> {
-        return delegate().invokeAll(callables.map { wrap(it) })
-    }
+  @Throws(InterruptedException::class)
+  override fun <T> invokeAll(callables: Collection<Callable<T>>): List<Future<T>> {
+    return delegate().invokeAll(callables.map { wrap(it) })
+  }
 
-    @Throws(InterruptedException::class)
-    override fun <T> invokeAll(callables: Collection<Callable<T>>, timeout: Long,
-            timeUnit: TimeUnit): List<Future<T>> {
-        return delegate().invokeAll(callables.map { wrap(it) }, timeout, timeUnit)
-    }
+  @Throws(InterruptedException::class)
+  override fun <T> invokeAll(
+      callables: Collection<Callable<T>>,
+      timeout: Long,
+      timeUnit: TimeUnit
+  ): List<Future<T>> {
+    return delegate().invokeAll(callables.map { wrap(it) }, timeout, timeUnit)
+  }
 
-    @Throws(InterruptedException::class, ExecutionException::class)
-    override fun <T> invokeAny(callables: Collection<Callable<T>>): T {
-        return delegate().invokeAny(callables.map { wrap(it) })
-    }
+  @Throws(InterruptedException::class, ExecutionException::class)
+  override fun <T> invokeAny(callables: Collection<Callable<T>>): T {
+    return delegate().invokeAny(callables.map { wrap(it) })
+  }
 
-    @Throws(InterruptedException::class, ExecutionException::class, TimeoutException::class)
-    override fun <T> invokeAny(callables: Collection<Callable<T>>, timeout: Long,
-            timeUnit: TimeUnit): T {
-        return delegate().invokeAny(callables.map { wrap(it) }, timeout, timeUnit)
-    }
+  @Throws(InterruptedException::class, ExecutionException::class, TimeoutException::class)
+  override fun <T> invokeAny(
+      callables: Collection<Callable<T>>,
+      timeout: Long,
+      timeUnit: TimeUnit
+  ): T {
+    return delegate().invokeAny(callables.map { wrap(it) }, timeout, timeUnit)
+  }
 
-    override fun execute(runnable: Runnable) {
-        delegate().submit(wrap<Unit>(Callable { runnable.run() }))
-    }
+  override fun execute(runnable: Runnable) {
+    delegate().submit(wrap<Unit>(Callable { runnable.run() }))
+  }
 }

--- a/misk/src/main/kotlin/misk/config/AppName.kt
+++ b/misk/src/main/kotlin/misk/config/AppName.kt
@@ -4,9 +4,9 @@ import javax.inject.Qualifier
 
 @Qualifier
 @Target(
-        AnnotationTarget.FIELD,
-        AnnotationTarget.PROPERTY,
-        AnnotationTarget.FUNCTION,
-        AnnotationTarget.VALUE_PARAMETER
+    AnnotationTarget.FIELD,
+    AnnotationTarget.PROPERTY,
+    AnnotationTarget.FUNCTION,
+    AnnotationTarget.VALUE_PARAMETER
 )
 annotation class AppName

--- a/misk/src/main/kotlin/misk/config/ConfigProvider.kt
+++ b/misk/src/main/kotlin/misk/config/ConfigProvider.kt
@@ -14,65 +14,65 @@ import javax.inject.Inject
 import javax.inject.Provider
 
 internal class ConfigProvider<T : Config>(
-        private val configClass: Class<out Config>,
-        private val appName: String
+    private val configClass: Class<out Config>,
+    private val appName: String
 ) : Provider<T> {
-    @Inject
-    lateinit var environment: Environment
+  @Inject
+  lateinit var environment: Environment
 
-    override fun get(): T {
-        val mapper = ObjectMapper(YAMLFactory())
-        mapper.registerModule(KotlinModule())
-        mapper.registerModule(JavaTimeModule())
+  override fun get(): T {
+    val mapper = ObjectMapper(YAMLFactory())
+    mapper.registerModule(KotlinModule())
+    mapper.registerModule(JavaTimeModule())
 
-        var jsonNode: JsonNode? = null
-        val missingConfigFiles = mutableListOf<String>()
-        for (configFileName in configFileNames) {
-            val url = getResource(configFileName)
-            if (url == null) {
-                missingConfigFiles.add(configFileName)
-                continue
-            }
+    var jsonNode: JsonNode? = null
+    val missingConfigFiles = mutableListOf<String>()
+    for (configFileName in configFileNames) {
+      val url = getResource(configFileName)
+      if (url == null) {
+        missingConfigFiles.add(configFileName)
+        continue
+      }
 
-            try {
-                open(url).use {
-                    val objectReader = if (jsonNode == null) {
-                        mapper.readerFor(JsonNode::class.java)
-                    } else {
-                        mapper.readerForUpdating(jsonNode)
-                    }
-                    jsonNode = objectReader.readValue(it)
-                }
-            } catch (e: Exception) {
-                throw IllegalStateException("could not parse $configFileName: ${e.message}", e)
-            }
+      try {
+        open(url).use {
+          val objectReader = if (jsonNode == null) {
+            mapper.readerFor(JsonNode::class.java)
+          } else {
+            mapper.readerForUpdating(jsonNode)
+          }
+          jsonNode = objectReader.readValue(it)
         }
-
-        if (jsonNode == null) {
-            val configFileMessage = missingConfigFiles.joinToString(", ")
-            throw IllegalStateException(
-                    "could not find configuration files - checked [$configFileMessage]"
-            )
-        }
-
-        @Suppress("UNCHECKED_CAST")
-        try {
-            return mapper.readValue(jsonNode.toString(), configClass) as T
-        } catch (e: MissingKotlinParameterException) {
-            throw IllegalStateException("could not find configuration for ${e.parameter.name}", e)
-        } catch (e: Exception) {
-            throw IllegalStateException(e)
-        }
+      } catch (e: Exception) {
+        throw IllegalStateException("could not parse $configFileName: ${e.message}", e)
+      }
     }
 
-    /** @return the list of config file names in the order they should be read */
-    private val configFileNames
-        get() = listOf("common", environment.name.toLowerCase()).map { "$appName-$it.yaml" }
-
-    private fun open(url: URL): BufferedReader {
-        return BufferedReader(InputStreamReader(url.openStream()))
+    if (jsonNode == null) {
+      val configFileMessage = missingConfigFiles.joinToString(", ")
+      throw IllegalStateException(
+          "could not find configuration files - checked [$configFileMessage]"
+      )
     }
 
-    private fun getResource(fileName: String) = configClass.classLoader.getResource(fileName)
+    @Suppress("UNCHECKED_CAST")
+    try {
+      return mapper.readValue(jsonNode.toString(), configClass) as T
+    } catch (e: MissingKotlinParameterException) {
+      throw IllegalStateException("could not find configuration for ${e.parameter.name}", e)
+    } catch (e: Exception) {
+      throw IllegalStateException(e)
+    }
+  }
+
+  /** @return the list of config file names in the order they should be read */
+  private val configFileNames
+    get() = listOf("common", environment.name.toLowerCase()).map { "$appName-$it.yaml" }
+
+  private fun open(url: URL): BufferedReader {
+    return BufferedReader(InputStreamReader(url.openStream()))
+  }
+
+  private fun getResource(fileName: String) = configClass.classLoader.getResource(fileName)
 }
 

--- a/misk/src/main/kotlin/misk/environment/Environment.kt
+++ b/misk/src/main/kotlin/misk/environment/Environment.kt
@@ -1,3 +1,7 @@
 package misk.environment
 
-enum class Environment { TESTING, DEVELOPMENT, STAGING, PRODUCTION }
+enum class Environment { TESTING,
+  DEVELOPMENT,
+  STAGING,
+  PRODUCTION
+}

--- a/misk/src/main/kotlin/misk/environment/EnvironmentModule.kt
+++ b/misk/src/main/kotlin/misk/environment/EnvironmentModule.kt
@@ -6,24 +6,24 @@ import misk.logging.getLogger
 private val logger = getLogger<EnvironmentModule>()
 
 class EnvironmentModule(val environment: Environment) : KAbstractModule() {
-    override fun configure() {
-        bind<Environment>().toInstance(environment)
-    }
+  override fun configure() {
+    bind<Environment>().toInstance(environment)
+  }
 
-    companion object {
-        private val environmentKey = "ENVIRONMENT"
+  companion object {
+    private val environmentKey = "ENVIRONMENT"
 
-        @JvmStatic
-        fun fromEnvironmentVariable(): EnvironmentModule {
-            val environmentName = System.getenv(environmentKey)
-            val environment = if (environmentName != null) {
-                Environment.valueOf(environmentName)
-            } else {
-                logger.warn { "No environment variable with key $environmentKey found, running in DEVELOPMENT" }
-                Environment.DEVELOPMENT
-            }
-            logger.info { "Running with environment ${environment.name}" }
-            return EnvironmentModule(environment)
-        }
+    @JvmStatic
+    fun fromEnvironmentVariable(): EnvironmentModule {
+      val environmentName = System.getenv(environmentKey)
+      val environment = if (environmentName != null) {
+        Environment.valueOf(environmentName)
+      } else {
+        logger.warn { "No environment variable with key $environmentKey found, running in DEVELOPMENT" }
+        Environment.DEVELOPMENT
+      }
+      logger.info { "Running with environment ${environment.name}" }
+      return EnvironmentModule(environment)
     }
+  }
 }

--- a/misk/src/main/kotlin/misk/environment/InstanceMetadata.kt
+++ b/misk/src/main/kotlin/misk/environment/InstanceMetadata.kt
@@ -1,4 +1,7 @@
 package misk.environment
 
 /** Metadata about the running instance */
-data class InstanceMetadata(val instanceName: String, val zone: String)
+data class InstanceMetadata(
+    val instanceName: String,
+    val zone: String
+)

--- a/misk/src/main/kotlin/misk/exceptions/Exceptions.kt
+++ b/misk/src/main/kotlin/misk/exceptions/Exceptions.kt
@@ -2,49 +2,67 @@ package misk.exceptions
 
 /** Common status codes for actions */
 enum class StatusCode(val code: Int) {
-    BAD_REQUEST(400),
-    NOT_FOUND(404),
-    UNAUTHENTICATED(401),
-    FORBIDDEN(403),
-    NOT_ACCEPTABLE(406),
-    ENHANCE_YOUR_CALM(420),
-    UNPROCESSABLE_ENTITY(429),
-    INTERNAL_SERVER_ERROR(500),
-    SERVICE_UNAVAILABLE(503);
+  BAD_REQUEST(400),
+  NOT_FOUND(404),
+  UNAUTHENTICATED(401),
+  FORBIDDEN(403),
+  NOT_ACCEPTABLE(406),
+  ENHANCE_YOUR_CALM(420),
+  UNPROCESSABLE_ENTITY(429),
+  INTERNAL_SERVER_ERROR(500),
+  SERVICE_UNAVAILABLE(503);
 
-    val isClientError = code in (400..499)
-    val isServerError = code in (500..599)
+  val isClientError = code in (400..499)
+  val isServerError = code in (500..599)
 }
 
 /** Base class for exceptions thrown by actions, translated into responses */
 open class ActionException(
-        val statusCode: StatusCode,
-        message: String = statusCode.name,
-        cause: Throwable? = null
+    val statusCode: StatusCode,
+    message: String = statusCode.name,
+    cause: Throwable? = null
 ) : Exception(message, cause)
 
 /** Base exception for when resources are not found */
-open class NotFoundException(message: String = "", cause: Throwable? = null) :
-        ActionException(StatusCode.NOT_FOUND, message, cause)
+open class NotFoundException(
+    message: String = "",
+    cause: Throwable? = null
+) :
+    ActionException(StatusCode.NOT_FOUND, message, cause)
 
 /** Base exception for when authentication fails */
-open class UnauthenticatedException(message: String = "", cause: Throwable? = null) :
-        ActionException(StatusCode.UNAUTHENTICATED, message, cause)
+open class UnauthenticatedException(
+    message: String = "",
+    cause: Throwable? = null
+) :
+    ActionException(StatusCode.UNAUTHENTICATED, message, cause)
 
 /** Base exception for when authenticated credentials lack access to a resource */
-open class UnauthorizedException(message: String = "", cause: Throwable? = null) :
-        ActionException(StatusCode.FORBIDDEN, message, cause)
+open class UnauthorizedException(
+    message: String = "",
+    cause: Throwable? = null
+) :
+    ActionException(StatusCode.FORBIDDEN, message, cause)
 
 /** Base exception for when a resource is unavailable */
-open class ResourceUnavailableException(message: String = "", cause: Throwable? = null) :
-        ActionException(StatusCode.SERVICE_UNAVAILABLE, message, cause)
+open class ResourceUnavailableException(
+    message: String = "",
+    cause: Throwable? = null
+) :
+    ActionException(StatusCode.SERVICE_UNAVAILABLE, message, cause)
 
 /** Base exception for bad client requests */
-open class BadRequestException(message: String = "", cause: Throwable? = null) :
-        ActionException(StatusCode.BAD_REQUEST, message, cause)
+open class BadRequestException(
+    message: String = "",
+    cause: Throwable? = null
+) :
+    ActionException(StatusCode.BAD_REQUEST, message, cause)
 
 /** Similar to [kotlin.require], but throws [BadRequestException] if the check fails */
-inline fun requireRequest(check: Boolean, lazyMessage: () -> String) {
-    if (!check) throw BadRequestException(lazyMessage())
+inline fun requireRequest(
+    check: Boolean,
+    lazyMessage: () -> String
+) {
+  if (!check) throw BadRequestException(lazyMessage())
 }
 

--- a/misk/src/main/kotlin/misk/healthchecks/HealthCheck.kt
+++ b/misk/src/main/kotlin/misk/healthchecks/HealthCheck.kt
@@ -7,20 +7,20 @@ import misk.web.actions.ReadinessCheckAction
  * readiness check in [ReadinessCheckAction], indicating that the app should not accept traffic.
  */
 interface HealthCheck {
-    /**
-     * Computes whether a component of an application is healthy. For example, an implementing class
-     * can check database connectivity.
-     */
-    fun status(): HealthStatus
+  /**
+   * Computes whether a component of an application is healthy. For example, an implementing class
+   * can check database connectivity.
+   */
+  fun status(): HealthStatus
 }
 
 data class HealthStatus(
     val isHealthy: Boolean,
     val messages: List<String>
 ) {
-    companion object {
-        fun healthy() = HealthStatus(true, listOf())
+  companion object {
+    fun healthy() = HealthStatus(true, listOf())
 
-        fun unhealthy(vararg messages: String) = HealthStatus(false, messages.asList())
-    }
+    fun unhealthy(vararg messages: String) = HealthStatus(false, messages.asList())
+  }
 }

--- a/misk/src/main/kotlin/misk/healthchecks/HealthChecksModule.kt
+++ b/misk/src/main/kotlin/misk/healthchecks/HealthChecksModule.kt
@@ -5,10 +5,11 @@ import misk.inject.KAbstractModule
 class HealthChecksModule(
     private vararg val healthCheckClasses: Class<out HealthCheck>
 ) : KAbstractModule() {
-    override fun configure() {
-        val setBinder = newSetBinder<HealthCheck>()
-        for (healthCheckClass in healthCheckClasses) {
-            setBinder.addBinding().to(healthCheckClass)
-        }
+  override fun configure() {
+    val setBinder = newSetBinder<HealthCheck>()
+    for (healthCheckClass in healthCheckClasses) {
+      setBinder.addBinding()
+          .to(healthCheckClass)
     }
+  }
 }

--- a/misk/src/main/kotlin/misk/hibernate/HibernateModule.kt
+++ b/misk/src/main/kotlin/misk/hibernate/HibernateModule.kt
@@ -6,7 +6,8 @@ import misk.inject.addMultibinderBinding
 import misk.inject.to
 
 class HibernateModule : AbstractModule() {
-    override fun configure() {
-        binder().addMultibinderBinding<Service>().to<HibernateService>()
-    }
+  override fun configure() {
+    binder().addMultibinderBinding<Service>()
+        .to<HibernateService>()
+  }
 }

--- a/misk/src/main/kotlin/misk/hibernate/HibernateService.kt
+++ b/misk/src/main/kotlin/misk/hibernate/HibernateService.kt
@@ -6,11 +6,11 @@ import misk.logging.getLogger
 private val logger = getLogger<HibernateService>()
 
 internal class HibernateService : AbstractIdleService() {
-    override fun startUp() {
-        logger.info("starting up Hibernate")
-    }
+  override fun startUp() {
+    logger.info("starting up Hibernate")
+  }
 
-    override fun shutDown() {
-        logger.info("shutting down Hibernate")
-    }
+  override fun shutDown() {
+    logger.info("shutting down Hibernate")
+  }
 }

--- a/misk/src/main/kotlin/misk/inject/Guice.kt
+++ b/misk/src/main/kotlin/misk/inject/Guice.kt
@@ -22,79 +22,82 @@ inline fun <reified T : Any> LinkedBindingBuilder<in T>.to() = to(T::class.java)
 
 @Suppress("UNCHECKED_CAST")
 inline fun <reified T : Any> Binder.newMultibinder(
-        annotation: Class<out Annotation>? = null
+    annotation: Class<out Annotation>? = null
 ): Multibinder<T> {
-    val typeLiteral =
-            parameterizedType<List<*>>(subtypeOf<T>()).typeLiteral() as TypeLiteral<List<T>>
-    bind(typeLiteral).toProvider(parameterizedType<ListProvider<*>>(
-            T::class.java).typeLiteral() as TypeLiteral<Provider<List<T>>>)
+  val typeLiteral =
+      parameterizedType<List<*>>(subtypeOf<T>()).typeLiteral() as TypeLiteral<List<T>>
+  bind(typeLiteral).toProvider(
+      parameterizedType<ListProvider<*>>(
+          T::class.java
+      ).typeLiteral() as TypeLiteral<Provider<List<T>>>
+  )
 
-    return when (annotation) {
-        null -> Multibinder.newSetBinder(this, T::class.java)
-        else -> Multibinder.newSetBinder(this, T::class.java, annotation)
-    }
+  return when (annotation) {
+    null -> Multibinder.newSetBinder(this, T::class.java)
+    else -> Multibinder.newSetBinder(this, T::class.java, annotation)
+  }
 }
 
 inline fun <reified T : Any, reified A : Annotation> Binder.addMultibinderBindingWithAnnotation() =
-        addMultibinderBinding<T>(A::class.java)
+    addMultibinderBinding<T>(A::class.java)
 
 @Suppress("UNCHECKED_CAST")
 inline fun <reified T : Any> Binder.addMultibinderBinding(
-        annotation: Class<out Annotation>? = null
+    annotation: Class<out Annotation>? = null
 ): LinkedBindingBuilder<T> = newMultibinder<T>(annotation).addBinding()
 
 fun ScopedBindingBuilder.asSingleton() {
-    `in`(Singleton::class.java)
+  `in`(Singleton::class.java)
 }
 
 class ListProvider<T> : Provider<List<T>> {
-    @Inject
-    lateinit var set: MutableSet<T>
+  @Inject
+  lateinit var set: MutableSet<T>
 
-    override fun get(): List<T> = ArrayList(set)
+  override fun get(): List<T> = ArrayList(set)
 }
 
 inline fun <reified T : Any> subtypeOf(): WildcardType {
-    return Types.subtypeOf(T::class.java)
+  return Types.subtypeOf(T::class.java)
 }
 
 inline fun <reified T : Any> parameterizedType(vararg typeParameters: Type)
-        : ParameterizedType {
-    return Types.newParameterizedType(T::class.java, *typeParameters)
+    : ParameterizedType {
+  return Types.newParameterizedType(T::class.java, *typeParameters)
 }
 
 fun ParameterizedType.typeLiteral() = TypeLiteral.get(this)
 
 fun KType.typeLiteral(): TypeLiteral<*> {
-    return TypeLiteral.get(javaType)
+  return TypeLiteral.get(javaType)
 }
 
 inline fun <reified T : Any> Injector.getInstance(): T {
-    return getInstance(T::class.java)
+  return getInstance(T::class.java)
 }
 
 inline fun <reified T : Any> keyOf(): Key<T> = Key.get(T::class.java)
 inline fun <reified T : Any> keyOf(a: Annotation): Key<T> = Key.get(T::class.java, a)
 inline fun <reified T : Any, A : Annotation> keyOf(a: KClass<A>): Key<T> =
-        Key.get(T::class.java, a.java)
+    Key.get(T::class.java, a.java)
 
 fun uninject(target: Any) {
-    try {
-        var c: Class<*> = target.javaClass
-        while (c != Any::class.java) {
-            for (f in c.declaredFields) {
-                if (f.isAnnotationPresent(Inject::class.java)) {
-                    f.isAccessible = true
-                    if (!f.type.isPrimitive) f.set(target, null)
-                }
-                if (f.isAnnotationPresent(com.google.inject.Inject::class.java)) {
-                    throw AssertionError("prefer @javax.inject.Inject for " + target.javaClass)
-                }
-            }
-            c = c.superclass
+  try {
+    var c: Class<*> = target.javaClass
+    while (c != Any::class.java) {
+      for (f in c.declaredFields) {
+        if (f.isAnnotationPresent(Inject::class.java)) {
+          f.isAccessible = true
+          if (!f.type.isPrimitive) f.set(target, null)
         }
-    } catch (e: IllegalAccessException) {
-        throw AssertionError(e)
+        if (f.isAnnotationPresent(com.google.inject.Inject::class.java)) {
+          throw AssertionError("prefer @javax.inject.Inject for " + target.javaClass)
+        }
+      }
+      c = c.superclass
     }
+  } catch (e: IllegalAccessException) {
+    throw AssertionError(e)
+  }
 
 }

--- a/misk/src/main/kotlin/misk/inject/KAbstractModule.kt
+++ b/misk/src/main/kotlin/misk/inject/KAbstractModule.kt
@@ -5,7 +5,6 @@ import com.google.inject.binder.AnnotatedBindingBuilder
 import com.google.inject.binder.LinkedBindingBuilder
 import com.google.inject.binder.ScopedBindingBuilder
 import com.google.inject.multibindings.Multibinder
-import javax.inject.Provider
 
 /**
  * A class that provides helper methods for working with Kotlin and Guice, allowing implementing
@@ -23,25 +22,25 @@ import javax.inject.Provider
  * ```
  */
 abstract class KAbstractModule : AbstractModule() {
-    protected class KotlinAnnotatedBindingBuilder<X>(
-            private val annotatedBuilder: AnnotatedBindingBuilder<X>
-    ) : AnnotatedBindingBuilder<X> by annotatedBuilder {
-        inline fun <reified T : Annotation> annotatedWith(): LinkedBindingBuilder<X> {
-            return annotatedWith(T::class.java)
-        }
+  protected class KotlinAnnotatedBindingBuilder<X>(
+      private val annotatedBuilder: AnnotatedBindingBuilder<X>
+  ) : AnnotatedBindingBuilder<X> by annotatedBuilder {
+    inline fun <reified T : Annotation> annotatedWith(): LinkedBindingBuilder<X> {
+      return annotatedWith(T::class.java)
     }
+  }
 
-    protected inline fun <reified T : Any> bind(): KotlinAnnotatedBindingBuilder<in T> {
-        return KotlinAnnotatedBindingBuilder<T>(binder().bind(T::class.java))
-    }
+  protected inline fun <reified T : Any> bind(): KotlinAnnotatedBindingBuilder<in T> {
+    return KotlinAnnotatedBindingBuilder<T>(binder().bind(T::class.java))
+  }
 
-    protected inline fun <reified T : Any> AnnotatedBindingBuilder<in T>.to(): ScopedBindingBuilder {
-        return to(T::class.java)
-    }
+  protected inline fun <reified T : Any> AnnotatedBindingBuilder<in T>.to(): ScopedBindingBuilder {
+    return to(T::class.java)
+  }
 
-    protected inline fun <reified T : Any> newSetBinder(): Multibinder<T> {
-        return Multibinder.newSetBinder(binder(), T::class.java)
-    }
+  protected inline fun <reified T : Any> newSetBinder(): Multibinder<T> {
+    return Multibinder.newSetBinder(binder(), T::class.java)
+  }
 }
 
 

--- a/misk/src/main/kotlin/misk/io/PathExtensions.kt
+++ b/misk/src/main/kotlin/misk/io/PathExtensions.kt
@@ -6,16 +6,19 @@ import kotlin.streams.asSequence
 
 /** @return all of the paths beneath this one, including nested paths */
 fun Path.listRecursively(includeDirs: Boolean = false): List<Path> {
-    val results = mutableListOf<Path>()
-    listRecursively(includeDirs, results)
-    return results.toList()
+  val results = mutableListOf<Path>()
+  listRecursively(includeDirs, results)
+  return results.toList()
 }
 
-private fun Path.listRecursively(includeDirs: Boolean, results: MutableList<Path>) {
-    val (dirs, files) = Files.list(this).asSequence().partition { Files.isDirectory(it) }
-    results.addAll(files)
-    if (includeDirs) {
-        results.addAll(dirs)
-    }
-    dirs.forEach { it.listRecursively(includeDirs, results) }
+private fun Path.listRecursively(
+    includeDirs: Boolean,
+    results: MutableList<Path>
+) {
+  val (dirs, files) = Files.list(this).asSequence().partition { Files.isDirectory(it) }
+  results.addAll(files)
+  if (includeDirs) {
+    results.addAll(dirs)
+  }
+  dirs.forEach { it.listRecursively(includeDirs, results) }
 }

--- a/misk/src/main/kotlin/misk/logging/Logging.kt
+++ b/misk/src/main/kotlin/misk/logging/Logging.kt
@@ -5,25 +5,32 @@ import mu.KotlinLogging
 import org.slf4j.event.Level
 
 inline fun <reified T> getLogger(): KLogger {
-    return KotlinLogging.logger(T::class.qualifiedName!!)
+  return KotlinLogging.logger(T::class.qualifiedName!!)
 }
 
-fun KLogger.log(level: Level, message: String) {
-    when (level) {
-        Level.ERROR -> error(message)
-        Level.WARN -> warn(message)
-        Level.INFO -> info(message)
-        Level.DEBUG -> debug(message)
-        Level.TRACE -> trace(message)
-    }
+fun KLogger.log(
+    level: Level,
+    message: String
+) {
+  when (level) {
+    Level.ERROR -> error(message)
+    Level.WARN -> warn(message)
+    Level.INFO -> info(message)
+    Level.DEBUG -> debug(message)
+    Level.TRACE -> trace(message)
+  }
 }
 
-fun KLogger.log(level: Level, th: Throwable, message: () -> Any?) {
-    when (level) {
-        Level.ERROR -> error(th, message)
-        Level.INFO -> info(th, message)
-        Level.WARN -> warn(th, message)
-        Level.DEBUG -> debug(th, message)
-        Level.TRACE -> trace(th, message)
-    }
+fun KLogger.log(
+    level: Level,
+    th: Throwable,
+    message: () -> Any?
+) {
+  when (level) {
+    Level.ERROR -> error(th, message)
+    Level.INFO -> info(th, message)
+    Level.WARN -> warn(th, message)
+    Level.DEBUG -> debug(th, message)
+    Level.TRACE -> trace(th, message)
+  }
 }

--- a/misk/src/main/kotlin/misk/metrics/Metrics.kt
+++ b/misk/src/main/kotlin/misk/metrics/Metrics.kt
@@ -9,18 +9,18 @@ import java.util.SortedMap
 import javax.inject.Inject
 
 class Metrics @Inject internal constructor(
-        metricRegistry: MetricRegistry
+    metricRegistry: MetricRegistry
 ) : MetricsScope("", metricRegistry) {
-    val timers: SortedMap<String, Timer> get() = metricRegistry.timers
-    val counters: SortedMap<String, Counter> get() = metricRegistry.counters
-    val gauges: SortedMap<String, Gauge<Any>> get() = metricRegistry.gauges
-    val histograms: SortedMap<String, Histogram> get() = metricRegistry.histograms
+  val timers: SortedMap<String, Timer> get() = metricRegistry.timers
+  val counters: SortedMap<String, Counter> get() = metricRegistry.counters
+  val gauges: SortedMap<String, Gauge<Any>> get() = metricRegistry.gauges
+  val histograms: SortedMap<String, Histogram> get() = metricRegistry.histograms
 
-    companion object {
-        /**
-         * @return a version of the name, sanitized to remove elements that are incompatible
-         * with the major metrics collection systems (notably graphite)
-         */
-        fun sanitize(name: String) = name.replace("[\\-\\.\t]", "_")
-    }
+  companion object {
+    /**
+     * @return a version of the name, sanitized to remove elements that are incompatible
+     * with the major metrics collection systems (notably graphite)
+     */
+    fun sanitize(name: String) = name.replace("[\\-\\.\t]", "_")
+  }
 }

--- a/misk/src/main/kotlin/misk/metrics/MetricsModule.kt
+++ b/misk/src/main/kotlin/misk/metrics/MetricsModule.kt
@@ -4,8 +4,8 @@ import com.codahale.metrics.MetricRegistry
 import misk.inject.KAbstractModule
 
 class MetricsModule : KAbstractModule() {
-    override fun configure() {
-        bind<Metrics>().asEagerSingleton()
-        bind<MetricRegistry>().asEagerSingleton()
-    }
+  override fun configure() {
+    bind<Metrics>().asEagerSingleton()
+    bind<MetricRegistry>().asEagerSingleton()
+  }
 }

--- a/misk/src/main/kotlin/misk/metrics/MetricsScope.kt
+++ b/misk/src/main/kotlin/misk/metrics/MetricsScope.kt
@@ -11,43 +11,55 @@ import java.time.Duration
 import java.util.concurrent.TimeUnit
 
 open class MetricsScope internal constructor(
-        internal val root: String,
-        internal val metricRegistry: MetricRegistry
+    internal val root: String,
+    internal val metricRegistry: MetricRegistry
 ) {
-    fun counter(name: String): Counter {
-        return metricRegistry.counter(scopedName(name))
-    }
+  fun counter(name: String): Counter {
+    return metricRegistry.counter(scopedName(name))
+  }
 
-    fun <T> gauge(name: String, f: () -> T): Gauge<T> {
-        return metricRegistry.register(scopedName(name), Gauge<T> { f.invoke() })
-    }
+  fun <T> gauge(
+      name: String,
+      f: () -> T
+  ): Gauge<T> {
+    return metricRegistry.register(scopedName(name), Gauge<T> { f.invoke() })
+  }
 
-    fun <T> cachedGauge(name: String, duration: Duration, f: () -> T): Gauge<T> {
-        val supplier = Suppliers.memoizeWithExpiration({ f.invoke() }, duration.toMillis(),
-                TimeUnit.MILLISECONDS)
-        return metricRegistry.register(scopedName(name), Gauge<T> { supplier.get() })
-    }
+  fun <T> cachedGauge(
+      name: String,
+      duration: Duration,
+      f: () -> T
+  ): Gauge<T> {
+    val supplier = Suppliers.memoizeWithExpiration(
+        { f.invoke() }, duration.toMillis(),
+        TimeUnit.MILLISECONDS
+    )
+    return metricRegistry.register(scopedName(name), Gauge<T> { supplier.get() })
+  }
 
-    fun settableGauge(name: String): SettableGauge {
-        return metricRegistry.register(scopedName(name), SettableGauge())
-    }
+  fun settableGauge(name: String): SettableGauge {
+    return metricRegistry.register(scopedName(name), SettableGauge())
+  }
 
-    fun timer(name: String): Timer {
-        return metricRegistry.timer(scopedName(name))
-    }
+  fun timer(name: String): Timer {
+    return metricRegistry.timer(scopedName(name))
+  }
 
-    fun histogram(name: String): Histogram {
-        return metricRegistry.histogram(scopedName(name))
-    }
+  fun histogram(name: String): Histogram {
+    return metricRegistry.histogram(scopedName(name))
+  }
 
-    fun scope(name: String, vararg names: String): MetricsScope {
-        val sanitizedNames = listOf(name, *names)
-                .filter { it.isNotBlank() }
-                .map { sanitize(it) }
-                .toTypedArray()
+  fun scope(
+      name: String,
+      vararg names: String
+  ): MetricsScope {
+    val sanitizedNames = listOf(name, *names)
+        .filter { it.isNotBlank() }
+        .map { sanitize(it) }
+        .toTypedArray()
 
-        return MetricsScope(MetricRegistry.name(root, *sanitizedNames), metricRegistry)
-    }
+    return MetricsScope(MetricRegistry.name(root, *sanitizedNames), metricRegistry)
+  }
 
-    fun scopedName(name: String): String = MetricRegistry.name(root, sanitize(name))
+  fun scopedName(name: String): String = MetricRegistry.name(root, sanitize(name))
 }

--- a/misk/src/main/kotlin/misk/metrics/SettableGauge.kt
+++ b/misk/src/main/kotlin/misk/metrics/SettableGauge.kt
@@ -4,7 +4,7 @@ import com.codahale.metrics.Gauge
 import java.util.concurrent.atomic.AtomicLong
 
 class SettableGauge : Gauge<Long> {
-    val value = AtomicLong()
+  val value = AtomicLong()
 
-    override fun getValue(): Long = value.get()
+  override fun getValue(): Long = value.get()
 }

--- a/misk/src/main/kotlin/misk/metrics/backends/MetricsBackendConfig.kt
+++ b/misk/src/main/kotlin/misk/metrics/backends/MetricsBackendConfig.kt
@@ -6,7 +6,7 @@ import misk.metrics.backends.signalfx.SignalFxBackendConfig
 import misk.metrics.backends.stackdriver.StackDriverBackendConfig
 
 data class MetricsBackendConfig(
-        val graphite: GraphiteBackendConfig?,
-        val stack_driver: StackDriverBackendConfig?,
-        val signal_fx: SignalFxBackendConfig?
+    val graphite: GraphiteBackendConfig?,
+    val stack_driver: StackDriverBackendConfig?,
+    val signal_fx: SignalFxBackendConfig?
 ) : Config

--- a/misk/src/main/kotlin/misk/metrics/backends/graphite/GraphiteBackendConfig.kt
+++ b/misk/src/main/kotlin/misk/metrics/backends/graphite/GraphiteBackendConfig.kt
@@ -3,4 +3,8 @@ package misk.metrics.backends.graphite
 import misk.config.Config
 import java.time.Duration
 
-data class GraphiteBackendConfig(val host: String, val port: Int, val interval: Duration) : Config
+data class GraphiteBackendConfig(
+    val host: String,
+    val port: Int,
+    val interval: Duration
+) : Config

--- a/misk/src/main/kotlin/misk/metrics/backends/graphite/GraphiteBackendModule.kt
+++ b/misk/src/main/kotlin/misk/metrics/backends/graphite/GraphiteBackendModule.kt
@@ -16,33 +16,34 @@ import misk.metrics.Metrics
 import java.util.concurrent.TimeUnit
 
 class GraphiteBackendModule : AbstractModule() {
-    override fun configure() {
-        binder().addMultibinderBinding<Service>().to<GraphiteReporterService>()
-    }
+  override fun configure() {
+    binder().addMultibinderBinding<Service>()
+        .to<GraphiteReporterService>()
+  }
 
-    @Provides
-    @Singleton
-    fun graphiteSender(config: GraphiteBackendConfig): GraphiteSender =
-        Graphite(config.host, config.port)
+  @Provides
+  @Singleton
+  fun graphiteSender(config: GraphiteBackendConfig): GraphiteSender =
+      Graphite(config.host, config.port)
 
-    @Provides
-    @Singleton
-    fun graphiteReporter(
-        @AppName appName: String,
-        instanceMetadata: InstanceMetadata,
-        metricRegistry: MetricRegistry,
-        sender: GraphiteSender
-    ): GraphiteReporter {
+  @Provides
+  @Singleton
+  fun graphiteReporter(
+      @AppName appName: String,
+      instanceMetadata: InstanceMetadata,
+      metricRegistry: MetricRegistry,
+      sender: GraphiteSender
+  ): GraphiteReporter {
 
-        val instanceName = Metrics.sanitize(instanceMetadata.instanceName)
-        val zone = Metrics.sanitize(instanceMetadata.zone)
-        val prefix = "$appName.$zone.$instanceName"
+    val instanceName = Metrics.sanitize(instanceMetadata.instanceName)
+    val zone = Metrics.sanitize(instanceMetadata.zone)
+    val prefix = "$appName.$zone.$instanceName"
 
-        return GraphiteReporter.forRegistry(metricRegistry)
-                .prefixedWith(prefix)
-                .convertDurationsTo(TimeUnit.MILLISECONDS)
-                .convertRatesTo(TimeUnit.MILLISECONDS)
-                .build(sender)
-    }
+    return GraphiteReporter.forRegistry(metricRegistry)
+        .prefixedWith(prefix)
+        .convertDurationsTo(TimeUnit.MILLISECONDS)
+        .convertRatesTo(TimeUnit.MILLISECONDS)
+        .build(sender)
+  }
 
 }

--- a/misk/src/main/kotlin/misk/metrics/backends/graphite/GraphiteReporterService.kt
+++ b/misk/src/main/kotlin/misk/metrics/backends/graphite/GraphiteReporterService.kt
@@ -6,9 +6,9 @@ import java.util.concurrent.TimeUnit
 import javax.inject.Inject
 
 internal class GraphiteReporterService @Inject internal constructor(
-        private val config: GraphiteBackendConfig,
-        private val reporter: GraphiteReporter
+    private val config: GraphiteBackendConfig,
+    private val reporter: GraphiteReporter
 ) : AbstractIdleService() {
-    override fun startUp() = reporter.start(config.interval.toMillis(), TimeUnit.MILLISECONDS)
-    override fun shutDown() = reporter.stop()
+  override fun startUp() = reporter.start(config.interval.toMillis(), TimeUnit.MILLISECONDS)
+  override fun shutDown() = reporter.stop()
 }

--- a/misk/src/main/kotlin/misk/metrics/backends/signalfx/SignalFxBackendConfig.kt
+++ b/misk/src/main/kotlin/misk/metrics/backends/signalfx/SignalFxBackendConfig.kt
@@ -4,6 +4,6 @@ import misk.config.Config
 import java.time.Duration
 
 data class SignalFxBackendConfig(
-        val access_token: String,
-        val interval: Duration
+    val access_token: String,
+    val interval: Duration
 ) : Config

--- a/misk/src/main/kotlin/misk/metrics/backends/signalfx/SignalFxBackendModule.kt
+++ b/misk/src/main/kotlin/misk/metrics/backends/signalfx/SignalFxBackendModule.kt
@@ -11,22 +11,24 @@ import misk.inject.addMultibinderBinding
 import misk.inject.to
 import javax.inject.Singleton
 
-class SignalFxBackendModule : KAbstractModule(){
-    override fun configure() {
-        binder().addMultibinderBinding<Service>().to<SignalFxReporterService>()
-    }
+class SignalFxBackendModule : KAbstractModule() {
+  override fun configure() {
+    binder().addMultibinderBinding<Service>()
+        .to<SignalFxReporterService>()
+  }
 
-    @Provides
-    @Singleton
-    fun signalFxReporter(
-            @AppName appName: String,
-            config: SignalFxBackendConfig,
-            metricRegistry: MetricRegistry
-    ): SignalFxReporter {
-        return SignalFxReporter.Builder(
-                metricRegistry,
-                StaticAuthToken(config.access_token),
-                appName
-        ).build()
-    }
+  @Provides
+  @Singleton
+  fun signalFxReporter(
+      @AppName appName: String,
+      config: SignalFxBackendConfig,
+      metricRegistry: MetricRegistry
+  ): SignalFxReporter {
+    return SignalFxReporter.Builder(
+        metricRegistry,
+        StaticAuthToken(config.access_token),
+        appName
+    )
+        .build()
+  }
 }

--- a/misk/src/main/kotlin/misk/metrics/backends/signalfx/SignalFxReporterService.kt
+++ b/misk/src/main/kotlin/misk/metrics/backends/signalfx/SignalFxReporterService.kt
@@ -6,9 +6,9 @@ import java.util.concurrent.TimeUnit
 import javax.inject.Inject
 
 internal class SignalFxReporterService @Inject internal constructor(
-        private val config: SignalFxBackendConfig,
-        private val reporter: SignalFxReporter
+    private val config: SignalFxBackendConfig,
+    private val reporter: SignalFxReporter
 ) : AbstractIdleService() {
-    override fun startUp() = reporter.start(config.interval.toMillis(), TimeUnit.MILLISECONDS)
-    override fun shutDown() = reporter.stop()
+  override fun startUp() = reporter.start(config.interval.toMillis(), TimeUnit.MILLISECONDS)
+  override fun shutDown() = reporter.stop()
 }

--- a/misk/src/main/kotlin/misk/metrics/backends/stackdriver/StackDriverBackendConfig.kt
+++ b/misk/src/main/kotlin/misk/metrics/backends/stackdriver/StackDriverBackendConfig.kt
@@ -4,7 +4,7 @@ import misk.config.Config
 import java.time.Duration
 
 data class StackDriverBackendConfig(
-        val project_id: String,
-        val interval: Duration,
-        val batch_size: Int = 200
+    val project_id: String,
+    val interval: Duration,
+    val batch_size: Int = 200
 ) : Config

--- a/misk/src/main/kotlin/misk/metrics/backends/stackdriver/StackDriverBackendModule.kt
+++ b/misk/src/main/kotlin/misk/metrics/backends/stackdriver/StackDriverBackendModule.kt
@@ -13,19 +13,20 @@ import misk.inject.asSingleton
 import misk.inject.to
 
 class StackDriverBackendModule : KAbstractModule() {
-    override fun configure() {
-        bind<StackDriverSender>()
-                .to<StackDriverBatchedSender>()
-                .asSingleton()
+  override fun configure() {
+    bind<StackDriverSender>()
+        .to<StackDriverBatchedSender>()
+        .asSingleton()
 
-        binder().addMultibinderBinding<Service>().to<StackDriverReporterService>()
-    }
+    binder().addMultibinderBinding<Service>()
+        .to<StackDriverReporterService>()
+  }
 
-    @Provides
-    @Singleton
-    fun monitoring(@AppName appName: String, config: StackDriverBackendConfig): Monitoring =
-            Monitoring.Builder(GoogleNetHttpTransport.newTrustedTransport(), JacksonFactory(), null)
-                    .setApplicationName(appName)
-                    .build()
+  @Provides
+  @Singleton
+  fun monitoring(@AppName appName: String, config: StackDriverBackendConfig): Monitoring =
+      Monitoring.Builder(GoogleNetHttpTransport.newTrustedTransport(), JacksonFactory(), null)
+          .setApplicationName(appName)
+          .build()
 
 }

--- a/misk/src/main/kotlin/misk/metrics/backends/stackdriver/StackDriverReporter.kt
+++ b/misk/src/main/kotlin/misk/metrics/backends/stackdriver/StackDriverReporter.kt
@@ -24,193 +24,247 @@ import java.util.concurrent.TimeUnit
 import javax.inject.Inject
 
 internal class StackDriverReporter @Inject internal constructor(
-        val clock: Clock,
-        @AppName val appName: String,
-        val instanceMetadata: InstanceMetadata,
-        val sender: StackDriverSender,
-        metricRegistry: com.codahale.metrics.MetricRegistry
-) : ScheduledReporter(metricRegistry, "stack-driver", null,
-        TimeUnit.MILLISECONDS, TimeUnit.MILLISECONDS) {
-    private val startTime = DateTime(clock.millis())
+    val clock: Clock,
+    @AppName val appName: String,
+    val instanceMetadata: InstanceMetadata,
+    val sender: StackDriverSender,
+    metricRegistry: com.codahale.metrics.MetricRegistry
+) : ScheduledReporter(
+    metricRegistry, "stack-driver", null,
+    TimeUnit.MILLISECONDS, TimeUnit.MILLISECONDS
+) {
+  private val startTime = DateTime(clock.millis())
 
-    override fun report(
-            gauges: SortedMap<String, Gauge<Any>>?,
-            counters: SortedMap<String, Counter>?,
-            histograms: SortedMap<String, Histogram>?,
-            meters: SortedMap<String, Meter>?,
-            timers: SortedMap<String, Timer>?) {
-        val timeSeries = toTimeSeries(gauges, counters, histograms, meters,
-                timers, startTime, DateTime(clock.millis()))
-        if (timeSeries.isEmpty()) {
-            return
-        }
-
-        sender.send(timeSeries)
+  override fun report(
+      gauges: SortedMap<String, Gauge<Any>>?,
+      counters: SortedMap<String, Counter>?,
+      histograms: SortedMap<String, Histogram>?,
+      meters: SortedMap<String, Meter>?,
+      timers: SortedMap<String, Timer>?
+  ) {
+    val timeSeries = toTimeSeries(
+        gauges, counters, histograms, meters,
+        timers, startTime, DateTime(clock.millis())
+    )
+    if (timeSeries.isEmpty()) {
+      return
     }
 
-    enum class MetricKind {
-        GAUGE,
-        CUMULATIVE
-    }
+    sender.send(timeSeries)
+  }
 
-    companion object {
-        private val CUSTOM_METRICS_PREFIX = "custom.googleapis.com/dw"
+  enum class MetricKind {
+    GAUGE,
+    CUMULATIVE
+  }
 
-        private val pathJoiner = Joiner.on('/')
-    }
+  companion object {
+    private val CUSTOM_METRICS_PREFIX = "custom.googleapis.com/dw"
 
-    fun toTimeSeries(
-            gauges: SortedMap<String, Gauge<Any>>?,
-            counters: SortedMap<String, Counter>?,
-            histograms: SortedMap<String, Histogram>?,
-            meters: SortedMap<String, Meter>?,
-            timers: SortedMap<String, Timer>?,
-            startTime: DateTime,
-            now: DateTime): List<TimeSeries> {
-        val timeSeries = ArrayList<TimeSeries>()
-        gauges?.forEach { timeSeries.addAll(toTimeSeries(it.key, it.value, startTime, now)) }
-        counters?.forEach { timeSeries.addAll(toTimeSeries(it.key, it.value, startTime, now)) }
-        histograms?.forEach { timeSeries.addAll(toTimeSeries(it.key, it.value, startTime, now)) }
-        timers?.forEach { timeSeries.addAll(toTimeSeries(it.key, it.value, startTime, now)) }
-        meters?.forEach { timeSeries.addAll(toTimeSeries(it.key, it.value, startTime, now)) }
-        return timeSeries
-    }
+    private val pathJoiner = Joiner.on('/')
+  }
 
-    fun toTimeSeries(
-            name: String,
-            gauge: Gauge<Any>,
-            startTime: DateTime,
-            now: DateTime
-    ): Array<TimeSeries> = arrayOf(
-            timeSeries(name, gauge.value, startTime, now, "value", MetricKind.GAUGE))
+  fun toTimeSeries(
+      gauges: SortedMap<String, Gauge<Any>>?,
+      counters: SortedMap<String, Counter>?,
+      histograms: SortedMap<String, Histogram>?,
+      meters: SortedMap<String, Meter>?,
+      timers: SortedMap<String, Timer>?,
+      startTime: DateTime,
+      now: DateTime
+  ): List<TimeSeries> {
+    val timeSeries = ArrayList<TimeSeries>()
+    gauges?.forEach { timeSeries.addAll(toTimeSeries(it.key, it.value, startTime, now)) }
+    counters?.forEach { timeSeries.addAll(toTimeSeries(it.key, it.value, startTime, now)) }
+    histograms?.forEach { timeSeries.addAll(toTimeSeries(it.key, it.value, startTime, now)) }
+    timers?.forEach { timeSeries.addAll(toTimeSeries(it.key, it.value, startTime, now)) }
+    meters?.forEach { timeSeries.addAll(toTimeSeries(it.key, it.value, startTime, now)) }
+    return timeSeries
+  }
 
-    fun toTimeSeries(
-            name: String,
-            counter: Counter,
-            startTime: DateTime,
-            now: DateTime
-    ): Array<TimeSeries> = arrayOf(
-            timeSeries(name, counter.count, startTime, now, "count", MetricKind.CUMULATIVE))
+  fun toTimeSeries(
+      name: String,
+      gauge: Gauge<Any>,
+      startTime: DateTime,
+      now: DateTime
+  ): Array<TimeSeries> = arrayOf(
+      timeSeries(name, gauge.value, startTime, now, "value", MetricKind.GAUGE)
+  )
 
-    fun toTimeSeries(
-            name: String,
-            timer: Timer,
-            startTime: DateTime,
-            now: DateTime
-    ): Array<TimeSeries> {
-        val snapshot = timer.snapshot
-        return arrayOf(
-                timeSeries(name, convertDuration(snapshot.max.toDouble()), startTime, now, "max",
-                        MetricKind.GAUGE),
-                timeSeries(name, convertDuration(snapshot.min.toDouble()), startTime, now, "min",
-                        MetricKind.GAUGE),
-                timeSeries(name, convertDuration(snapshot.mean), startTime, now, "mean",
-                        MetricKind.GAUGE),
-                timeSeries(name, convertDuration(snapshot.stdDev), startTime, now, "stdDev",
-                        MetricKind.GAUGE),
-                timeSeries(name, convertDuration(snapshot.median), startTime, now, "p50",
-                        MetricKind.GAUGE),
-                timeSeries(name, convertDuration(snapshot.get75thPercentile()), startTime, now,
-                        "p75", MetricKind.GAUGE),
-                timeSeries(name, convertDuration(snapshot.get95thPercentile()), startTime, now,
-                        "p95", MetricKind.GAUGE),
-                timeSeries(name, convertDuration(snapshot.get98thPercentile()), startTime, now,
-                        "p98", MetricKind.GAUGE),
-                timeSeries(name, convertDuration(snapshot.get99thPercentile()), startTime, now,
-                        "p99", MetricKind.GAUGE),
-                timeSeries(name, convertDuration(snapshot.get999thPercentile()), startTime, now,
-                        "p999", MetricKind.GAUGE),
-                *toTimeSeries(name, timer as Metered, startTime, now))
-    }
+  fun toTimeSeries(
+      name: String,
+      counter: Counter,
+      startTime: DateTime,
+      now: DateTime
+  ): Array<TimeSeries> = arrayOf(
+      timeSeries(name, counter.count, startTime, now, "count", MetricKind.CUMULATIVE)
+  )
 
-    fun toTimeSeries(
-            name: String,
-            hist: Histogram,
-            startTime: DateTime,
-            now: DateTime
-    ): Array<TimeSeries> {
-        val snapshot = hist.snapshot
-        return arrayOf(
-                timeSeries(name, hist.count, startTime, now, "count", MetricKind.CUMULATIVE),
-                timeSeries(name, snapshot.max.toDouble(), startTime, now, "max", MetricKind.GAUGE),
-                timeSeries(name, snapshot.min.toDouble(), startTime, now, "min", MetricKind.GAUGE),
-                timeSeries(name, snapshot.mean, startTime, now, "mean", MetricKind.GAUGE),
-                timeSeries(name, snapshot.stdDev, startTime, now, "stdDev", MetricKind.GAUGE),
-                timeSeries(name, snapshot.median, startTime, now, "p50", MetricKind.GAUGE),
-                timeSeries(name, snapshot.get75thPercentile(), startTime, now, "p75",
-                        MetricKind.GAUGE),
-                timeSeries(name, snapshot.get95thPercentile(), startTime, now, "p95",
-                        MetricKind.GAUGE),
-                timeSeries(name, snapshot.get98thPercentile(), startTime, now, "p98",
-                        MetricKind.GAUGE),
-                timeSeries(name, snapshot.get99thPercentile(), startTime, now, "p99",
-                        MetricKind.GAUGE),
-                timeSeries(name, snapshot.get999thPercentile(), startTime, now, "p999",
-                        MetricKind.GAUGE))
-    }
+  fun toTimeSeries(
+      name: String,
+      timer: Timer,
+      startTime: DateTime,
+      now: DateTime
+  ): Array<TimeSeries> {
+    val snapshot = timer.snapshot
+    return arrayOf(
+        timeSeries(
+            name, convertDuration(snapshot.max.toDouble()), startTime, now, "max",
+            MetricKind.GAUGE
+        ),
+        timeSeries(
+            name, convertDuration(snapshot.min.toDouble()), startTime, now, "min",
+            MetricKind.GAUGE
+        ),
+        timeSeries(
+            name, convertDuration(snapshot.mean), startTime, now, "mean",
+            MetricKind.GAUGE
+        ),
+        timeSeries(
+            name, convertDuration(snapshot.stdDev), startTime, now, "stdDev",
+            MetricKind.GAUGE
+        ),
+        timeSeries(
+            name, convertDuration(snapshot.median), startTime, now, "p50",
+            MetricKind.GAUGE
+        ),
+        timeSeries(
+            name, convertDuration(snapshot.get75thPercentile()), startTime, now,
+            "p75", MetricKind.GAUGE
+        ),
+        timeSeries(
+            name, convertDuration(snapshot.get95thPercentile()), startTime, now,
+            "p95", MetricKind.GAUGE
+        ),
+        timeSeries(
+            name, convertDuration(snapshot.get98thPercentile()), startTime, now,
+            "p98", MetricKind.GAUGE
+        ),
+        timeSeries(
+            name, convertDuration(snapshot.get99thPercentile()), startTime, now,
+            "p99", MetricKind.GAUGE
+        ),
+        timeSeries(
+            name, convertDuration(snapshot.get999thPercentile()), startTime, now,
+            "p999", MetricKind.GAUGE
+        ),
+        *toTimeSeries(name, timer as Metered, startTime, now)
+    )
+  }
 
-    fun toTimeSeries(
-            name: String,
-            metered: Metered,
-            startTime: DateTime,
-            now: DateTime
-    ): Array<TimeSeries> = arrayOf(
-            timeSeries(name, metered.count, startTime, now, "count", MetricKind.CUMULATIVE),
-            timeSeries(name, convertRate(metered.oneMinuteRate), startTime, now, "m1_rate",
-                    MetricKind.GAUGE),
-            timeSeries(name, convertRate(metered.meanRate), startTime, now, "mean_rate",
-                    MetricKind.GAUGE),
-            timeSeries(name, convertRate(metered.fiveMinuteRate), startTime, now, "m5_rate",
-                    MetricKind.GAUGE),
-            timeSeries(name, convertRate(metered.fifteenMinuteRate), startTime, now, "m15_rate",
-                    MetricKind.GAUGE))
+  fun toTimeSeries(
+      name: String,
+      hist: Histogram,
+      startTime: DateTime,
+      now: DateTime
+  ): Array<TimeSeries> {
+    val snapshot = hist.snapshot
+    return arrayOf(
+        timeSeries(name, hist.count, startTime, now, "count", MetricKind.CUMULATIVE),
+        timeSeries(name, snapshot.max.toDouble(), startTime, now, "max", MetricKind.GAUGE),
+        timeSeries(name, snapshot.min.toDouble(), startTime, now, "min", MetricKind.GAUGE),
+        timeSeries(name, snapshot.mean, startTime, now, "mean", MetricKind.GAUGE),
+        timeSeries(name, snapshot.stdDev, startTime, now, "stdDev", MetricKind.GAUGE),
+        timeSeries(name, snapshot.median, startTime, now, "p50", MetricKind.GAUGE),
+        timeSeries(
+            name, snapshot.get75thPercentile(), startTime, now, "p75",
+            MetricKind.GAUGE
+        ),
+        timeSeries(
+            name, snapshot.get95thPercentile(), startTime, now, "p95",
+            MetricKind.GAUGE
+        ),
+        timeSeries(
+            name, snapshot.get98thPercentile(), startTime, now, "p98",
+            MetricKind.GAUGE
+        ),
+        timeSeries(
+            name, snapshot.get99thPercentile(), startTime, now, "p99",
+            MetricKind.GAUGE
+        ),
+        timeSeries(
+            name, snapshot.get999thPercentile(), startTime, now, "p999",
+            MetricKind.GAUGE
+        )
+    )
+  }
 
-    private fun timeSeries(
-            name: String,
-            pointValue: Any,
-            startTime: DateTime,
-            now: DateTime,
-            subType: String,
-            metricKind: MetricKind
-    ): TimeSeries = TimeSeries()
-            .setMetricKind(metricKind.name)
-            .setMetric(metric(type(name, subType)))
-            .setPoints(listOf(point(metricKind, startTime, now, typedValue(pointValue))))
+  fun toTimeSeries(
+      name: String,
+      metered: Metered,
+      startTime: DateTime,
+      now: DateTime
+  ): Array<TimeSeries> = arrayOf(
+      timeSeries(name, metered.count, startTime, now, "count", MetricKind.CUMULATIVE),
+      timeSeries(
+          name, convertRate(metered.oneMinuteRate), startTime, now, "m1_rate",
+          MetricKind.GAUGE
+      ),
+      timeSeries(
+          name, convertRate(metered.meanRate), startTime, now, "mean_rate",
+          MetricKind.GAUGE
+      ),
+      timeSeries(
+          name, convertRate(metered.fiveMinuteRate), startTime, now, "m5_rate",
+          MetricKind.GAUGE
+      ),
+      timeSeries(
+          name, convertRate(metered.fifteenMinuteRate), startTime, now, "m15_rate",
+          MetricKind.GAUGE
+      )
+  )
 
-    private fun point(
-            metricKind: MetricKind,
-            startTime: DateTime,
-            now: DateTime,
-            value: TypedValue
-    ): Point = Point()
-            .setInterval(timeInterval(startTime, now, metricKind))
-            .setValue(value)
+  private fun timeSeries(
+      name: String,
+      pointValue: Any,
+      startTime: DateTime,
+      now: DateTime,
+      subType: String,
+      metricKind: MetricKind
+  ): TimeSeries = TimeSeries()
+      .setMetricKind(metricKind.name)
+      .setMetric(metric(type(name, subType)))
+      .setPoints(listOf(point(metricKind, startTime, now, typedValue(pointValue))))
 
-    private fun timeInterval(
-            startTime: DateTime,
-            now: DateTime,
-            metricKind: MetricKind
-    ): TimeInterval = when (metricKind) {
-        MetricKind.CUMULATIVE -> TimeInterval()
-                .setStartTime(startTime.toStringRfc3339())
-                .setEndTime(now.toStringRfc3339())
-        MetricKind.GAUGE -> TimeInterval().setEndTime(now.toStringRfc3339())
-    }
+  private fun point(
+      metricKind: MetricKind,
+      startTime: DateTime,
+      now: DateTime,
+      value: TypedValue
+  ): Point = Point()
+      .setInterval(timeInterval(startTime, now, metricKind))
+      .setValue(value)
 
-    private fun type(root: String, vararg others: String) =
-            pathJoiner.join(CUSTOM_METRICS_PREFIX,
-                    appName, instanceMetadata.zone, instanceMetadata.instanceName,
-                    root, *others)
+  private fun timeInterval(
+      startTime: DateTime,
+      now: DateTime,
+      metricKind: MetricKind
+  ): TimeInterval = when (metricKind) {
+    MetricKind.CUMULATIVE -> TimeInterval()
+        .setStartTime(startTime.toStringRfc3339())
+        .setEndTime(now.toStringRfc3339())
+    MetricKind.GAUGE -> TimeInterval().setEndTime(now.toStringRfc3339())
+  }
 
-    private fun metric(type: String): Metric = Metric().setType(type)
+  private fun type(
+      root: String,
+      vararg others: String
+  ) =
+      pathJoiner.join(
+          CUSTOM_METRICS_PREFIX,
+          appName, instanceMetadata.zone, instanceMetadata.instanceName,
+          root, *others
+      )
 
-    private fun typedValue(o: Any): TypedValue = when (o) {
-        is Float -> TypedValue().setDoubleValue(o.toDouble())
-        is Double -> TypedValue().setDoubleValue(o.toDouble())
-        is BigInteger -> TypedValue().setDoubleValue(o.toDouble())
-        is BigDecimal -> TypedValue().setDoubleValue(o.toDouble())
-        is Number -> TypedValue().setInt64Value(o.toLong())
-        else -> TypedValue()
-    }
+  private fun metric(type: String): Metric = Metric().setType(type)
+
+  private fun typedValue(o: Any): TypedValue = when (o) {
+    is Float -> TypedValue().setDoubleValue(o.toDouble())
+    is Double -> TypedValue().setDoubleValue(o.toDouble())
+    is BigInteger -> TypedValue().setDoubleValue(o.toDouble())
+    is BigDecimal -> TypedValue().setDoubleValue(o.toDouble())
+    is Number -> TypedValue().setInt64Value(o.toLong())
+    else -> TypedValue()
+  }
 
 }

--- a/misk/src/main/kotlin/misk/metrics/backends/stackdriver/StackDriverReporterService.kt
+++ b/misk/src/main/kotlin/misk/metrics/backends/stackdriver/StackDriverReporterService.kt
@@ -5,9 +5,9 @@ import java.util.concurrent.TimeUnit
 import javax.inject.Inject
 
 internal class StackDriverReporterService @Inject internal constructor(
-        private val config: StackDriverBackendConfig,
-        private val reporter: StackDriverReporter
+    private val config: StackDriverBackendConfig,
+    private val reporter: StackDriverReporter
 ) : AbstractIdleService() {
-    override fun startUp() = reporter.start(config.interval.toMillis(), TimeUnit.MILLISECONDS)
-    override fun shutDown() = reporter.stop()
+  override fun startUp() = reporter.start(config.interval.toMillis(), TimeUnit.MILLISECONDS)
+  override fun shutDown() = reporter.stop()
 }

--- a/misk/src/main/kotlin/misk/metrics/backends/stackdriver/StackDriverSender.kt
+++ b/misk/src/main/kotlin/misk/metrics/backends/stackdriver/StackDriverSender.kt
@@ -3,5 +3,5 @@ package misk.metrics.backends.stackdriver
 import com.google.api.services.monitoring.v3.model.TimeSeries
 
 internal interface StackDriverSender {
-    fun send(timeSeries: List<TimeSeries>)
+  fun send(timeSeries: List<TimeSeries>)
 }

--- a/misk/src/main/kotlin/misk/metrics/web/JsonMetrics.kt
+++ b/misk/src/main/kotlin/misk/metrics/web/JsonMetrics.kt
@@ -9,72 +9,79 @@ import misk.metrics.Metrics
 import java.util.concurrent.TimeUnit
 
 data class JsonCounter(val count: Long) {
-    constructor(counter: Counter) : this(counter.count)
+  constructor(counter: Counter) : this(counter.count)
 }
 
 data class JsonGauge<T>(val value: T) {
-    constructor(gauge: Gauge<T>) : this(gauge.value)
+  constructor(gauge: Gauge<T>) : this(gauge.value)
 }
 
 data class JsonTimer(
-        val count: Long,
-        val oneMinuteRate: Double,
-        val fiveMinuteRate: Double,
-        val fifteenMinuteRate: Double,
-        val meanRate: Double,
-        val snapshot: JsonHistogramSnapshot
+    val count: Long,
+    val oneMinuteRate: Double,
+    val fiveMinuteRate: Double,
+    val fifteenMinuteRate: Double,
+    val meanRate: Double,
+    val snapshot: JsonHistogramSnapshot
 ) {
-    constructor(timer: Timer) : this(
-            timer.count,
-            timer.oneMinuteRate * RATE_FACTOR,
-            timer.fiveMinuteRate * RATE_FACTOR,
-            timer.fifteenMinuteRate * RATE_FACTOR,
-            timer.meanRate * RATE_FACTOR,
-            JsonHistogramSnapshot(timer.snapshot, DURATION_FACTOR)
-    )
+  constructor(timer: Timer) : this(
+      timer.count,
+      timer.oneMinuteRate * RATE_FACTOR,
+      timer.fiveMinuteRate * RATE_FACTOR,
+      timer.fifteenMinuteRate * RATE_FACTOR,
+      timer.meanRate * RATE_FACTOR,
+      JsonHistogramSnapshot(timer.snapshot, DURATION_FACTOR)
+  )
 }
 
 data class JsonHistogramSnapshot(
-        val min: Double,
-        val max: Double,
-        val mean: Double,
-        val stdDev: Double,
-        val p50: Double,
-        val p75: Double,
-        val p95: Double,
-        val p98: Double,
-        val p99: Double,
-        val p999: Double
+    val min: Double,
+    val max: Double,
+    val mean: Double,
+    val stdDev: Double,
+    val p50: Double,
+    val p75: Double,
+    val p95: Double,
+    val p98: Double,
+    val p99: Double,
+    val p999: Double
 ) {
-    constructor(snapshot: Snapshot, conversionFactor: Double = 1.0) : this(
-            min = snapshot.min.toDouble() * conversionFactor,
-            max = snapshot.max.toDouble() * conversionFactor,
-            mean = snapshot.mean * conversionFactor,
-            stdDev = snapshot.stdDev * conversionFactor,
-            p50 = snapshot.median * conversionFactor,
-            p75 = snapshot.get75thPercentile() * conversionFactor,
-            p95 = snapshot.get95thPercentile() * conversionFactor,
-            p98 = snapshot.get98thPercentile() * conversionFactor,
-            p99 = snapshot.get99thPercentile() * conversionFactor,
-            p999 = snapshot.get999thPercentile() * conversionFactor)
+  constructor(
+      snapshot: Snapshot,
+      conversionFactor: Double = 1.0
+  ) : this(
+      min = snapshot.min.toDouble() * conversionFactor,
+      max = snapshot.max.toDouble() * conversionFactor,
+      mean = snapshot.mean * conversionFactor,
+      stdDev = snapshot.stdDev * conversionFactor,
+      p50 = snapshot.median * conversionFactor,
+      p75 = snapshot.get75thPercentile() * conversionFactor,
+      p95 = snapshot.get95thPercentile() * conversionFactor,
+      p98 = snapshot.get98thPercentile() * conversionFactor,
+      p99 = snapshot.get99thPercentile() * conversionFactor,
+      p999 = snapshot.get999thPercentile() * conversionFactor
+  )
 }
 
-data class JsonHistogram(val count: Long, val snapshot: JsonHistogramSnapshot) {
-    constructor(hist: Histogram) : this(hist.count, JsonHistogramSnapshot(hist.snapshot))
+data class JsonHistogram(
+    val count: Long,
+    val snapshot: JsonHistogramSnapshot
+) {
+  constructor(hist: Histogram) : this(hist.count, JsonHistogramSnapshot(hist.snapshot))
 }
 
 data class JsonMetrics(
-        val counters: Map<String, JsonCounter>,
-        val timers: Map<String, JsonTimer>,
-        val histograms: Map<String, JsonHistogram>,
-        val gauges: Map<String, JsonGauge<Any>>
+    val counters: Map<String, JsonCounter>,
+    val timers: Map<String, JsonTimer>,
+    val histograms: Map<String, JsonHistogram>,
+    val gauges: Map<String, JsonGauge<Any>>
 ) {
-    constructor(metrics: Metrics) : this(
-            metrics.counters.map { it.key to JsonCounter(it.value) }.toMap(),
-            metrics.timers.map { it.key to JsonTimer(it.value) }.toMap(),
-            metrics.histograms.map { it.key to JsonHistogram(it.value) }.toMap(),
-            metrics.gauges.map { it.key to JsonGauge(it.value) }.toMap()
-    )
+  constructor(metrics: Metrics) : this(
+      metrics.counters.map { it.key to JsonCounter(it.value) }.toMap(),
+      metrics.timers.map { it.key to JsonTimer(it.value) }.toMap(),
+      metrics.histograms.map { it.key to JsonHistogram(it.value) }.toMap(),
+      metrics.gauges.map { it.key to JsonGauge(it.value) }.toMap()
+  )
 }
 
 private val RATE_FACTOR = 1.0 / TimeUnit.MILLISECONDS.toNanos(1)

--- a/misk/src/main/kotlin/misk/metrics/web/MetricsJsonAction.kt
+++ b/misk/src/main/kotlin/misk/metrics/web/MetricsJsonAction.kt
@@ -11,7 +11,7 @@ import javax.inject.Singleton
 /** Exposes metrics as JSON over HTTP */
 @Singleton
 class MetricsJsonAction @Inject internal constructor(val metrics: Metrics) : WebAction {
-    @Get("/_metrics")
-    @ResponseContentType(MediaTypes.APPLICATION_JSON)
-    fun getMetrics(): JsonMetrics = JsonMetrics(metrics)
+  @Get("/_metrics")
+  @ResponseContentType(MediaTypes.APPLICATION_JSON)
+  fun getMetrics(): JsonMetrics = JsonMetrics(metrics)
 }

--- a/misk/src/main/kotlin/misk/moshi/MoshiModule.kt
+++ b/misk/src/main/kotlin/misk/moshi/MoshiModule.kt
@@ -7,19 +7,19 @@ import misk.inject.KAbstractModule
 import javax.inject.Singleton
 
 class MoshiModule : KAbstractModule() {
-    override fun configure() {
-        newSetBinder<JsonAdapter.Factory>()
-    }
+  override fun configure() {
+    newSetBinder<JsonAdapter.Factory>()
+  }
 
-    @Provides
-    @Singleton
-    fun provideMoshi(
-        jsonAdapterFactories: MutableSet<JsonAdapter.Factory>
-    ): Moshi {
-        val builder = Moshi.Builder()
-        for (jsonAdapterFactory in jsonAdapterFactories) {
-            builder.add(jsonAdapterFactory)
-        }
-        return builder.build()
+  @Provides
+  @Singleton
+  fun provideMoshi(
+      jsonAdapterFactories: MutableSet<JsonAdapter.Factory>
+  ): Moshi {
+    val builder = Moshi.Builder()
+    for (jsonAdapterFactory in jsonAdapterFactories) {
+      builder.add(jsonAdapterFactory)
     }
+    return builder.build()
+  }
 }

--- a/misk/src/main/kotlin/misk/nio/FileExtensions.kt
+++ b/misk/src/main/kotlin/misk/nio/FileExtensions.kt
@@ -2,7 +2,10 @@ package misk.nio
 
 import java.nio.channels.FileChannel
 
-fun <T> FileChannel.withLock(shared: Boolean, action: () -> T) =
-        lock(0, Long.MAX_VALUE, shared).use { action() }
+fun <T> FileChannel.withLock(
+    shared: Boolean,
+    action: () -> T
+) =
+    lock(0, Long.MAX_VALUE, shared).use { action() }
 
 

--- a/misk/src/main/kotlin/misk/okio/OkioExtensions.kt
+++ b/misk/src/main/kotlin/misk/okio/OkioExtensions.kt
@@ -1,16 +1,21 @@
 package misk.okio
 
-import okio.Buffer
 import okio.BufferedSource
 
-fun BufferedSource.forEachBlock(buffer: ByteArray, f: (buffer: ByteArray, bytesRead: Int) -> Unit) {
-    var bytesRead = read(buffer)
-    while (bytesRead != -1) {
-        f(buffer, bytesRead)
-        bytesRead = read(buffer)
-    }
+fun BufferedSource.forEachBlock(
+    buffer: ByteArray,
+    f: (buffer: ByteArray, bytesRead: Int) -> Unit
+) {
+  var bytesRead = read(buffer)
+  while (bytesRead != -1) {
+    f(buffer, bytesRead)
+    bytesRead = read(buffer)
+  }
 }
 
-fun BufferedSource.forEachBlock(blockSize: Int, f: (buffer: ByteArray, bytesRead: Int) -> Unit) {
-    forEachBlock(ByteArray(blockSize), f)
+fun BufferedSource.forEachBlock(
+    blockSize: Int,
+    f: (buffer: ByteArray, bytesRead: Int) -> Unit
+) {
+  forEachBlock(ByteArray(blockSize), f)
 }

--- a/misk/src/main/kotlin/misk/resources/ResourceLoader.kt
+++ b/misk/src/main/kotlin/misk/resources/ResourceLoader.kt
@@ -12,27 +12,27 @@ import okio.Okio
  * while the process is running, and because scanning the classpath isn't necessarily very fast!
  */
 object ResourceLoader {
-    val resourcesByPath: Map<String, ResourceInfo>
+  val resourcesByPath: Map<String, ResourceInfo>
 
-    init {
-        val classLoader = ResourceLoader::class.java.classLoader
-        val classPath = ClassPath.from(classLoader)
-        resourcesByPath = classPath.resources.associateBy { r -> r.resourceName }
-    }
+  init {
+    val classLoader = ResourceLoader::class.java.classLoader
+    val classPath = ClassPath.from(classLoader)
+    resourcesByPath = classPath.resources.associateBy { r -> r.resourceName }
+  }
 
-    /** Return a buffered source for `path`, or null if no such resource exists. */
-    fun open(path: String): BufferedSource? {
-        val resource = resourcesByPath[path] ?: return null
-        return Okio.buffer(Okio.source(resource.asByteSource().openStream()))
-    }
+  /** Return a buffered source for `path`, or null if no such resource exists. */
+  fun open(path: String): BufferedSource? {
+    val resource = resourcesByPath[path] ?: return null
+    return Okio.buffer(Okio.source(resource.asByteSource().openStream()))
+  }
 
-    /**
-     * Return the contents of `path` as a string, or null if no such resource exists. Note that this
-     * method decodes the resource on every use. It is the caller's responsibility to cache the
-     * result if it is to be loaded frequently.
-     */
-    fun utf8(path: String): String? {
-        val source = open(path) ?: return null
-        return source.use { it.readUtf8() }
-    }
+  /**
+   * Return the contents of `path` as a string, or null if no such resource exists. Note that this
+   * method decodes the resource on every use. It is the caller's responsibility to cache the
+   * result if it is to be loaded frequently.
+   */
+  fun utf8(path: String): String? {
+    val source = open(path) ?: return null
+    return source.use { it.readUtf8() }
+  }
 }

--- a/misk/src/main/kotlin/misk/scope/ActionScope.kt
+++ b/misk/src/main/kotlin/misk/scope/ActionScope.kt
@@ -13,128 +13,131 @@ import kotlin.reflect.KVisibility
 
 @Singleton
 class ActionScope @Inject internal constructor(
-        // NB(mmihic): ActionScoped depends on ActionScope depends on
-        // on ActionScopedProviders, which might depend on other ActionScopeds. We break
-        // this circular dependency by injecting a map of Provider<ActionScopedProvider>
-        // rather than the map of ActionScopedProvider directly
-        private val providers: @JvmSuppressWildcards Map<Key<*>, Provider<ActionScopedProvider<*>>>
+    // NB(mmihic): ActionScoped depends on ActionScope depends on
+    // on ActionScopedProviders, which might depend on other ActionScopeds. We break
+    // this circular dependency by injecting a map of Provider<ActionScopedProvider>
+    // rather than the map of ActionScopedProvider directly
+    private val providers: @JvmSuppressWildcards Map<Key<*>, Provider<ActionScopedProvider<*>>>
 ) : AutoCloseable {
-    companion object {
-        private val tls = ThreadLocal<LinkedHashMap<Key<*>, Any>>()
+  companion object {
+    private val tls = ThreadLocal<LinkedHashMap<Key<*>, Any>>()
+  }
+
+  /** Starts the scope on a thread with the provided seed data */
+  fun enter(seedData: Map<Key<*>, Any>): ActionScope {
+    check(tls.get() == null) {
+      "cannot begin an ActionScope on a thread that is already running in an action scope"
     }
 
-    /** Starts the scope on a thread with the provided seed data */
-    fun enter(seedData: Map<Key<*>, Any>): ActionScope {
-        check(tls.get() == null) {
-            "cannot begin an ActionScope on a thread that is already running in an action scope"
-        }
+    tls.set(LinkedHashMap(seedData))
+    return this
+  }
 
-        tls.set(LinkedHashMap(seedData))
-        return this
+  override fun close() {
+    tls.remove()
+  }
+
+  /** Returns true if currently in the scope */
+  fun inScope(): Boolean = tls.get() != null
+
+  /**
+   * Wraps a [Callable] that will be called on another thread, propagating the current
+   * scoped data onto that thread
+   */
+  fun <T> propagate(c: Callable<T>): Callable<T> {
+    check(tls.get() != null) { "not running within an ActionScope" }
+
+    val currentScopedData = tls.get()
+        .toMap()
+    return Callable {
+      enter(currentScopedData).use {
+        c.call()
+      }
     }
+  }
 
-    override fun close() {
-        tls.remove()
+  /**
+   * Wraps a [KFunction] that will be called on another thread, propagating the current
+   * scoped data onto that thread
+   */
+  fun <T> propagate(f: KFunction<T>): KFunction<T> {
+    check(tls.get() != null) { "not running within an ActionScope" }
+
+    val currentScopedData = tls.get()
+        .toMap()
+    return WrappedKFunction(currentScopedData, this, f)
+  }
+
+  /**
+   * Wraps a function or lambda that will be called on another thread, propagating the current
+   * scoped data onto that thread
+   */
+  fun <T> propagate(f: () -> T): () -> T {
+    check(tls.get() != null) { "not running within an ActionScope" }
+
+    val currentScopedData = tls.get()
+        .toMap()
+    return {
+      enter(currentScopedData).use {
+        f.invoke()
+      }
     }
+  }
 
-    /** Returns true if currently in the scope */
-    fun inScope(): Boolean = tls.get() != null
+  /** Returns the action scoped value for the given key */
+  fun <T> get(key: Key<T>): T {
+    check(tls.get() != null) { "not running within an ActionScope" }
 
-    /**
-     * Wraps a [Callable] that will be called on another thread, propagating the current
-     * scoped data onto that thread
-     */
-    fun <T> propagate(c: Callable<T>): Callable<T> {
-        check(tls.get() != null) { "not running within an ActionScope" }
-
-        val currentScopedData = tls.get().toMap()
-        return Callable {
-            enter(currentScopedData).use {
-                c.call()
-            }
-        }
-    }
-
-    /**
-     * Wraps a [KFunction] that will be called on another thread, propagating the current
-     * scoped data onto that thread
-     */
-    fun <T> propagate(f: KFunction<T>): KFunction<T> {
-        check(tls.get() != null) { "not running within an ActionScope" }
-
-        val currentScopedData = tls.get().toMap()
-        return WrappedKFunction(currentScopedData, this, f)
-    }
-
-    /**
-     * Wraps a function or lambda that will be called on another thread, propagating the current
-     * scoped data onto that thread
-     */
-    fun <T> propagate(f: () -> T): () -> T {
-        check(tls.get() != null) { "not running within an ActionScope" }
-
-        val currentScopedData = tls.get().toMap()
-        return {
-            enter(currentScopedData).use {
-                f.invoke()
-            }
-        }
-    }
-
-    /** Returns the action scoped value for the given key */
-    fun <T> get(key: Key<T>): T {
-        check(tls.get() != null) { "not running within an ActionScope" }
-
-        // NB(mmihic): We don't use computeIfAbsent because computing the value of this
-        // key might require computing the values of keys on which we depend, which would
-        // cause recursive calls to computeIfAbsent which is unsupported (and explicitly
-        // detected in JDK 9+)
-        val threadState = tls.get()
-        val cachedValue = threadState[key]
-        if (cachedValue != null) {
-            @Suppress("UNCHECKED_CAST")
-            return cachedValue as T
-        }
-
-        @Suppress("UNCHECKED_CAST")
-        val value = providerFor(key as Key<Any>).get() as T
-        threadState[key] = value as Any
-        return value
+    // NB(mmihic): We don't use computeIfAbsent because computing the value of this
+    // key might require computing the values of keys on which we depend, which would
+    // cause recursive calls to computeIfAbsent which is unsupported (and explicitly
+    // detected in JDK 9+)
+    val threadState = tls.get()
+    val cachedValue = threadState[key]
+    if (cachedValue != null) {
+      @Suppress("UNCHECKED_CAST")
+      return cachedValue as T
     }
 
     @Suppress("UNCHECKED_CAST")
-    private fun providerFor(key: Key<*>): ActionScopedProvider<*> {
-        return requireNotNull(providers[key]?.get()) {
-            "no ActionScopedProvider available for $key"
-        }
+    val value = providerFor(key as Key<Any>).get() as T
+    threadState[key] = value as Any
+    return value
+  }
+
+  @Suppress("UNCHECKED_CAST")
+  private fun providerFor(key: Key<*>): ActionScopedProvider<*> {
+    return requireNotNull(providers[key]?.get()) {
+      "no ActionScopedProvider available for $key"
+    }
+  }
+
+  private class WrappedKFunction<T>(
+      val seedData: Map<Key<*>, Any>,
+      val scope: ActionScope,
+      val wrapped: KFunction<T>
+  ) : KFunction<T> {
+    override fun call(vararg args: Any?): T = scope.enter(seedData).use {
+      wrapped.call(*args)
     }
 
-    private class WrappedKFunction<T>(
-            val seedData: Map<Key<*>, Any>,
-            val scope: ActionScope,
-            val wrapped: KFunction<T>
-    ) : KFunction<T> {
-        override fun call(vararg args: Any?): T = scope.enter(seedData).use {
-                    wrapped.call(*args)
-                }
-
-        override fun callBy(args: Map<KParameter, Any?>): T = scope.enter(seedData).use {
-                    wrapped.callBy(args)
-                }
-
-        override val annotations: List<Annotation> = wrapped.annotations
-        override val isAbstract: Boolean = wrapped.isAbstract
-        override val isFinal: Boolean = true
-        override val isOpen: Boolean = false
-        override val name: String = wrapped.name
-        override val parameters: List<KParameter> = wrapped.parameters
-        override val returnType: KType = wrapped.returnType
-        override val typeParameters: List<KTypeParameter> = wrapped.typeParameters
-        override val visibility: KVisibility? = wrapped.visibility
-        override val isExternal: Boolean = wrapped.isExternal
-        override val isInfix: Boolean = wrapped.isInfix
-        override val isInline: Boolean = wrapped.isInline
-        override val isOperator: Boolean = wrapped.isOperator
-        override val isSuspend: Boolean = wrapped.isSuspend
+    override fun callBy(args: Map<KParameter, Any?>): T = scope.enter(seedData).use {
+      wrapped.callBy(args)
     }
+
+    override val annotations: List<Annotation> = wrapped.annotations
+    override val isAbstract: Boolean = wrapped.isAbstract
+    override val isFinal: Boolean = true
+    override val isOpen: Boolean = false
+    override val name: String = wrapped.name
+    override val parameters: List<KParameter> = wrapped.parameters
+    override val returnType: KType = wrapped.returnType
+    override val typeParameters: List<KTypeParameter> = wrapped.typeParameters
+    override val visibility: KVisibility? = wrapped.visibility
+    override val isExternal: Boolean = wrapped.isExternal
+    override val isInfix: Boolean = wrapped.isInfix
+    override val isInline: Boolean = wrapped.isInline
+    override val isOperator: Boolean = wrapped.isOperator
+    override val isSuspend: Boolean = wrapped.isSuspend
+  }
 }

--- a/misk/src/main/kotlin/misk/scope/ActionScoped.kt
+++ b/misk/src/main/kotlin/misk/scope/ActionScoped.kt
@@ -2,12 +2,12 @@ package misk.scope
 
 /** Provides access to a context object specific to the current action */
 interface ActionScoped<out T> {
-    fun get() : T
+  fun get(): T
 
-    companion object {
-        /** @return an [ActionScoped] hard-coded to a specific value, useful for tests */
-        fun <T> of(value: T) = object: ActionScoped<T> {
-            override fun get() = value
-        }
+  companion object {
+    /** @return an [ActionScoped] hard-coded to a specific value, useful for tests */
+    fun <T> of(value: T) = object : ActionScoped<T> {
+      override fun get() = value
     }
+  }
 }

--- a/misk/src/main/kotlin/misk/scope/ActionScopedProvider.kt
+++ b/misk/src/main/kotlin/misk/scope/ActionScopedProvider.kt
@@ -5,5 +5,5 @@ package misk.scope
  * provide contextual information based on an incoming request, job data, etc.
  */
 interface ActionScopedProvider<out T> {
-    fun get(): T
+  fun get(): T
 }

--- a/misk/src/main/kotlin/misk/scope/ActionScopedProviderModule.kt
+++ b/misk/src/main/kotlin/misk/scope/ActionScopedProviderModule.kt
@@ -14,96 +14,112 @@ import kotlin.reflect.KClass
 
 /** Module used by components and applications to provide [ActionScoped] context objects */
 abstract class ActionScopedProviderModule : KAbstractModule() {
-    override fun configure() {
-        MapBinder.newMapBinder(binder(), KEY_TYPE, ACTION_SCOPED_PROVIDER_TYPE)
-        Multibinder.newSetBinder(binder(), KEY_TYPE)
-        configureProviders()
+  override fun configure() {
+    MapBinder.newMapBinder(binder(), KEY_TYPE, ACTION_SCOPED_PROVIDER_TYPE)
+    Multibinder.newSetBinder(binder(), KEY_TYPE)
+    configureProviders()
+  }
+
+  abstract fun configureProviders()
+
+  /** Binds an [ActionScoped] which only pulls from data seeded at the scope entry */
+  fun <T : Any> bindSeedData(kclass: KClass<T>) {
+    bindSeedData(Key.get(kclass.java), Key.get(actionScopedType(kclass)))
+  }
+
+  /** Binds an annotation qualified [ActionScoped] which only pulls from data seeded at the scope entry */
+  fun <T : Any> bindSeedData(
+      kclass: KClass<T>,
+      a: Annotation
+  ) {
+    bindSeedData(Key.get(kclass.java, a), Key.get(actionScopedType(kclass), a))
+  }
+
+  /** Binds an annotation qualified [ActionScoped] which only pulls from data seeded at the scope entry */
+  fun <T : Any, A : Annotation> bindSeedData(
+      kclass: KClass<T>,
+      a: KClass<A>
+  ) {
+    bindSeedData(Key.get(kclass.java, a.java), Key.get(actionScopedType(kclass), a.java))
+  }
+
+  private fun <T : Any> bindSeedData(
+      key: Key<T>,
+      actionScopedKey: Key<ActionScoped<T>>
+  ) {
+    bindProvider(key, actionScopedKey, Provider<ActionScopedProvider<T>> {
+      SeedDataActionScopedProvider(key)
+    })
+  }
+
+  /** Binds an unqualified [ActionScoped] along with its provider */
+  fun <T : Any> bindProvider(
+      kclass: KClass<T>,
+      providerClass: KClass<out ActionScopedProvider<T>>
+  ) {
+    bindProvider(
+        Key.get(kclass.java),
+        Key.get(actionScopedType(kclass)),
+        binder().getProvider(providerClass.java)
+    )
+  }
+
+  /** Binds an annotation qualified [ActionScoped] along with its provider */
+  fun <T : Any> bindProvider(
+      kclass: KClass<T>,
+      a: Annotation,
+      providerClass: KClass<out ActionScopedProvider<T>>
+  ) {
+    bindProvider(
+        Key.get(kclass.java, a),
+        Key.get(actionScopedType(kclass), a),
+        binder().getProvider(providerClass.java)
+    )
+  }
+
+  /** Binds an annotation qualified [ActionScoped] along with its provider */
+  fun <T : Any> bindProvider(
+      kclass: KClass<T>,
+      a: KClass<Annotation>,
+      providerClass: KClass<out ActionScopedProvider<T>>
+  ) {
+    bindProvider(
+        Key.get(kclass.java, a.java),
+        Key.get(actionScopedType(kclass), a.java),
+        binder().getProvider(providerClass.java)
+    )
+  }
+
+  private fun <T : Any> bindProvider(
+      key: Key<T>,
+      actionScopedKey: Key<ActionScoped<T>>,
+      providerProvider: Provider<out ActionScopedProvider<T>>
+  ) {
+    MapBinder.newMapBinder(binder(), KEY_TYPE, ACTION_SCOPED_PROVIDER_TYPE)
+        .addBinding(key)
+        .toProvider(providerProvider)
+    bind(actionScopedKey).toProvider(object : Provider<ActionScoped<T>> {
+      @Inject lateinit var scope: ActionScope
+      override fun get() = RealActionScoped(key, scope)
+    })
+        .asSingleton()
+  }
+
+  companion object {
+    @Suppress("UNCHECKED_CAST")
+    private fun <T : Any> actionScopedType(kclass: KClass<T>) =
+        parameterizedType<ActionScoped<T>>(kclass.java).typeLiteral()
+            as TypeLiteral<ActionScoped<T>>
+
+    private val KEY_TYPE = object : TypeLiteral<Key<*>>() {}
+    private val ACTION_SCOPED_PROVIDER_TYPE = object : TypeLiteral<ActionScopedProvider<*>>() {}
+
+    private class SeedDataActionScopedProvider<out T>(private val key: Key<T>) :
+        ActionScopedProvider<T> {
+      override fun get(): T {
+        throw IllegalStateException("$key can only be provided as seed data")
+      }
     }
-
-    abstract fun configureProviders()
-
-    /** Binds an [ActionScoped] which only pulls from data seeded at the scope entry */
-    fun <T : Any> bindSeedData(kclass: KClass<T>) {
-        bindSeedData(Key.get(kclass.java), Key.get(actionScopedType(kclass)))
-    }
-
-    /** Binds an annotation qualified [ActionScoped] which only pulls from data seeded at the scope entry */
-    fun <T : Any> bindSeedData(kclass: KClass<T>, a: Annotation) {
-        bindSeedData(Key.get(kclass.java, a), Key.get(actionScopedType(kclass), a))
-    }
-
-    /** Binds an annotation qualified [ActionScoped] which only pulls from data seeded at the scope entry */
-    fun <T : Any, A : Annotation> bindSeedData(kclass: KClass<T>, a: KClass<A>) {
-        bindSeedData(Key.get(kclass.java, a.java), Key.get(actionScopedType(kclass), a.java))
-    }
-
-    private fun <T : Any> bindSeedData(key: Key<T>, actionScopedKey: Key<ActionScoped<T>>) {
-        bindProvider(key, actionScopedKey, Provider<ActionScopedProvider<T>> {
-            SeedDataActionScopedProvider(key)
-        })
-    }
-
-    /** Binds an unqualified [ActionScoped] along with its provider */
-    fun <T : Any> bindProvider(
-            kclass: KClass<T>,
-            providerClass: KClass<out ActionScopedProvider<T>>) {
-        bindProvider(
-                Key.get(kclass.java),
-                Key.get(actionScopedType(kclass)),
-                binder().getProvider(providerClass.java))
-    }
-
-    /** Binds an annotation qualified [ActionScoped] along with its provider */
-    fun <T : Any> bindProvider(
-            kclass: KClass<T>,
-            a: Annotation,
-            providerClass: KClass<out ActionScopedProvider<T>>) {
-        bindProvider(
-                Key.get(kclass.java, a),
-                Key.get(actionScopedType(kclass), a),
-                binder().getProvider(providerClass.java))
-    }
-
-    /** Binds an annotation qualified [ActionScoped] along with its provider */
-    fun <T : Any> bindProvider(
-            kclass: KClass<T>,
-            a: KClass<Annotation>,
-            providerClass: KClass<out ActionScopedProvider<T>>) {
-        bindProvider(
-                Key.get(kclass.java, a.java),
-                Key.get(actionScopedType(kclass), a.java),
-                binder().getProvider(providerClass.java))
-    }
-
-    private fun <T : Any> bindProvider(
-            key: Key<T>,
-            actionScopedKey: Key<ActionScoped<T>>,
-            providerProvider: Provider<out ActionScopedProvider<T>>
-    ) {
-        MapBinder.newMapBinder(binder(), KEY_TYPE, ACTION_SCOPED_PROVIDER_TYPE)
-                .addBinding(key)
-                .toProvider(providerProvider)
-        bind(actionScopedKey).toProvider(object : Provider<ActionScoped<T>> {
-            @Inject lateinit var scope: ActionScope
-            override fun get() = RealActionScoped(key, scope)
-        }).asSingleton()
-    }
-
-    companion object {
-        @Suppress("UNCHECKED_CAST")
-        private fun <T : Any> actionScopedType(kclass: KClass<T>) =
-                parameterizedType<ActionScoped<T>>(kclass.java).typeLiteral()
-                        as TypeLiteral<ActionScoped<T>>
-
-        private val KEY_TYPE = object : TypeLiteral<Key<*>>() {}
-        private val ACTION_SCOPED_PROVIDER_TYPE = object : TypeLiteral<ActionScopedProvider<*>>() {}
-
-        private class SeedDataActionScopedProvider<out T>(private val key: Key<T>) :
-                ActionScopedProvider<T> {
-            override fun get(): T {
-                throw IllegalStateException("$key can only be provided as seed data")
-            }
-        }
-    }
+  }
 
 }

--- a/misk/src/main/kotlin/misk/scope/RealActionScoped.kt
+++ b/misk/src/main/kotlin/misk/scope/RealActionScoped.kt
@@ -4,8 +4,8 @@ import com.google.inject.Key
 import javax.inject.Inject
 
 internal class RealActionScoped<T> @Inject internal constructor(
-        val key: Key<T>,
-        val scope: ActionScope
+    val key: Key<T>,
+    val scope: ActionScope
 ) : ActionScoped<T> {
-    override fun get(): T = scope.get(key)
+  override fun get(): T = scope.get(key)
 }

--- a/misk/src/main/kotlin/misk/scope/executor/ActionScopedExecutorService.kt
+++ b/misk/src/main/kotlin/misk/scope/executor/ActionScopedExecutorService.kt
@@ -12,13 +12,13 @@ import java.util.concurrent.ExecutorService
  * submitted by the current thread
  */
 class ActionScopedExecutorService(
-        target: ExecutorService,
-        private val scope: ActionScope
+    target: ExecutorService,
+    private val scope: ActionScope
 ) : WrappingListeningExecutorService() {
 
-    private val target = MoreExecutors.listeningDecorator(target)
+  private val target = MoreExecutors.listeningDecorator(target)
 
-    override fun <T> wrap(callable: Callable<T>): Callable<T> = scope.propagate(callable)
+  override fun <T> wrap(callable: Callable<T>): Callable<T> = scope.propagate(callable)
 
-    override fun delegate(): ListeningExecutorService = target
+  override fun delegate(): ListeningExecutorService = target
 }

--- a/misk/src/main/kotlin/misk/security/keys/KeyService.kt
+++ b/misk/src/main/kotlin/misk/security/keys/KeyService.kt
@@ -4,9 +4,15 @@ import okio.ByteString
 
 /** Handles encryption and decryption using keys stored in a key management service */
 interface KeyService {
-    /** encrypts the provided plain text using the given stored key */
-    fun encrypt(keyAlias: String, plainText: ByteString) : ByteString
+  /** encrypts the provided plain text using the given stored key */
+  fun encrypt(
+      keyAlias: String,
+      plainText: ByteString
+  ): ByteString
 
-    /** decrypts the provided cipher text using the given stored key */
-    fun decrypt(keyAlias: String, cipherText: ByteString) : ByteString
+  /** decrypts the provided cipher text using the given stored key */
+  fun decrypt(
+      keyAlias: String,
+      cipherText: ByteString
+  ): ByteString
 }

--- a/misk/src/main/kotlin/misk/time/ClockModule.kt
+++ b/misk/src/main/kotlin/misk/time/ClockModule.kt
@@ -4,7 +4,7 @@ import misk.inject.KAbstractModule
 import java.time.Clock
 
 class ClockModule : KAbstractModule() {
-    override fun configure() {
-        bind<Clock>().toInstance(Clock.systemUTC())
-    }
+  override fun configure() {
+    bind<Clock>().toInstance(Clock.systemUTC())
+  }
 }

--- a/misk/src/main/kotlin/misk/web/BoundAction.kt
+++ b/misk/src/main/kotlin/misk/web/BoundAction.kt
@@ -5,10 +5,8 @@ import misk.web.actions.WebAction
 import misk.web.actions.asChain
 import misk.web.extractors.ParameterExtractor
 import misk.web.mediatype.MediaRange
-import okhttp3.Headers
 import okhttp3.HttpUrl
 import okhttp3.MediaType
-import okio.Okio
 import org.eclipse.jetty.http.HttpMethod
 import java.util.regex.Matcher
 import javax.inject.Provider
@@ -22,122 +20,133 @@ import kotlin.reflect.KParameter
  * response.
  */
 internal class BoundAction<A : WebAction, out R>(
-        private val webActionProvider: Provider<A>,
-        val interceptors: MutableList<Interceptor>,
-        parameterExtractorFactories: List<ParameterExtractor.Factory>,
-        val function: KFunction<R>,
-        val pathPattern: PathPattern,
-        private val httpMethod: HttpMethod,
-        private val acceptedContentTypes: List<MediaRange>,
-        private val responseContentType: MediaType?
+    private val webActionProvider: Provider<A>,
+    val interceptors: MutableList<Interceptor>,
+    parameterExtractorFactories: List<ParameterExtractor.Factory>,
+    val function: KFunction<R>,
+    val pathPattern: PathPattern,
+    private val httpMethod: HttpMethod,
+    private val acceptedContentTypes: List<MediaRange>,
+    private val responseContentType: MediaType?
 ) {
-    private val parameterExtractors = function.parameters
-            .drop(1) // the first parameter is always _this_
-            .map { findParameterExtractor(parameterExtractorFactories, it) }
+  private val parameterExtractors = function.parameters
+      .drop(1) // the first parameter is always _this_
+      .map { findParameterExtractor(parameterExtractorFactories, it) }
 
-    private fun findParameterExtractor(
-            parameterExtractorFactories: List<ParameterExtractor.Factory>,
-            parameter: KParameter
-    ): ParameterExtractor {
-        var result: ParameterExtractor? = null
-        for (factory in parameterExtractorFactories) {
-            val parameterExtractor = factory.create(function, parameter, pathPattern) ?: continue
-            if (result != null) {
-                throw IllegalArgumentException(
-                        "multiple ways to extract $parameter: $result and $parameterExtractor")
-            }
-            result = parameterExtractor
-        }
-        if (result == null) {
-            throw IllegalArgumentException("no ways to extract $parameter")
-        }
-        return result
+  private fun findParameterExtractor(
+      parameterExtractorFactories: List<ParameterExtractor.Factory>,
+      parameter: KParameter
+  ): ParameterExtractor {
+    var result: ParameterExtractor? = null
+    for (factory in parameterExtractorFactories) {
+      val parameterExtractor = factory.create(function, parameter, pathPattern) ?: continue
+      if (result != null) {
+        throw IllegalArgumentException(
+            "multiple ways to extract $parameter: $result and $parameterExtractor"
+        )
+      }
+      result = parameterExtractor
+    }
+    if (result == null) {
+      throw IllegalArgumentException("no ways to extract $parameter")
+    }
+    return result
+  }
+
+  fun match(
+      jettyRequest: HttpServletRequest,
+      url: HttpUrl
+  ): RequestMatch? {
+    // Confirm the path and method matches
+    val pathMatcher = pathMatcher(url) ?: return null
+    if (jettyRequest.method != httpMethod.name) return null
+
+    // Confirm the request content type matches the types we accept, and pick the most specific
+    // content type match
+    val requestContentType = jettyRequest.contentType?.let { MediaType.parse(it) }
+    val requestContentTypeMatch =
+        requestContentType?.closestMediaRangeMatch(acceptedContentTypes)
+    if (requestContentType != null && requestContentTypeMatch == null) return null
+
+    // Confirm we can generate a response content type matching the set accepted by the request,
+    // and pick the most specific response content type match
+    val responseContentTypeMatch =
+        responseContentType?.closestMediaRangeMatch(jettyRequest.accepts())
+    if (responseContentType != null && responseContentTypeMatch == null) return null
+
+    return RequestMatch(this, pathMatcher, responseContentTypeMatch)
+  }
+
+  internal fun handle(
+      request: Request,
+      pathMather: Matcher
+  ): Response<ResponseBody> {
+    // Find values for all the parameters.
+    val webAction = webActionProvider.get()
+    val parameters = parameterExtractors.map {
+      it.extract(webAction, request, pathMather)
     }
 
-    fun match(jettyRequest: HttpServletRequest, url: HttpUrl): RequestMatch? {
-        // Confirm the path and method matches
-        val pathMatcher = pathMatcher(url) ?: return null
-        if (jettyRequest.method != httpMethod.name) return null
+    val chain = webAction.asChain(function, parameters, *interceptors.toTypedArray())
 
-        // Confirm the request content type matches the types we accept, and pick the most specific
-        // content type match
-        val requestContentType = jettyRequest.contentType?.let { MediaType.parse(it) }
-        val requestContentTypeMatch =
-                requestContentType?.closestMediaRangeMatch(acceptedContentTypes)
-        if (requestContentType != null && requestContentTypeMatch == null) return null
+    val response = chain.proceed(chain.args) as Response<*>
 
-        // Confirm we can generate a response content type matching the set accepted by the request,
-        // and pick the most specific response content type match
-        val responseContentTypeMatch =
-                responseContentType?.closestMediaRangeMatch(jettyRequest.accepts())
-        if (responseContentType != null && responseContentTypeMatch == null) return null
-
-        return RequestMatch(this, pathMatcher, responseContentTypeMatch)
+    if (response.body !is ResponseBody) {
+      throw IllegalStateException("expected a ResponseBody for $webAction")
     }
 
-    internal fun handle(request: Request, pathMather: Matcher): Response<ResponseBody> {
-        // Find values for all the parameters.
-        val webAction = webActionProvider.get()
-        val parameters = parameterExtractors.map {
-            it.extract(webAction, request, pathMather)
-        }
+    @Suppress("UNCHECKED_CAST")
+    return response as Response<ResponseBody>
+  }
 
-        val chain = webAction.asChain(function, parameters, *interceptors.toTypedArray())
-
-        val response = chain.proceed(chain.args) as Response<*>
-
-        if (response.body !is ResponseBody) {
-            throw IllegalStateException("expected a ResponseBody for $webAction")
-        }
-
-        @Suppress("UNCHECKED_CAST")
-        return response as Response<ResponseBody>
-    }
-
-    /** Returns a Matcher if requestUrl can be matched, else null */
-    private fun pathMatcher(requestUrl: HttpUrl): Matcher? {
-        val matcher = pathPattern.pattern.matcher(requestUrl.encodedPath())
-        return if (matcher.matches()) matcher else null
-    }
+  /** Returns a Matcher if requestUrl can be matched, else null */
+  private fun pathMatcher(requestUrl: HttpUrl): Matcher? {
+    val matcher = pathPattern.pattern.matcher(requestUrl.encodedPath())
+    return if (matcher.matches()) matcher else null
+  }
 }
 
 private fun HttpServletRequest.accepts(): List<MediaRange> {
-    // TODO(mmihic): Don't blow up if one of the accept headers can't be parsed
-    val accepts = getHeaders("Accept")?.toList()?.flatMap {
+  // TODO(mmihic): Don't blow up if one of the accept headers can't be parsed
+  val accepts = getHeaders("Accept")?.toList()
+      ?.flatMap {
         MediaRange.parseRanges(it)
-    }
+      }
 
-    return if (accepts == null || accepts.isEmpty()) {
-        listOf(MediaRange.ALL_MEDIA)
-    } else {
-        accepts
-    }
+  return if (accepts == null || accepts.isEmpty()) {
+    listOf(MediaRange.ALL_MEDIA)
+  } else {
+    accepts
+  }
 }
 
 /** Matches a request to an action. Can be sorted to pick the most specific match amongst a set of candidates */
 internal class RequestMatch(
-        val action: BoundAction<*, *>,
-        private val pathMatcher: Matcher,
-        private val responseContentTypeMatch: MediaRange.Matcher?
+    val action: BoundAction<*, *>,
+    private val pathMatcher: Matcher,
+    private val responseContentTypeMatch: MediaRange.Matcher?
 ) : Comparable<RequestMatch> {
-    override fun compareTo(other: RequestMatch): Int {
-        val patternDiff = action.pathPattern.compareTo(other.action.pathPattern)
-        if (patternDiff != 0) return patternDiff
+  override fun compareTo(other: RequestMatch): Int {
+    val patternDiff = action.pathPattern.compareTo(other.action.pathPattern)
+    if (patternDiff != 0) return patternDiff
 
-        if (responseContentTypeMatch != null && other.responseContentTypeMatch == null) return -1
-        if (responseContentTypeMatch == null && other.responseContentTypeMatch != null) return 1
-        if (responseContentTypeMatch != null && other.responseContentTypeMatch != null) {
-            return responseContentTypeMatch.compareTo(other.responseContentTypeMatch)
-        }
-
-        return 0
+    if (responseContentTypeMatch != null && other.responseContentTypeMatch == null) return -1
+    if (responseContentTypeMatch == null && other.responseContentTypeMatch != null) return 1
+    if (responseContentTypeMatch != null && other.responseContentTypeMatch != null) {
+      return responseContentTypeMatch.compareTo(other.responseContentTypeMatch)
     }
 
-    fun handle(request: Request, jettyResponse: HttpServletResponse) {
-        val result = action.handle(request, pathMatcher)
-        result.writeToJettyResponse(jettyResponse)
-    }
+    return 0
+  }
+
+  fun handle(
+      request: Request,
+      jettyResponse: HttpServletResponse
+  ) {
+    val result = action.handle(request, pathMatcher)
+    result.writeToJettyResponse(jettyResponse)
+  }
 }
 
 private fun MediaType.closestMediaRangeMatch(ranges: List<MediaRange>) =
-        ranges.mapNotNull { it.matcher(this) }.sorted().firstOrNull()
+    ranges.mapNotNull { it.matcher(this) }.sorted().firstOrNull()

--- a/misk/src/main/kotlin/misk/web/PathPattern.kt
+++ b/misk/src/main/kotlin/misk/web/PathPattern.kt
@@ -9,110 +9,115 @@ import java.util.regex.Pattern
  * characters.
  */
 data class PathPattern(
-        val pattern: Pattern,
-        val variableNames: List<String>,
-        val numRegexVariables: Int,
-        val numSegments: Int,
-        val matchesWildcardPath: Boolean
+    val pattern: Pattern,
+    val variableNames: List<String>,
+    val numRegexVariables: Int,
+    val numSegments: Int,
+    val matchesWildcardPath: Boolean
 ) : Comparable<PathPattern> {
 
-    /** Compares path patterns by specificity, with the more specific pattern ordered first */
-    override fun compareTo(other: PathPattern): Int {
-        // A path with more segments requires a more specific match
-        val numSegmentDiff = other.numSegments - numSegments
-        if (numSegmentDiff != 0) return numSegmentDiff
+  /** Compares path patterns by specificity, with the more specific pattern ordered first */
+  override fun compareTo(other: PathPattern): Int {
+    // A path with more segments requires a more specific match
+    val numSegmentDiff = other.numSegments - numSegments
+    if (numSegmentDiff != 0) return numSegmentDiff
 
-        // If we have the same number of fixed segments, but one of the patterns captures
-        // the trailing part of the path in a variable, that pattern is less specific
-        if (matchesWildcardPath && !other.matchesWildcardPath) return 1
-        if (!matchesWildcardPath && other.matchesWildcardPath) return -1
+    // If we have the same number of fixed segments, but one of the patterns captures
+    // the trailing part of the path in a variable, that pattern is less specific
+    if (matchesWildcardPath && !other.matchesWildcardPath) return 1
+    if (!matchesWildcardPath && other.matchesWildcardPath) return -1
 
-        // Assuming we match on the same number of segments, then the pattern that has
-        // more of those segments as constant text is a more specific match
-        val numVariablesDiff = variableNames.size - other.variableNames.size
-        if (numVariablesDiff != 0) return numVariablesDiff
+    // Assuming we match on the same number of segments, then the pattern that has
+    // more of those segments as constant text is a more specific match
+    val numVariablesDiff = variableNames.size - other.variableNames.size
+    if (numVariablesDiff != 0) return numVariablesDiff
 
-        // Finally, the pattern which qualifies more of its variables with regexes is a
-        // more specific match
-        return other.numRegexVariables - numRegexVariables
-    }
-    companion object {
-        fun parse(pattern: String): PathPattern {
-            val variableNames = ArrayList<String>()
-            val result = StringBuilder()
+    // Finally, the pattern which qualifies more of its variables with regexes is a
+    // more specific match
+    return other.numRegexVariables - numRegexVariables
+  }
 
-            var numSegments = 0
-            var numRegexVariables = 0
-            var lastVariableIsWildcardMatch = false
-            var pos = 0
-            while (pos < pattern.length) {
-                lastVariableIsWildcardMatch = false
+  companion object {
+    fun parse(pattern: String): PathPattern {
+      val variableNames = ArrayList<String>()
+      val result = StringBuilder()
 
-                when (pattern[pos]) {
-                    '{' -> {
-                        // Variables must start on path boundaries
-                        require(pos == 0 || pattern[pos-1] == '/') {
-                            "invalid path pattern $pattern; variables must start on path boundaries"
-                        }
+      var numSegments = 0
+      var numRegexVariables = 0
+      var lastVariableIsWildcardMatch = false
+      var pos = 0
+      while (pos < pattern.length) {
+        lastVariableIsWildcardMatch = false
 
-                        val variableNameEnd = pattern.indexOfAny(charArrayOf('}', ':'), pos + 1)
-                        require(variableNameEnd != -1)
-                        variableNames.add(pattern.substring(pos + 1, variableNameEnd))
-                        if (pattern[variableNameEnd] == ':') {
-                            pos = pattern.indexOf('}', variableNameEnd + 1) + 1
-                            require(pos != -1)
-
-                            var regex = pattern.substring(variableNameEnd + 1, pos - 1)
-                            if (pos < pattern.length && regex.endsWith(".*")) {
-                                regex = regex.substring(0, regex.length - 2) + "[^/]*"
-                            }
-
-                            result.append("(").append(regex).append(")")
-                            numRegexVariables++
-
-                            lastVariableIsWildcardMatch = regex.endsWith(".*")
-                        } else {
-                            pos = variableNameEnd + 1
-                            result.append("([^/]*)")
-                        }
-
-                        // Variables must end on path boundaries
-                        require(pos == pattern.length || pattern[pos] == '/') {
-                            "invalid path pattern $pattern; variables must end on path boundaries"
-                        }
-                    }
-
-                    '\\' -> {
-                        result.append("\\\\")
-                        pos++
-                    }
-
-                    else -> {
-                        result.append("\\Q")
-                        while (pos < pattern.length && pattern[pos] != '\\' && pattern[pos] != '{') {
-                            if (pattern[pos] == '/') numSegments++
-
-                            result.append(pattern[pos])
-                            pos++
-                        }
-                        result.append("\\E")
-
-                        /*
-                        var nextMetacharacterStart = pattern.indexOfAny(charArrayOf('\\', '{'), pos)
-                        if (nextMetacharacterStart == -1) {
-                            nextMetacharacterStart = pattern.length
-                        }
-                        result.append("\\Q")
-                        result.append(pattern, pos, nextMetacharacterStart)
-                        result.append("\\E")
-                        pos = nextMetacharacterStart
-                        */
-                    }
-                }
+        when (pattern[pos]) {
+          '{' -> {
+            // Variables must start on path boundaries
+            require(pos == 0 || pattern[pos - 1] == '/') {
+              "invalid path pattern $pattern; variables must start on path boundaries"
             }
 
-            return PathPattern(Pattern.compile(result.toString()), variableNames, numRegexVariables,
-                    numSegments, lastVariableIsWildcardMatch)
+            val variableNameEnd = pattern.indexOfAny(charArrayOf('}', ':'), pos + 1)
+            require(variableNameEnd != -1)
+            variableNames.add(pattern.substring(pos + 1, variableNameEnd))
+            if (pattern[variableNameEnd] == ':') {
+              pos = pattern.indexOf('}', variableNameEnd + 1) + 1
+              require(pos != -1)
+
+              var regex = pattern.substring(variableNameEnd + 1, pos - 1)
+              if (pos < pattern.length && regex.endsWith(".*")) {
+                regex = regex.substring(0, regex.length - 2) + "[^/]*"
+              }
+
+              result.append("(")
+                  .append(regex)
+                  .append(")")
+              numRegexVariables++
+
+              lastVariableIsWildcardMatch = regex.endsWith(".*")
+            } else {
+              pos = variableNameEnd + 1
+              result.append("([^/]*)")
+            }
+
+            // Variables must end on path boundaries
+            require(pos == pattern.length || pattern[pos] == '/') {
+              "invalid path pattern $pattern; variables must end on path boundaries"
+            }
+          }
+
+          '\\' -> {
+            result.append("\\\\")
+            pos++
+          }
+
+          else -> {
+            result.append("\\Q")
+            while (pos < pattern.length && pattern[pos] != '\\' && pattern[pos] != '{') {
+              if (pattern[pos] == '/') numSegments++
+
+              result.append(pattern[pos])
+              pos++
+            }
+            result.append("\\E")
+
+            /*
+            var nextMetacharacterStart = pattern.indexOfAny(charArrayOf('\\', '{'), pos)
+            if (nextMetacharacterStart == -1) {
+                nextMetacharacterStart = pattern.length
+            }
+            result.append("\\Q")
+            result.append(pattern, pos, nextMetacharacterStart)
+            result.append("\\E")
+            pos = nextMetacharacterStart
+            */
+          }
         }
+      }
+
+      return PathPattern(
+          Pattern.compile(result.toString()), variableNames, numRegexVariables,
+          numSegments, lastVariableIsWildcardMatch
+      )
     }
+  }
 }

--- a/misk/src/main/kotlin/misk/web/RealChain.kt
+++ b/misk/src/main/kotlin/misk/web/RealChain.kt
@@ -13,18 +13,18 @@ internal class RealChain(
     private val index: Int = 0
 ) : Chain {
 
-    override val action: WebAction
-        get() = _action
+  override val action: WebAction
+    get() = _action
 
-    override val args: List<Any?>
-        get() = _args
+  override val args: List<Any?>
+    get() = _args
 
-    override val function: KFunction<*>
-        get() = _function
+  override val function: KFunction<*>
+    get() = _function
 
-    override fun proceed(args: List<Any?>): Any? {
-        check(index < interceptors.size) { "final interceptor must be terminal" }
-        val next = RealChain(_action, args, interceptors, function, index + 1)
-        return interceptors[index].intercept(next)
-    }
+  override fun proceed(args: List<Any?>): Any? {
+    check(index < interceptors.size) { "final interceptor must be terminal" }
+    val next = RealChain(_action, args, interceptors, function, index + 1)
+    return interceptors[index].intercept(next)
+  }
 }

--- a/misk/src/main/kotlin/misk/web/Response.kt
+++ b/misk/src/main/kotlin/misk/web/Response.kt
@@ -13,21 +13,21 @@ data class Response<out T>(
 )
 
 interface ResponseBody {
-    fun writeTo(sink: BufferedSink)
+  fun writeTo(sink: BufferedSink)
 }
 
 fun Response<ResponseBody>.writeToJettyResponse(jettyResponse: HttpServletResponse) {
-    jettyResponse.status = statusCode
+  jettyResponse.status = statusCode
 
-    for ((key, values) in headers.toMultimap()) {
-        for (value in values) {
-            jettyResponse.addHeader(key, value)
-        }
+  for ((key, values) in headers.toMultimap()) {
+    for (value in values) {
+      jettyResponse.addHeader(key, value)
     }
+  }
 
-    val sink = jettyResponse.bufferedSink()
-    body.writeTo(sink)
-    sink.emit()
+  val sink = jettyResponse.bufferedSink()
+  body.writeTo(sink)
+  sink.emit()
 }
 
 private fun HttpServletResponse.bufferedSink() = Okio.buffer(Okio.sink(outputStream))

--- a/misk/src/main/kotlin/misk/web/WebConfig.kt
+++ b/misk/src/main/kotlin/misk/web/WebConfig.kt
@@ -2,4 +2,7 @@ package misk.web
 
 import misk.config.Config
 
-data class WebConfig(val port: Int, val idle_timeout: Long) : Config
+data class WebConfig(
+    val port: Int,
+    val idle_timeout: Long
+) : Config

--- a/misk/src/main/kotlin/misk/web/WebModule.kt
+++ b/misk/src/main/kotlin/misk/web/WebModule.kt
@@ -29,56 +29,62 @@ import misk.web.marshal.UnmarshallerModule
 import javax.servlet.http.HttpServletRequest
 
 class WebModule : KAbstractModule() {
-    override fun configure() {
-        install(JettyModule())
-        install(object: ActionScopedProviderModule() {
-            override fun configureProviders() {
-                bindSeedData(Request::class)
-                bindSeedData(HttpServletRequest::class)
-            }
-        })
+  override fun configure() {
+    install(JettyModule())
+    install(object : ActionScopedProviderModule() {
+      override fun configureProviders() {
+        bindSeedData(Request::class)
+        bindSeedData(HttpServletRequest::class)
+      }
+    })
 
-        // Register built-in marshallers and unmarshallers
-        install(MarshallerModule.create<PlainTextMarshaller.Factory>())
-        install(MarshallerModule.create<JsonMarshaller.Factory>())
-        install(UnmarshallerModule.create<JsonUnmarshaller.Factory>())
+    // Register built-in marshallers and unmarshallers
+    install(MarshallerModule.create<PlainTextMarshaller.Factory>())
+    install(MarshallerModule.create<JsonMarshaller.Factory>())
+    install(UnmarshallerModule.create<JsonUnmarshaller.Factory>())
 
-        // Create an empty set binder of interceptor factories that can be added to by users.
-        newSetBinder<Interceptor.Factory>()
+    // Create an empty set binder of interceptor factories that can be added to by users.
+    newSetBinder<Interceptor.Factory>()
 
-        // Register built-in interceptors. Interceptors run in the order in which they are
-        // installed, and the order of these interceptors is critical.
+    // Register built-in interceptors. Interceptors run in the order in which they are
+    // installed, and the order of these interceptors is critical.
 
-        // Handle all unexpected errors that occur during dispatch
-        binder().addMultibinderBindingWithAnnotation<Interceptor.Factory, MiskDefault>().to<InternalErrorInterceptorFactory>()
+    // Handle all unexpected errors that occur during dispatch
+    binder().addMultibinderBindingWithAnnotation<Interceptor.Factory, MiskDefault>()
+        .to<InternalErrorInterceptorFactory>()
 
-        // Optionally log request and response details
-        binder().addMultibinderBindingWithAnnotation<Interceptor.Factory, MiskDefault>().to<RequestLoggingInterceptor.Factory>()
+    // Optionally log request and response details
+    binder().addMultibinderBindingWithAnnotation<Interceptor.Factory, MiskDefault>()
+        .to<RequestLoggingInterceptor.Factory>()
 
-        // Collect metrics on the status of results and response times of requests
-        binder().addMultibinderBindingWithAnnotation<Interceptor.Factory, MiskDefault>().to<MetricsInterceptor.Factory>()
+    // Collect metrics on the status of results and response times of requests
+    binder().addMultibinderBindingWithAnnotation<Interceptor.Factory, MiskDefault>()
+        .to<MetricsInterceptor.Factory>()
 
-        // Convert and log application level exceptions into their appropriate response format
-        binder().addMultibinderBindingWithAnnotation<Interceptor.Factory, MiskDefault>().to<ExceptionHandlingInterceptor.Factory>()
+    // Convert and log application level exceptions into their appropriate response format
+    binder().addMultibinderBindingWithAnnotation<Interceptor.Factory, MiskDefault>()
+        .to<ExceptionHandlingInterceptor.Factory>()
 
-        // Convert typed responses into a ResponseBody that can marshal the response according to
-        // the client's requested content-typ
-        binder().addMultibinderBindingWithAnnotation<Interceptor.Factory, MiskDefault>().to<MarshallerInterceptor.Factory>()
+    // Convert typed responses into a ResponseBody that can marshal the response according to
+    // the client's requested content-typ
+    binder().addMultibinderBindingWithAnnotation<Interceptor.Factory, MiskDefault>()
+        .to<MarshallerInterceptor.Factory>()
 
-        // Wrap "raw" responses with a Response object
-        binder().addMultibinderBindingWithAnnotation<Interceptor.Factory, MiskDefault>().to<BoxResponseInterceptorFactory>()
+    // Wrap "raw" responses with a Response object
+    binder().addMultibinderBindingWithAnnotation<Interceptor.Factory, MiskDefault>()
+        .to<BoxResponseInterceptorFactory>()
 
-        // Register build-in exception mappers
-        install(ExceptionMapperModule.create<ActionExceptionMapper>())
+    // Register build-in exception mappers
+    install(ExceptionMapperModule.create<ActionExceptionMapper>())
 
-        // Register built-in parameter extractors
-        binder().addMultibinderBinding<ParameterExtractor.Factory>()
-                .toInstance(PathPatternParameterExtractorFactory)
-        binder().addMultibinderBinding<ParameterExtractor.Factory>()
-                .toInstance(QueryStringParameterExtractorFactory)
-        binder().addMultibinderBinding<ParameterExtractor.Factory>()
-                .toInstance(HeadersParameterExtractorFactory)
-        binder().addMultibinderBinding<ParameterExtractor.Factory>()
-                .to<RequestBodyParameterExtractor.Factory>()
-    }
+    // Register built-in parameter extractors
+    binder().addMultibinderBinding<ParameterExtractor.Factory>()
+        .toInstance(PathPatternParameterExtractorFactory)
+    binder().addMultibinderBinding<ParameterExtractor.Factory>()
+        .toInstance(QueryStringParameterExtractorFactory)
+    binder().addMultibinderBinding<ParameterExtractor.Factory>()
+        .toInstance(HeadersParameterExtractorFactory)
+    binder().addMultibinderBinding<ParameterExtractor.Factory>()
+        .to<RequestBodyParameterExtractor.Factory>()
+  }
 }

--- a/misk/src/main/kotlin/misk/web/actions/InternalErrorAction.kt
+++ b/misk/src/main/kotlin/misk/web/actions/InternalErrorAction.kt
@@ -5,8 +5,8 @@ import javax.inject.Singleton
 
 @Singleton
 class InternalErrorAction : WebAction {
-    @Get("/error")
-    fun error(): Nothing {
-        throw UnsupportedOperationException()
-    }
+  @Get("/error")
+  fun error(): Nothing {
+    throw UnsupportedOperationException()
+  }
 }

--- a/misk/src/main/kotlin/misk/web/actions/LivenessCheckAction.kt
+++ b/misk/src/main/kotlin/misk/web/actions/LivenessCheckAction.kt
@@ -11,18 +11,18 @@ import javax.inject.Singleton
 
 @Singleton
 class LivenessCheckAction : WebAction {
-    @Inject private lateinit var services: MutableSet<Service>
+  @Inject private lateinit var services: MutableSet<Service>
 
-    @Get("/_liveness")
-    @ResponseContentType(MediaTypes.TEXT_PLAIN_UTF8)
-    fun livenessCheck(): Response<String> {
-        val isAlive = services.all {
-            it.state() != State.FAILED && it.state() != State.TERMINATED
-        }
-        // TODO(jgulbronson) - Should return an empty body
-        return Response(
-                "",
-                statusCode = if (isAlive) 200 else 503
-        )
+  @Get("/_liveness")
+  @ResponseContentType(MediaTypes.TEXT_PLAIN_UTF8)
+  fun livenessCheck(): Response<String> {
+    val isAlive = services.all {
+      it.state() != State.FAILED && it.state() != State.TERMINATED
     }
+    // TODO(jgulbronson) - Should return an empty body
+    return Response(
+        "",
+        statusCode = if (isAlive) 200 else 503
+    )
+  }
 }

--- a/misk/src/main/kotlin/misk/web/actions/NotFoundAction.kt
+++ b/misk/src/main/kotlin/misk/web/actions/NotFoundAction.kt
@@ -9,12 +9,12 @@ import javax.inject.Singleton
 
 @Singleton
 class NotFoundAction : WebAction {
-    @Get("/{path:.*}")
-    @ResponseContentType(MediaTypes.TEXT_PLAIN_UTF8)
-    fun notFound(@PathParam path: String): Response<String> {
-        return Response(
-                body = "Nothing found at /$path",
-                statusCode = 404
-        )
-    }
+  @Get("/{path:.*}")
+  @ResponseContentType(MediaTypes.TEXT_PLAIN_UTF8)
+  fun notFound(@PathParam path: String): Response<String> {
+    return Response(
+        body = "Nothing found at /$path",
+        statusCode = 404
+    )
+  }
 }

--- a/misk/src/main/kotlin/misk/web/actions/ReadinessCheckAction.kt
+++ b/misk/src/main/kotlin/misk/web/actions/ReadinessCheckAction.kt
@@ -11,19 +11,22 @@ import javax.inject.Singleton
 
 @Singleton
 class ReadinessCheckAction : WebAction {
-    @Inject lateinit var services: MutableSet<Service>
-    @Inject lateinit var healthChecks: MutableSet<HealthCheck>
+  @Inject lateinit var services: MutableSet<Service>
+  @Inject lateinit var healthChecks: MutableSet<HealthCheck>
 
-    @Get("/_readiness")
-    @ResponseContentType(MediaTypes.APPLICATION_JSON)
-    fun readinessCheck(): Response<String> {
-        val isReady = services.all { it.isRunning }
-                && healthChecks.all { it.status().isHealthy }
-
-        // TODO(jgulbronson) - Should return an empty body
-        return Response(
-                "",
-                statusCode = if (isReady) 200 else 503
-        )
+  @Get("/_readiness")
+  @ResponseContentType(MediaTypes.APPLICATION_JSON)
+  fun readinessCheck(): Response<String> {
+    val isReady = services.all { it.isRunning }
+        && healthChecks.all {
+      it.status()
+          .isHealthy
     }
+
+    // TODO(jgulbronson) - Should return an empty body
+    return Response(
+        "",
+        statusCode = if (isReady) 200 else 503
+    )
+  }
 }

--- a/misk/src/main/kotlin/misk/web/actions/WebActions.kt
+++ b/misk/src/main/kotlin/misk/web/actions/WebActions.kt
@@ -12,21 +12,21 @@ fun WebAction.asChain(
     args: List<Any?>,
     vararg _interceptors: Interceptor
 ): Chain {
-    val interceptors = Lists.newArrayList(_interceptors.iterator())
-    interceptors.add(object : Interceptor {
-        override fun intercept(chain: Chain): Any? {
-            val parameterMap = LinkedHashMap<KParameter, Any?>()
-            parameterMap.put(function.parameters.first(), chain.action)
-            for (i in 1 until function.parameters.size) {
-                val param = function.parameters.get(i)
-                val arg = chain.args.get(i - 1)
-                if (param.isOptional && arg == null) {
-                    continue
-                }
-                parameterMap.put(param, arg)
-            }
-            return function.callBy(parameterMap)
+  val interceptors = Lists.newArrayList(_interceptors.iterator())
+  interceptors.add(object : Interceptor {
+    override fun intercept(chain: Chain): Any? {
+      val parameterMap = LinkedHashMap<KParameter, Any?>()
+      parameterMap.put(function.parameters.first(), chain.action)
+      for (i in 1 until function.parameters.size) {
+        val param = function.parameters.get(i)
+        val arg = chain.args.get(i - 1)
+        if (param.isOptional && arg == null) {
+          continue
         }
-    })
-    return RealChain(this, args, interceptors, function, 0)
+        parameterMap.put(param, arg)
+      }
+      return function.callBy(parameterMap)
+    }
+  })
+  return RealChain(this, args, interceptors, function, 0)
 }

--- a/misk/src/main/kotlin/misk/web/exceptions/ActionExceptionMapper.kt
+++ b/misk/src/main/kotlin/misk/web/exceptions/ActionExceptionMapper.kt
@@ -16,21 +16,21 @@ import org.slf4j.event.Level
  * implementation details and possible vulnerabilities
  */
 internal class ActionExceptionMapper : ExceptionMapper<ActionException> {
-    override fun toResponse(th: ActionException): Response<ResponseBody> {
-        val message = if (th.statusCode.isClientError) th.message ?: th.statusCode.name
-        else th.statusCode.name
-        return Response(StringResponseBody(message), HEADERS, statusCode = th.statusCode.code)
-    }
+  override fun toResponse(th: ActionException): Response<ResponseBody> {
+    val message = if (th.statusCode.isClientError) th.message ?: th.statusCode.name
+    else th.statusCode.name
+    return Response(StringResponseBody(message), HEADERS, statusCode = th.statusCode.code)
+  }
 
-    override fun canHandle(th: Throwable): Boolean = th is ActionException
+  override fun canHandle(th: Throwable): Boolean = th is ActionException
 
-    override fun loggingLevel(th: ActionException) =
-            if (th.statusCode.isClientError) Level.WARN
-            else Level.ERROR
+  override fun loggingLevel(th: ActionException) =
+      if (th.statusCode.isClientError) Level.WARN
+      else Level.ERROR
 
-    private companion object {
-        val HEADERS: Headers =
-                Headers.of(listOf("Content-Type" to MediaTypes.TEXT_PLAIN_UTF8).toMap())
-    }
+  private companion object {
+    val HEADERS: Headers =
+        Headers.of(listOf("Content-Type" to MediaTypes.TEXT_PLAIN_UTF8).toMap())
+  }
 }
 

--- a/misk/src/main/kotlin/misk/web/exceptions/ExceptionHandlingInterceptor.kt
+++ b/misk/src/main/kotlin/misk/web/exceptions/ExceptionHandlingInterceptor.kt
@@ -23,48 +23,49 @@ import javax.inject.Inject
  * mapped by installing [ExceptionMapper] via the [ExceptionMapperModule]
  */
 class ExceptionHandlingInterceptor(
-        private val actionName: String,
-        private val mappers: Set<ExceptionMapper<*>>
+    private val actionName: String,
+    private val mappers: Set<ExceptionMapper<*>>
 ) : Interceptor {
 
-    override fun intercept(chain: Chain): Any? = try {
-        chain.proceed(chain.args)
-    } catch (th: Throwable) {
-        toResponse(th)
-    }
+  override fun intercept(chain: Chain): Any? = try {
+    chain.proceed(chain.args)
+  } catch (th: Throwable) {
+    toResponse(th)
+  }
 
-    private fun toResponse(th: Throwable): Response<*> = when (th) {
-        is ExecutionException -> toResponse(th.cause!!)
-        is InvocationTargetException -> toResponse(th.targetException)
-        is UncheckedExecutionException -> toResponse(th.cause!!)
-        else -> mapperFor(th)?.let {
-            log.log(it.loggingLevel(th), th) { "exception dispatching to $actionName" }
-            it.toResponse(th)
-        } ?: toInternalServerError(th)
-    }
+  private fun toResponse(th: Throwable): Response<*> = when (th) {
+    is ExecutionException -> toResponse(th.cause!!)
+    is InvocationTargetException -> toResponse(th.targetException)
+    is UncheckedExecutionException -> toResponse(th.cause!!)
+    else -> mapperFor(th)?.let {
+      log.log(it.loggingLevel(th), th) { "exception dispatching to $actionName" }
+      it.toResponse(th)
+    } ?: toInternalServerError(th)
+  }
 
-    @Suppress("UNCHECKED_CAST")
-    private fun mapperFor(th: Throwable): ExceptionMapper<Throwable>? = mappers.firstOrNull {
-        it.canHandle(th)
-    } as ExceptionMapper<Throwable>?
+  @Suppress("UNCHECKED_CAST")
+  private fun mapperFor(th: Throwable): ExceptionMapper<Throwable>? = mappers.firstOrNull {
+    it.canHandle(th)
+  } as ExceptionMapper<Throwable>?
 
-    private fun toInternalServerError(th: Throwable): Response<*> {
-        log.error(th) { "unexpected error dispatching to $actionName" }
-        return INTERNAL_SERVER_ERROR_RESPONSE
-    }
+  private fun toInternalServerError(th: Throwable): Response<*> {
+    log.error(th) { "unexpected error dispatching to $actionName" }
+    return INTERNAL_SERVER_ERROR_RESPONSE
+  }
 
-    class Factory @Inject internal constructor(
-            private val mappers: MutableSet<ExceptionMapper<*>>
-    ) : Interceptor.Factory {
-        override fun create(action: Action) = ExceptionHandlingInterceptor(action.name, mappers)
-    }
+  class Factory @Inject internal constructor(
+      private val mappers: MutableSet<ExceptionMapper<*>>
+  ) : Interceptor.Factory {
+    override fun create(action: Action) = ExceptionHandlingInterceptor(action.name, mappers)
+  }
 
-    private companion object {
-        val log = getLogger<ExceptionHandlingInterceptor>()
+  private companion object {
+    val log = getLogger<ExceptionHandlingInterceptor>()
 
-        val INTERNAL_SERVER_ERROR_RESPONSE = Response(StringResponseBody("internal server error"),
-                Headers.of(listOf("Content-Type" to MediaTypes.TEXT_PLAIN_UTF8).toMap()),
-                StatusCode.INTERNAL_SERVER_ERROR.code
-        )
-    }
+    val INTERNAL_SERVER_ERROR_RESPONSE = Response(
+        StringResponseBody("internal server error"),
+        Headers.of(listOf("Content-Type" to MediaTypes.TEXT_PLAIN_UTF8).toMap()),
+        StatusCode.INTERNAL_SERVER_ERROR.code
+    )
+  }
 }

--- a/misk/src/main/kotlin/misk/web/exceptions/ExceptionMapper.kt
+++ b/misk/src/main/kotlin/misk/web/exceptions/ExceptionMapper.kt
@@ -6,23 +6,23 @@ import org.slf4j.event.Level
 
 /** Maps an exception to a [Response] */
 interface ExceptionMapper<in T : Throwable> {
-    /** @return true if the [ExceptionMapper] can handle the given exception */
-    fun canHandle(th: Throwable): Boolean
+  /** @return true if the [ExceptionMapper] can handle the given exception */
+  fun canHandle(th: Throwable): Boolean
 
-    /** @return the [Response] corresponding to the exception. */
-    // TODO(mmihic): Allow control of marshalling based on content type. Ideally we could
-    // return a Response<*> and then content negotiation would control how that * gets mapped.
-    // Right now however the marshalling interceptor works off the static return type of the
-    // action method, so it blows up when we return a different type from here. This is a general
-    // issue; interceptors should be able to return responses that are of a different structure
-    // then the action method return value
-    fun toResponse(th: T): Response<ResponseBody>
+  /** @return the [Response] corresponding to the exception. */
+  // TODO(mmihic): Allow control of marshalling based on content type. Ideally we could
+  // return a Response<*> and then content negotiation would control how that * gets mapped.
+  // Right now however the marshalling interceptor works off the static return type of the
+  // action method, so it blows up when we return a different type from here. This is a general
+  // issue; interceptors should be able to return responses that are of a different structure
+  // then the action method return value
+  fun toResponse(th: T): Response<ResponseBody>
 
-    /**
-     * @return the level at which the given exception should be logged. defaults to ERROR but can
-     * be overriden by the mapper for the given exception
-     */
-    fun loggingLevel(th: T): Level = Level.ERROR
+  /**
+   * @return the level at which the given exception should be logged. defaults to ERROR but can
+   * be overriden by the mapper for the given exception
+   */
+  fun loggingLevel(th: T): Level = Level.ERROR
 
 }
 

--- a/misk/src/main/kotlin/misk/web/exceptions/ExceptionMapperModule.kt
+++ b/misk/src/main/kotlin/misk/web/exceptions/ExceptionMapperModule.kt
@@ -6,15 +6,17 @@ import misk.inject.KAbstractModule
 import kotlin.reflect.KClass
 
 class ExceptionMapperModule<T : ExceptionMapper<*>>(
-        private val kclass: KClass<T>
+    private val kclass: KClass<T>
 ) : KAbstractModule() {
-    override fun configure() {
-        Multibinder.newSetBinder(binder(), exceptionMapperTypeLiteral).addBinding().to(kclass.java)
-    }
+  override fun configure() {
+    Multibinder.newSetBinder(binder(), exceptionMapperTypeLiteral)
+        .addBinding()
+        .to(kclass.java)
+  }
 
-    companion object {
-        inline fun <reified T : ExceptionMapper<*>> create() = ExceptionMapperModule(T::class)
+  companion object {
+    inline fun <reified T : ExceptionMapper<*>> create() = ExceptionMapperModule(T::class)
 
-        private val exceptionMapperTypeLiteral = object : TypeLiteral<ExceptionMapper<*>>() {}
-    }
+    private val exceptionMapperTypeLiteral = object : TypeLiteral<ExceptionMapper<*>>() {}
+  }
 }

--- a/misk/src/main/kotlin/misk/web/extractors/HeadersParameterExtractorFactory.kt
+++ b/misk/src/main/kotlin/misk/web/extractors/HeadersParameterExtractorFactory.kt
@@ -14,19 +14,23 @@ import kotlin.reflect.full.findAnnotation
  * is annotated with [RequestHeaders].
  */
 object HeadersParameterExtractorFactory : ParameterExtractor.Factory {
-    private val extractor = object : ParameterExtractor {
-        override fun extract(webAction: WebAction, request: Request, pathMatcher: Matcher): Any? {
-            return request.headers
-        }
+  private val extractor = object : ParameterExtractor {
+    override fun extract(
+        webAction: WebAction,
+        request: Request,
+        pathMatcher: Matcher
+    ): Any? {
+      return request.headers
     }
+  }
 
-    override fun create(
-            function: KFunction<*>,
-            parameter: KParameter,
-            pathPattern: PathPattern
-    ): ParameterExtractor? {
-        if (parameter.findAnnotation<RequestHeaders>() == null) return null
+  override fun create(
+      function: KFunction<*>,
+      parameter: KParameter,
+      pathPattern: PathPattern
+  ): ParameterExtractor? {
+    if (parameter.findAnnotation<RequestHeaders>() == null) return null
 
-        return extractor
-    }
+    return extractor
+  }
 }

--- a/misk/src/main/kotlin/misk/web/extractors/ParameterExtractor.kt
+++ b/misk/src/main/kotlin/misk/web/extractors/ParameterExtractor.kt
@@ -8,23 +8,27 @@ import kotlin.reflect.KFunction
 import kotlin.reflect.KParameter
 
 interface ParameterExtractor {
-    /**
-     * Extracts a parameter from [request], such as a URL parameter or the request body.
-     */
-    fun extract(webAction: WebAction, request: Request, pathMatcher: Matcher): Any?
+  /**
+   * Extracts a parameter from [request], such as a URL parameter or the request body.
+   */
+  fun extract(
+      webAction: WebAction,
+      request: Request,
+      pathMatcher: Matcher
+  ): Any?
 
-    interface Factory {
-        /**
-         * Returns an instance of a [ParameterExtractor] that extracts the value for [parameter],
-         * or null if the extractor does not apply to [parameter].
-         *
-         * See [HeadersParameterExtractorFactory] and [RequestBodyParameterExtractor] for
-         * examples.
-         */
-        fun create(
-                function: KFunction<*>,
-                parameter: KParameter,
-                pathPattern: PathPattern
-        ): ParameterExtractor?
-    }
+  interface Factory {
+    /**
+     * Returns an instance of a [ParameterExtractor] that extracts the value for [parameter],
+     * or null if the extractor does not apply to [parameter].
+     *
+     * See [HeadersParameterExtractorFactory] and [RequestBodyParameterExtractor] for
+     * examples.
+     */
+    fun create(
+        function: KFunction<*>,
+        parameter: KParameter,
+        pathPattern: PathPattern
+    ): ParameterExtractor?
+  }
 }

--- a/misk/src/main/kotlin/misk/web/extractors/PathPatternParameterExtractor.kt
+++ b/misk/src/main/kotlin/misk/web/extractors/PathPatternParameterExtractor.kt
@@ -15,33 +15,33 @@ import kotlin.reflect.jvm.javaType
  * and returns it as a [String]. If the parameter name doesn't occur in [pathPattern], returns null.
  */
 object PathPatternParameterExtractorFactory : ParameterExtractor.Factory {
-    override fun create(
-            function: KFunction<*>,
-            parameter: KParameter,
-            pathPattern: PathPattern
-    ): ParameterExtractor? {
-        val pathParamAnnotation = parameter.findAnnotation<PathParam>() ?: return null
-        val parameterName =
-                if (pathParamAnnotation.value.isBlank()) parameter.name
-                else pathParamAnnotation.value
+  override fun create(
+      function: KFunction<*>,
+      parameter: KParameter,
+      pathPattern: PathPattern
+  ): ParameterExtractor? {
+    val pathParamAnnotation = parameter.findAnnotation<PathParam>() ?: return null
+    val parameterName =
+        if (pathParamAnnotation.value.isBlank()) parameter.name
+        else pathParamAnnotation.value
 
-        val patternIndex = pathPattern.variableNames.indexOf(parameterName)
-        if (patternIndex == -1) return null
+    val patternIndex = pathPattern.variableNames.indexOf(parameterName)
+    if (patternIndex == -1) return null
 
-        val parameterType = parameter.type
-        val converter = converterFor(parameterType)
-                ?: throw IllegalArgumentException(
-                        "cannot convert path parameters to ${parameterType.javaType.typeName}"
-                )
-        return object : ParameterExtractor {
-            override fun extract(
-                    webAction: WebAction,
-                    request: Request,
-                    pathMatcher: Matcher
-            ): Any? {
-                val pathParam = pathMatcher.group(patternIndex + 1)
-                return converter(pathParam)
-            }
-        }
+    val parameterType = parameter.type
+    val converter = converterFor(parameterType)
+        ?: throw IllegalArgumentException(
+            "cannot convert path parameters to ${parameterType.javaType.typeName}"
+        )
+    return object : ParameterExtractor {
+      override fun extract(
+          webAction: WebAction,
+          request: Request,
+          pathMatcher: Matcher
+      ): Any? {
+        val pathParam = pathMatcher.group(patternIndex + 1)
+        return converter(pathParam)
+      }
     }
+  }
 }

--- a/misk/src/main/kotlin/misk/web/extractors/QueryStringParameterExtractor.kt
+++ b/misk/src/main/kotlin/misk/web/extractors/QueryStringParameterExtractor.kt
@@ -1,7 +1,7 @@
 package misk.web.extractors
 
-import misk.web.QueryParam
 import misk.web.PathPattern
+import misk.web.QueryParam
 import misk.web.Request
 import misk.web.actions.WebAction
 import java.util.regex.Matcher
@@ -15,24 +15,27 @@ import kotlin.reflect.full.findAnnotation
  * parameter doesn't occur in the request, or can't be parsed into the correct type.
  */
 object QueryStringParameterExtractorFactory : ParameterExtractor.Factory {
-    override fun create(
-            function: KFunction<*>,
-            parameter: KParameter,
-            pathPattern: PathPattern
-    ): ParameterExtractor? {
-        val queryParamAnnotation = parameter.findAnnotation<QueryParam>() ?: return null
-        val parameterName =
-                if (queryParamAnnotation.value.isBlank()) parameter.name!!
-                else queryParamAnnotation.value
-        val queryParamProcessor = QueryStringParameterProcessor(parameter)
+  override fun create(
+      function: KFunction<*>,
+      parameter: KParameter,
+      pathPattern: PathPattern
+  ): ParameterExtractor? {
+    val queryParamAnnotation = parameter.findAnnotation<QueryParam>() ?: return null
+    val parameterName =
+        if (queryParamAnnotation.value.isBlank()) parameter.name!!
+        else queryParamAnnotation.value
+    val queryParamProcessor = QueryStringParameterProcessor(parameter)
 
-        return object : ParameterExtractor {
-            override fun extract(webAction: WebAction, request: Request,
-                    pathMatcher: Matcher): Any? {
-                val parameterValues: List<String> = request.url.queryParameterValues(parameterName)
-                return queryParamProcessor.extractFunctionArgumentValue(parameterValues)
-            }
-        }
+    return object : ParameterExtractor {
+      override fun extract(
+          webAction: WebAction,
+          request: Request,
+          pathMatcher: Matcher
+      ): Any? {
+        val parameterValues: List<String> = request.url.queryParameterValues(parameterName)
+        return queryParamProcessor.extractFunctionArgumentValue(parameterValues)
+      }
     }
+  }
 
 }

--- a/misk/src/main/kotlin/misk/web/extractors/QueryStringParameterProcessor.kt
+++ b/misk/src/main/kotlin/misk/web/extractors/QueryStringParameterProcessor.kt
@@ -9,23 +9,23 @@ import kotlin.reflect.jvm.javaType
  *     used, as well as finding the KType of the primitive.
  */
 internal class QueryStringParameterProcessor constructor(parameter: KParameter) {
-    private val name: String? = parameter.name ?: parameter.type.javaType.typeName
-    private val isList: Boolean = parameter.type.classifier?.equals(List::class) ?: false
-    private val stringConverter = converterFor(
-        if (isList) parameter.type.arguments.first().type!!
-        else parameter.type
-    ) ?: throw IllegalArgumentException("Unable to create converter for ${parameter.name}")
+  private val name: String? = parameter.name ?: parameter.type.javaType.typeName
+  private val isList: Boolean = parameter.type.classifier?.equals(List::class) ?: false
+  private val stringConverter = converterFor(
+      if (isList) parameter.type.arguments.first().type!!
+      else parameter.type
+  ) ?: throw IllegalArgumentException("Unable to create converter for ${parameter.name}")
 
-    fun extractFunctionArgumentValue(parameterStrings: List<String>): Any? {
-        if (parameterStrings.isEmpty()) {
-            return null
-        }
-
-        try {
-            return if (isList) parameterStrings.map { stringConverter(it) }
-              else stringConverter(parameterStrings.first())
-        } catch(e: IllegalArgumentException) {
-            throw IllegalArgumentException("Invalid format for parameter: $name", e)
-        }
+  fun extractFunctionArgumentValue(parameterStrings: List<String>): Any? {
+    if (parameterStrings.isEmpty()) {
+      return null
     }
+
+    try {
+      return if (isList) parameterStrings.map { stringConverter(it) }
+      else stringConverter(parameterStrings.first())
+    } catch (e: IllegalArgumentException) {
+      throw IllegalArgumentException("Invalid format for parameter: $name", e)
+    }
+  }
 }

--- a/misk/src/main/kotlin/misk/web/extractors/StringConverter.kt
+++ b/misk/src/main/kotlin/misk/web/extractors/StringConverter.kt
@@ -37,7 +37,7 @@ private fun numberConversionWrapper(wrappedFunc: StringConverter): StringConvert
   return {
     try {
       wrappedFunc(it)
-    } catch(e: NumberFormatException) {
+    } catch (e: NumberFormatException) {
       throw IllegalArgumentException("Invalid parameter format: $it", e)
     }
   }
@@ -51,8 +51,8 @@ private fun createFromValueOf(type: KType): StringConverter? {
     if (valueOfMethod != null) {
       return { param -> valueOfMethod(null, param) }
     }
-  } catch(e: ClassCastException) {
-  } catch(e: NoSuchMethodException) {
+  } catch (e: ClassCastException) {
+  } catch (e: NoSuchMethodException) {
   }
   return null
 }

--- a/misk/src/main/kotlin/misk/web/interceptors/BoxResponseInterceptor.kt
+++ b/misk/src/main/kotlin/misk/web/interceptors/BoxResponseInterceptor.kt
@@ -10,18 +10,18 @@ import javax.inject.Singleton
 /** Wraps the method's result `T` as a `Response<T>` if necessary. */
 @Singleton
 class BoxResponseInterceptorFactory : Interceptor.Factory {
-    val interceptor = object : Interceptor {
-        override fun intercept(chain: Chain): Any? {
-            val result = chain.proceed(chain.args)
-            return Response(result)
-        }
+  val interceptor = object : Interceptor {
+    override fun intercept(chain: Chain): Any? {
+      val result = chain.proceed(chain.args)
+      return Response(result)
     }
+  }
 
-    override fun create(action: Action): Interceptor? {
-        return when {
-            action.returnType.typeLiteral().rawType == Response::class.java -> null
-            else -> interceptor
-        }
+  override fun create(action: Action): Interceptor? {
+    return when {
+      action.returnType.typeLiteral().rawType == Response::class.java -> null
+      else -> interceptor
     }
+  }
 }
 

--- a/misk/src/main/kotlin/misk/web/interceptors/InternalErrorInterceptorFactory.kt
+++ b/misk/src/main/kotlin/misk/web/interceptors/InternalErrorInterceptorFactory.kt
@@ -11,31 +11,31 @@ import javax.inject.Singleton
 
 @Singleton
 class InternalErrorInterceptorFactory : Interceptor.Factory {
-    override fun create(action: Action): Interceptor? {
-        return INTERCEPTOR
+  override fun create(action: Action): Interceptor? {
+    return INTERCEPTOR
+  }
+
+  private companion object {
+    val HEADERS: Headers = Headers.Builder()
+        .set("Content-Type", "text/plain; charset=utf-8")
+        .build()
+
+    const val STATUS_CODE = 500
+
+    val BODY = object : ResponseBody {
+      override fun writeTo(sink: BufferedSink) {
+        sink.writeUtf8("Internal server error")
+      }
     }
 
-    private companion object {
-        val HEADERS: Headers = Headers.Builder()
-                .set("Content-Type", "text/plain; charset=utf-8")
-                .build()
-
-        const val STATUS_CODE = 500
-
-        val BODY = object : ResponseBody {
-            override fun writeTo(sink: BufferedSink) {
-                sink.writeUtf8("Internal server error")
-            }
+    val INTERCEPTOR = object : Interceptor {
+      override fun intercept(chain: Chain): Any? {
+        return try {
+          chain.proceed(chain.args)
+        } catch (_: Throwable) {
+          Response(BODY, HEADERS, STATUS_CODE)
         }
-
-        val INTERCEPTOR = object : Interceptor {
-            override fun intercept(chain: Chain): Any? {
-                return try {
-                    chain.proceed(chain.args)
-                } catch (_: Throwable) {
-                    Response(BODY, HEADERS, STATUS_CODE)
-                }
-            }
-        }
+      }
     }
+  }
 }

--- a/misk/src/main/kotlin/misk/web/interceptors/MarshallerInterceptor.kt
+++ b/misk/src/main/kotlin/misk/web/interceptors/MarshallerInterceptor.kt
@@ -1,6 +1,5 @@
 package misk.web.interceptors
 
-import com.google.inject.TypeLiteral
 import misk.Action
 import misk.Chain
 import misk.Interceptor
@@ -16,49 +15,55 @@ import kotlin.reflect.KType
 import kotlin.reflect.full.findAnnotation
 
 @Singleton
-internal class MarshallerInterceptor constructor(private val marshaller: Marshaller<Any>)
-    : Interceptor {
-    override fun intercept(chain: Chain): Response<Any> {
-        @Suppress("UNCHECKED_CAST")
-        val response = chain.proceed(chain.args) as Response<Any>
+internal class MarshallerInterceptor constructor(private val marshaller: Marshaller<Any>) :
+    Interceptor {
+  override fun intercept(chain: Chain): Response<Any> {
+    @Suppress("UNCHECKED_CAST")
+    val response = chain.proceed(chain.args) as Response<Any>
 
-        val headers = marshaller.contentType()?.let {
-            response.headers.newBuilder()
-                    .set("Content-Type", it.toString())
-                    .build()
-        } ?: response.headers
+    val headers = marshaller.contentType()?.let {
+      response.headers.newBuilder()
+          .set("Content-Type", it.toString())
+          .build()
+    } ?: response.headers
 
-        val body = marshaller.responseBody(response.body)
-        return Response(body, headers, response.statusCode)
+    val body = marshaller.responseBody(response.body)
+    return Response(body, headers, response.statusCode)
+  }
+
+  class Factory @Inject internal constructor(
+      @JvmSuppressWildcards private val marshallerFactories: List<Marshaller.Factory>
+  ) : Interceptor.Factory {
+    override fun create(action: Action): Interceptor? {
+      return findMarshaller(action)?.let { MarshallerInterceptor(it) }
     }
 
-    class Factory @Inject internal constructor(
-            @JvmSuppressWildcards private val marshallerFactories: List<Marshaller.Factory>
-    ) : Interceptor.Factory {
-        override fun create(action: Action): Interceptor? {
-            return findMarshaller(action)?.let { MarshallerInterceptor(it) }
-        }
+    private fun findMarshaller(action: Action): Marshaller<Any>? {
+      val responseMediaType = action.function.findAnnotation<ResponseContentType>()
+          ?.let {
+            MediaType.parse(it.value)
+          }
 
-        private fun findMarshaller(action: Action): Marshaller<Any>? {
-            val responseMediaType = action.function.findAnnotation<ResponseContentType>()?.let {
-                MediaType.parse(it.value)
-            }
+      if (responseMediaType == null || responseMediaType == MediaTypes.ALL_MEDIA_TYPE) {
+        return genericMarshallerFor(responseMediaType, action.returnType)
+      }
 
-            if (responseMediaType == null || responseMediaType == MediaTypes.ALL_MEDIA_TYPE) {
-                return genericMarshallerFor(responseMediaType, action.returnType)
-            }
+      val contentTypeMarshaller = marshallerFactories.mapNotNull {
+        it.create(responseMediaType, action.returnType)
+      }
+          .firstOrNull()
 
-            val contentTypeMarshaller = marshallerFactories.mapNotNull {
-                it.create(responseMediaType, action.returnType)
-            }.firstOrNull()
-
-            return contentTypeMarshaller
-                    ?: genericMarshallerFor(responseMediaType, action.returnType)
-        }
-
-        private fun genericMarshallerFor(mediaType: MediaType?, type: KType): Marshaller<Any> {
-            return GenericMarshallers.from(mediaType, type) ?:
-                    throw IllegalArgumentException("no marshaller for $mediaType as $type")
-        }
+      return contentTypeMarshaller
+          ?: genericMarshallerFor(responseMediaType, action.returnType)
     }
+
+    private fun genericMarshallerFor(
+        mediaType: MediaType?,
+        type: KType
+    ): Marshaller<Any> {
+      return GenericMarshallers.from(mediaType, type) ?: throw IllegalArgumentException(
+          "no marshaller for $mediaType as $type"
+      )
+    }
+  }
 }

--- a/misk/src/main/kotlin/misk/web/interceptors/MetricsInterceptor.kt
+++ b/misk/src/main/kotlin/misk/web/interceptors/MetricsInterceptor.kt
@@ -12,20 +12,24 @@ import javax.inject.Singleton
 
 internal class MetricsInterceptor internal constructor(val scope: MetricsScope) : Interceptor {
 
-    @Singleton
-    class Factory @Inject constructor(val m: Metrics) : Interceptor.Factory {
-        override fun create(action: Action): Interceptor? =
-                MetricsInterceptor(m.scope("web.${action.name}"))
+  @Singleton
+  class Factory @Inject constructor(val m: Metrics) : Interceptor.Factory {
+    override fun create(action: Action): Interceptor? =
+        MetricsInterceptor(m.scope("web.${action.name}"))
+  }
+
+  override fun intercept(chain: Chain): Any? {
+    scope.counter("requests")
+        .inc()
+    val result = scope.timer("timing")
+        .time(Callable { chain.proceed(chain.args) })
+    if (result is Response<*>) {
+      scope.counter("responses.${result.statusCode / 100}xx")
+          .inc()
+      scope.counter("responses.${result.statusCode}")
+          .inc()
     }
 
-    override fun intercept(chain: Chain): Any? {
-        scope.counter("requests").inc()
-        val result = scope.timer("timing").time(Callable { chain.proceed(chain.args) })
-        if (result is Response<*>) {
-            scope.counter("responses.${result.statusCode / 100}xx").inc()
-            scope.counter("responses.${result.statusCode}").inc()
-        }
-
-        return result
-    }
+    return result
+  }
 }

--- a/misk/src/main/kotlin/misk/web/interceptors/RequestLoggingInterceptor.kt
+++ b/misk/src/main/kotlin/misk/web/interceptors/RequestLoggingInterceptor.kt
@@ -14,18 +14,18 @@ private val logger = getLogger<RequestLoggingInterceptor>()
  * client.
  */
 internal class RequestLoggingInterceptor : Interceptor {
-    @Singleton
-    class Factory : Interceptor.Factory {
-        override fun create(action: Action): Interceptor? {
-            // TODO: return null if we don't want to log the request
-            return RequestLoggingInterceptor()
-        }
+  @Singleton
+  class Factory : Interceptor.Factory {
+    override fun create(action: Action): Interceptor? {
+      // TODO: return null if we don't want to log the request
+      return RequestLoggingInterceptor()
     }
+  }
 
-    override fun intercept(chain: Chain): Any? {
-        val stopwatch = Stopwatch.createStarted()
-        val result = chain.proceed(chain.args)
-        logger.debug { "action ${chain.action} took $stopwatch" }
-        return result
-    }
+  override fun intercept(chain: Chain): Any? {
+    val stopwatch = Stopwatch.createStarted()
+    val result = chain.proceed(chain.args)
+    logger.debug { "action ${chain.action} took $stopwatch" }
+    return result
+  }
 }

--- a/misk/src/main/kotlin/misk/web/jetty/JettyModule.kt
+++ b/misk/src/main/kotlin/misk/web/jetty/JettyModule.kt
@@ -6,7 +6,8 @@ import misk.inject.addMultibinderBinding
 import misk.inject.to
 
 class JettyModule : AbstractModule() {
-    override fun configure() {
-        binder().addMultibinderBinding<Service>().to<JettyService>()
-    }
+  override fun configure() {
+    binder().addMultibinderBinding<Service>()
+        .to<JettyService>()
+  }
 }

--- a/misk/src/main/kotlin/misk/web/jetty/JettyService.kt
+++ b/misk/src/main/kotlin/misk/web/jetty/JettyService.kt
@@ -16,47 +16,47 @@ private val logger = getLogger<JettyService>()
 
 @Singleton
 class JettyService @Inject internal constructor(
-        private val webActionsServlet: WebActionsServlet,
-        private val webConfig: WebConfig
+    private val webActionsServlet: WebActionsServlet,
+    private val webConfig: WebConfig
 ) : AbstractIdleService() {
 
-    private val server = Server()
+  private val server = Server()
 
-    val serverUrl: HttpUrl
-        get() {
-            return HttpUrl.Builder()
-                    .scheme(server.uri.scheme)
-                    .host(server.uri.host)
-                    .port(server.uri.port)
-                    .build()
-        }
-
-    override fun startUp() {
-        val stopwatch = Stopwatch.createStarted()
-        logger.info("Starting up Jetty")
-
-        val serverConnector = ServerConnector(server)
-        serverConnector.port = webConfig.port
-        serverConnector.idleTimeout = webConfig.idle_timeout
-        val servletHandler = ServletHandler()
-        servletHandler.addServletWithMapping(ServletHolder(webActionsServlet), "/*")
-
-        server.addConnector(serverConnector)
-        server.addManaged(servletHandler)
-
-        server.handler = servletHandler
-
-        server.start()
-
-        logger.info { "Started Jetty in $stopwatch on port ${webConfig.port}" }
+  val serverUrl: HttpUrl
+    get() {
+      return HttpUrl.Builder()
+          .scheme(server.uri.scheme)
+          .host(server.uri.host)
+          .port(server.uri.port)
+          .build()
     }
 
-    override fun shutDown() {
-        val stopwatch = Stopwatch.createStarted()
-        logger.info("Stopping Jetty")
+  override fun startUp() {
+    val stopwatch = Stopwatch.createStarted()
+    logger.info("Starting up Jetty")
 
-        server.stop()
+    val serverConnector = ServerConnector(server)
+    serverConnector.port = webConfig.port
+    serverConnector.idleTimeout = webConfig.idle_timeout
+    val servletHandler = ServletHandler()
+    servletHandler.addServletWithMapping(ServletHolder(webActionsServlet), "/*")
 
-        logger.info { "Stopped Jetty in $stopwatch" }
-    }
+    server.addConnector(serverConnector)
+    server.addManaged(servletHandler)
+
+    server.handler = servletHandler
+
+    server.start()
+
+    logger.info { "Started Jetty in $stopwatch on port ${webConfig.port}" }
+  }
+
+  override fun shutDown() {
+    val stopwatch = Stopwatch.createStarted()
+    logger.info("Stopping Jetty")
+
+    server.stop()
+
+    logger.info { "Stopped Jetty in $stopwatch" }
+  }
 }

--- a/misk/src/main/kotlin/misk/web/jetty/WebActionsServlet.kt
+++ b/misk/src/main/kotlin/misk/web/jetty/WebActionsServlet.kt
@@ -20,49 +20,61 @@ private val logger = getLogger<WebActionsServlet>()
 
 @Singleton
 internal class WebActionsServlet @Inject constructor(
-        private val boundActions: MutableSet<BoundAction<out WebAction, *>>,
-        private val scope: ActionScope
+    private val boundActions: MutableSet<BoundAction<out WebAction, *>>,
+    private val scope: ActionScope
 ) : HttpServlet() {
-    override fun doGet(request: HttpServletRequest, response: HttpServletResponse) {
-        handleCall(request, response)
-    }
+  override fun doGet(
+      request: HttpServletRequest,
+      response: HttpServletResponse
+  ) {
+    handleCall(request, response)
+  }
 
-    override fun doPost(request: HttpServletRequest, response: HttpServletResponse) {
-        handleCall(request, response)
-    }
+  override fun doPost(
+      request: HttpServletRequest,
+      response: HttpServletResponse
+  ) {
+    handleCall(request, response)
+  }
 
-    private fun handleCall(request: HttpServletRequest, response: HttpServletResponse) {
-        val asRequest = request.asRequest()
-        val seedData = mapOf(
-                keyOf<HttpServletRequest>() to request,
-                keyOf<Request>() to asRequest)
+  private fun handleCall(
+      request: HttpServletRequest,
+      response: HttpServletResponse
+  ) {
+    val asRequest = request.asRequest()
+    val seedData = mapOf(
+        keyOf<HttpServletRequest>() to request,
+        keyOf<Request>() to asRequest
+    )
 
-        scope.enter(seedData).use {
-            val candidateActions = boundActions.mapNotNull { it.match(request, asRequest.url) }
-            val bestAction = candidateActions.sorted().firstOrNull()
-            bestAction?.handle(asRequest, response)
-            logger.debug {"Request handled by WebActionServlet" }
+    scope.enter(seedData)
+        .use {
+          val candidateActions = boundActions.mapNotNull { it.match(request, asRequest.url) }
+          val bestAction = candidateActions.sorted()
+              .firstOrNull()
+          bestAction?.handle(asRequest, response)
+          logger.debug { "Request handled by WebActionServlet" }
         }
-    }
+  }
 }
 
 internal fun HttpServletRequest.asRequest(): Request {
-    val urlString = requestURL.toString() +
-            if (queryString != null) "?" + queryString
-            else ""
+  val urlString = requestURL.toString() +
+      if (queryString != null) "?" + queryString
+      else ""
 
-    val headersBuilder = Headers.Builder()
-    val headerNames = headerNames
-    for (headerName in headerNames) {
-        val headerValues = getHeaders(headerName)
-        for (headerValue in headerValues) {
-            headersBuilder.add(headerName, headerValue)
-        }
+  val headersBuilder = Headers.Builder()
+  val headerNames = headerNames
+  for (headerName in headerNames) {
+    val headerValues = getHeaders(headerName)
+    for (headerValue in headerValues) {
+      headersBuilder.add(headerName, headerValue)
     }
-    return Request(
-            HttpUrl.parse(urlString)!!,
-            HttpMethod.valueOf(method),
-            headersBuilder.build(),
-            Okio.buffer(Okio.source(inputStream))
-    )
+  }
+  return Request(
+      HttpUrl.parse(urlString)!!,
+      HttpMethod.valueOf(method),
+      headersBuilder.build(),
+      Okio.buffer(Okio.source(inputStream))
+  )
 }

--- a/misk/src/main/kotlin/misk/web/marshal/Generic.kt
+++ b/misk/src/main/kotlin/misk/web/marshal/Generic.kt
@@ -14,88 +14,91 @@ import kotlin.reflect.jvm.javaType
 
 /** Handles generic unmarshalling, for cases where the action can accept anything */
 object GenericUnmarshallers {
-    fun canHandle(type: KType) = canHandle(type.javaType)
-    fun canHandle(type: Type) = GENERIC_REQUEST_TYPES.contains(type)
+  fun canHandle(type: KType) = canHandle(type.javaType)
+  fun canHandle(type: Type) = GENERIC_REQUEST_TYPES.contains(type)
 
-    private val GENERIC_REQUEST_TYPES = setOf(
-            String::class.java,
-            BufferedSource::class.java,
-            ByteString::class.java
-    )
+  private val GENERIC_REQUEST_TYPES = setOf(
+      String::class.java,
+      BufferedSource::class.java,
+      ByteString::class.java
+  )
 
-    private object ToString : Unmarshaller {
-        override fun unmarshal(source: BufferedSource): Any? = source.readUtf8()
+  private object ToString : Unmarshaller {
+    override fun unmarshal(source: BufferedSource): Any? = source.readUtf8()
+  }
+
+  private object ToBufferedSource : Unmarshaller {
+    override fun unmarshal(source: BufferedSource): Any? = source
+  }
+
+  private object ToByteString : Unmarshaller {
+    override fun unmarshal(source: BufferedSource): Any? = source.readByteString()
+  }
+
+  fun into(parameter: KParameter): Unmarshaller? {
+    val paramType = parameter.type
+    return when (paramType.typeLiteral().rawType) {
+      String::class.java -> ToString
+      BufferedSource::class.java -> ToBufferedSource
+      ByteString::class.java -> ToByteString
+      else -> null
     }
-
-    private object ToBufferedSource : Unmarshaller {
-        override fun unmarshal(source: BufferedSource): Any? = source
-    }
-
-    private object ToByteString : Unmarshaller {
-        override fun unmarshal(source: BufferedSource): Any? = source.readByteString()
-    }
-
-    fun into(parameter: KParameter): Unmarshaller? {
-        val paramType = parameter.type
-        return when (paramType.typeLiteral().rawType) {
-            String::class.java -> ToString
-            BufferedSource::class.java -> ToBufferedSource
-            ByteString::class.java -> ToByteString
-            else -> null
-        }
-    }
+  }
 }
 
 /** Handles generic marshalling, for cases where the action doesn't explicitly specify return content */
 object GenericMarshallers {
-    fun canHandle(type: KType) = canHandle(type.javaType)
-    fun canHandle(type: Type) = GENERIC_RESPONSE_TYPES.contains(type)
+  fun canHandle(type: KType) = canHandle(type.javaType)
+  fun canHandle(type: Type) = GENERIC_RESPONSE_TYPES.contains(type)
 
-    private val GENERIC_RESPONSE_TYPES = setOf(
-            String::class.java,
-            ResponseBody::class.java,
-            ByteString::class.java,
-            Nothing::class.java
-    )
+  private val GENERIC_RESPONSE_TYPES = setOf(
+      String::class.java,
+      ResponseBody::class.java,
+      ByteString::class.java,
+      Nothing::class.java
+  )
 
-    private class FromResponseBody(private val contentType: MediaType?) : Marshaller<ResponseBody> {
-        override fun contentType(): MediaType? = contentType
-        override fun responseBody(o: ResponseBody) = o
+  private class FromResponseBody(private val contentType: MediaType?) : Marshaller<ResponseBody> {
+    override fun contentType(): MediaType? = contentType
+    override fun responseBody(o: ResponseBody) = o
+  }
+
+  private class FromString(private val contentType: MediaType?) : Marshaller<String> {
+    override fun contentType(): MediaType? = contentType
+    override fun responseBody(o: String) = object : ResponseBody {
+      override fun writeTo(sink: BufferedSink) {
+        sink.writeString(o, Charsets.UTF_8)
+      }
     }
+  }
 
-    private class FromString(private val contentType: MediaType?) : Marshaller<String> {
-        override fun contentType(): MediaType? = contentType
-        override fun responseBody(o: String) = object : ResponseBody {
-            override fun writeTo(sink: BufferedSink) {
-                sink.writeString(o, Charsets.UTF_8)
-            }
-        }
+  class FromByteString(private val contentType: MediaType?) : Marshaller<ByteString> {
+    override fun contentType(): MediaType? = contentType
+    override fun responseBody(o: ByteString) = object : ResponseBody {
+      override fun writeTo(sink: BufferedSink) {
+        sink.write(o)
+      }
     }
+  }
 
-    class FromByteString(private val contentType: MediaType?) : Marshaller<ByteString> {
-        override fun contentType(): MediaType? = contentType
-        override fun responseBody(o: ByteString) = object : ResponseBody {
-            override fun writeTo(sink: BufferedSink) {
-                sink.write(o)
-            }
-        }
+  class ToNothing(private val contentType: MediaType?) : Marshaller<Nothing> {
+    override fun contentType(): MediaType? = contentType
+    override fun responseBody(o: Nothing) = object : ResponseBody {
+      override fun writeTo(sink: BufferedSink) {}
     }
+  }
 
-    class ToNothing(private val contentType: MediaType?) : Marshaller<Nothing> {
-        override fun contentType(): MediaType? = contentType
-        override fun responseBody(o: Nothing) = object : ResponseBody {
-            override fun writeTo(sink: BufferedSink) {}
-        }
-    }
-
-    fun from(contentType: MediaType?, returnType: KType): Marshaller<Any>? {
-        @Suppress("UNCHECKED_CAST")
-        return when (actualResponseType(returnType)) {
-            String::class.java -> FromString(contentType)
-            ByteString::class.java -> FromByteString(contentType)
-            ResponseBody::class.java -> FromResponseBody(contentType)
-            Nothing::class.java -> ToNothing(contentType)
-            else -> null
-        } as Marshaller<Any>?
-    }
+  fun from(
+      contentType: MediaType?,
+      returnType: KType
+  ): Marshaller<Any>? {
+    @Suppress("UNCHECKED_CAST")
+    return when (actualResponseType(returnType)) {
+      String::class.java -> FromString(contentType)
+      ByteString::class.java -> FromByteString(contentType)
+      ResponseBody::class.java -> FromResponseBody(contentType)
+      Nothing::class.java -> ToNothing(contentType)
+      else -> null
+    } as Marshaller<Any>?
+  }
 }

--- a/misk/src/main/kotlin/misk/web/marshal/Json.kt
+++ b/misk/src/main/kotlin/misk/web/marshal/Json.kt
@@ -13,38 +13,44 @@ import kotlin.reflect.KType
 import kotlin.reflect.jvm.javaType
 
 class JsonMarshaller<T>(val adapter: JsonAdapter<T>) : Marshaller<T> {
-    override fun contentType() = MediaTypes.APPLICATION_JSON_MEDIA_TYPE
+  override fun contentType() = MediaTypes.APPLICATION_JSON_MEDIA_TYPE
 
-    override fun responseBody(o: T) = object : ResponseBody {
-        override fun writeTo(sink: BufferedSink) {
-            adapter.toJson(sink, o)
-        }
+  override fun responseBody(o: T) = object : ResponseBody {
+    override fun writeTo(sink: BufferedSink) {
+      adapter.toJson(sink, o)
     }
+  }
 
-    class Factory @Inject internal constructor(val moshi: Moshi) : Marshaller.Factory {
-        override fun create(mediaType: MediaType, type: KType): Marshaller<Any>? {
-            if (mediaType.type() != MediaTypes.APPLICATION_JSON_MEDIA_TYPE.type() ||
-                    mediaType.subtype() != MediaTypes.APPLICATION_JSON_MEDIA_TYPE.subtype()) {
-                return null
-            }
+  class Factory @Inject internal constructor(val moshi: Moshi) : Marshaller.Factory {
+    override fun create(
+        mediaType: MediaType,
+        type: KType
+    ): Marshaller<Any>? {
+      if (mediaType.type() != MediaTypes.APPLICATION_JSON_MEDIA_TYPE.type() ||
+          mediaType.subtype() != MediaTypes.APPLICATION_JSON_MEDIA_TYPE.subtype()) {
+        return null
+      }
 
-            val responseType = actualResponseType(type)
-            if (GenericMarshallers.canHandle(responseType)) return null
-            return JsonMarshaller<Any>(moshi.adapter<Any>(responseType))
-        }
+      val responseType = actualResponseType(type)
+      if (GenericMarshallers.canHandle(responseType)) return null
+      return JsonMarshaller<Any>(moshi.adapter<Any>(responseType))
     }
+  }
 }
 
 class JsonUnmarshaller(val adapter: JsonAdapter<Any>) : Unmarshaller {
-    override fun unmarshal(source: BufferedSource) = adapter.fromJson(source)
+  override fun unmarshal(source: BufferedSource) = adapter.fromJson(source)
 
-    class Factory @Inject internal constructor(val moshi: Moshi) : Unmarshaller.Factory {
-        override fun create(mediaType: MediaType, type: KType): Unmarshaller? {
-            if (mediaType.type() != MediaTypes.APPLICATION_JSON_MEDIA_TYPE.type() ||
-                    mediaType.subtype() != MediaTypes.APPLICATION_JSON_MEDIA_TYPE.subtype()) return null
+  class Factory @Inject internal constructor(val moshi: Moshi) : Unmarshaller.Factory {
+    override fun create(
+        mediaType: MediaType,
+        type: KType
+    ): Unmarshaller? {
+      if (mediaType.type() != MediaTypes.APPLICATION_JSON_MEDIA_TYPE.type() ||
+          mediaType.subtype() != MediaTypes.APPLICATION_JSON_MEDIA_TYPE.subtype()) return null
 
-            if (GenericUnmarshallers.canHandle(type)) return null
-            return JsonUnmarshaller(moshi.adapter<Any>(type.javaType))
-        }
+      if (GenericUnmarshallers.canHandle(type)) return null
+      return JsonUnmarshaller(moshi.adapter<Any>(type.javaType))
     }
+  }
 }

--- a/misk/src/main/kotlin/misk/web/marshal/Marshaller.kt
+++ b/misk/src/main/kotlin/misk/web/marshal/Marshaller.kt
@@ -10,26 +10,29 @@ import kotlin.reflect.KType
 
 /** Marshalls typed kotlin objects into a [ResponseBody] */
 interface Marshaller<in T> {
-    /** @return the media type of the marshalled content, if known to the [Marshaller] */
-    fun contentType(): MediaType?
+  /** @return the media type of the marshalled content, if known to the [Marshaller] */
+  fun contentType(): MediaType?
 
-    /** @return The object marshalled into a [ResponseBody] */
-    fun responseBody(o: T): ResponseBody
+  /** @return The object marshalled into a [ResponseBody] */
+  fun responseBody(o: T): ResponseBody
 
-    interface Factory {
-        fun create(mediaType: MediaType, type: KType): Marshaller<Any>?
-    }
+  interface Factory {
+    fun create(
+        mediaType: MediaType,
+        type: KType
+    ): Marshaller<Any>?
+  }
 
-    companion object {
-        fun actualResponseType(type: KType): Type {
-            val typeLiteral = type.typeLiteral()
-            return when {
-                typeLiteral.rawType == Response::class.java -> {
-                    (typeLiteral.type as ParameterizedType).actualTypeArguments[0]
-                }
-                else -> typeLiteral.type
-            }
-
+  companion object {
+    fun actualResponseType(type: KType): Type {
+      val typeLiteral = type.typeLiteral()
+      return when {
+        typeLiteral.rawType == Response::class.java -> {
+          (typeLiteral.type as ParameterizedType).actualTypeArguments[0]
         }
+        else -> typeLiteral.type
+      }
+
     }
+  }
 }

--- a/misk/src/main/kotlin/misk/web/marshal/MarshallerModule.kt
+++ b/misk/src/main/kotlin/misk/web/marshal/MarshallerModule.kt
@@ -5,11 +5,12 @@ import misk.inject.addMultibinderBinding
 import kotlin.reflect.KClass
 
 class MarshallerModule<T : Marshaller.Factory>(val kclass: KClass<T>) : KAbstractModule() {
-    override fun configure() {
-        binder().addMultibinderBinding<Marshaller.Factory>().to(kclass.java)
-    }
+  override fun configure() {
+    binder().addMultibinderBinding<Marshaller.Factory>()
+        .to(kclass.java)
+  }
 
-    companion object {
-        inline fun <reified T : Marshaller.Factory> create() = MarshallerModule(T::class)
-    }
+  companion object {
+    inline fun <reified T : Marshaller.Factory> create() = MarshallerModule(T::class)
+  }
 }

--- a/misk/src/main/kotlin/misk/web/marshal/PlainText.kt
+++ b/misk/src/main/kotlin/misk/web/marshal/PlainText.kt
@@ -10,47 +10,53 @@ import okio.ByteString
 import kotlin.reflect.KType
 
 object PlainTextMarshaller : Marshaller<Any> {
-    override fun contentType() = MediaTypes.TEXT_PLAIN_UTF8_MEDIA_TYPE
-    override fun responseBody(o: Any) = object : ResponseBody {
-        override fun writeTo(sink: BufferedSink) {
-            sink.writeString(o.toString(), Charsets.UTF_8)
-        }
+  override fun contentType() = MediaTypes.TEXT_PLAIN_UTF8_MEDIA_TYPE
+  override fun responseBody(o: Any) = object : ResponseBody {
+    override fun writeTo(sink: BufferedSink) {
+      sink.writeString(o.toString(), Charsets.UTF_8)
     }
+  }
 
-    class Factory : Marshaller.Factory {
-        override fun create(mediaType: MediaType, type: KType): Marshaller<Any>? {
-            if (mediaType.type() != MediaTypes.TEXT_PLAIN_UTF8_MEDIA_TYPE.type() ||
-                    mediaType.subtype() != MediaTypes.TEXT_PLAIN_UTF8_MEDIA_TYPE.subtype()) {
-                return null
-            }
+  class Factory : Marshaller.Factory {
+    override fun create(
+        mediaType: MediaType,
+        type: KType
+    ): Marshaller<Any>? {
+      if (mediaType.type() != MediaTypes.TEXT_PLAIN_UTF8_MEDIA_TYPE.type() ||
+          mediaType.subtype() != MediaTypes.TEXT_PLAIN_UTF8_MEDIA_TYPE.subtype()) {
+        return null
+      }
 
-            if (GenericMarshallers.canHandle(actualResponseType(type))) return null
-            return PlainTextMarshaller
-        }
+      if (GenericMarshallers.canHandle(actualResponseType(type))) return null
+      return PlainTextMarshaller
     }
+  }
 }
 
 object PlainTextUnmarshaller {
-    object ToString : Unmarshaller {
-        override fun unmarshal(source: BufferedSource) = source.readUtf8()
+  object ToString : Unmarshaller {
+    override fun unmarshal(source: BufferedSource) = source.readUtf8()
+  }
+
+  object ToByteString : Unmarshaller {
+    override fun unmarshal(source: BufferedSource) = source.readByteString()
+  }
+
+  class Factory : Unmarshaller.Factory {
+    override fun create(
+        mediaType: MediaType,
+        type: KType
+    ): Unmarshaller? {
+      if (mediaType.type() != MediaTypes.TEXT_PLAIN_UTF8_MEDIA_TYPE.type() ||
+          mediaType.subtype() != MediaTypes.TEXT_PLAIN_UTF8_MEDIA_TYPE.subtype()) return null
+
+      if (GenericUnmarshallers.canHandle(type)) return null
+
+      return when (type) {
+        String::class -> ToString
+        ByteString::class -> ToByteString
+        else -> throw IllegalArgumentException("no plain/text unmarshaller for $type")
+      }
     }
-
-    object ToByteString : Unmarshaller {
-        override fun unmarshal(source: BufferedSource) = source.readByteString()
-    }
-
-    class Factory : Unmarshaller.Factory {
-        override fun create(mediaType: MediaType, type: KType): Unmarshaller? {
-            if (mediaType.type() != MediaTypes.TEXT_PLAIN_UTF8_MEDIA_TYPE.type() ||
-                    mediaType.subtype() != MediaTypes.TEXT_PLAIN_UTF8_MEDIA_TYPE.subtype()) return null
-
-            if (GenericUnmarshallers.canHandle(type)) return null
-
-            return when (type) {
-                String::class -> ToString
-                ByteString::class -> ToByteString
-                else -> throw IllegalArgumentException("no plain/text unmarshaller for $type")
-            }
-        }
-    }
+  }
 }

--- a/misk/src/main/kotlin/misk/web/marshal/StringResponseBody.kt
+++ b/misk/src/main/kotlin/misk/web/marshal/StringResponseBody.kt
@@ -5,7 +5,7 @@ import okio.BufferedSink
 
 /** A [ResponseBody] that writes the value out as a string */
 class StringResponseBody(val obj: Any) : ResponseBody {
-    override fun writeTo(sink: BufferedSink) {
-        sink.writeUtf8(obj.toString())
-    }
+  override fun writeTo(sink: BufferedSink) {
+    sink.writeUtf8(obj.toString())
+  }
 }

--- a/misk/src/main/kotlin/misk/web/marshal/Unmarshaller.kt
+++ b/misk/src/main/kotlin/misk/web/marshal/Unmarshaller.kt
@@ -6,9 +6,12 @@ import kotlin.reflect.KType
 
 /** Unmarshalls a typed object from an incoming source */
 interface Unmarshaller {
-    fun unmarshal(source: BufferedSource): Any?
+  fun unmarshal(source: BufferedSource): Any?
 
-    interface Factory {
-        fun create(mediaType: MediaType, type: KType): Unmarshaller?
-    }
+  interface Factory {
+    fun create(
+        mediaType: MediaType,
+        type: KType
+    ): Unmarshaller?
+  }
 }

--- a/misk/src/main/kotlin/misk/web/marshal/UnmarshallerModule.kt
+++ b/misk/src/main/kotlin/misk/web/marshal/UnmarshallerModule.kt
@@ -5,11 +5,12 @@ import misk.inject.addMultibinderBinding
 import kotlin.reflect.KClass
 
 class UnmarshallerModule<T : Unmarshaller.Factory>(val kclass: KClass<T>) : KAbstractModule() {
-    override fun configure() {
-        binder().addMultibinderBinding<Unmarshaller.Factory>().to(kclass.java)
-    }
+  override fun configure() {
+    binder().addMultibinderBinding<Unmarshaller.Factory>()
+        .to(kclass.java)
+  }
 
-    companion object {
-        inline fun <reified T : Unmarshaller.Factory> create() = UnmarshallerModule(T::class)
-    }
+  companion object {
+    inline fun <reified T : Unmarshaller.Factory> create() = UnmarshallerModule(T::class)
+  }
 }

--- a/misk/src/main/kotlin/misk/web/mediatype/MediaTypes.kt
+++ b/misk/src/main/kotlin/misk/web/mediatype/MediaTypes.kt
@@ -3,14 +3,14 @@ package misk.web.mediatype
 import okhttp3.MediaType
 
 object MediaTypes {
-    const val APPLICATION_JSON = "application/json;charset=utf-8"
-    val APPLICATION_JSON_MEDIA_TYPE = APPLICATION_JSON.asMediaType()
+  const val APPLICATION_JSON = "application/json;charset=utf-8"
+  val APPLICATION_JSON_MEDIA_TYPE = APPLICATION_JSON.asMediaType()
 
-    const val TEXT_PLAIN_UTF8 = "text/plain;charset=utf-8"
-    val TEXT_PLAIN_UTF8_MEDIA_TYPE = TEXT_PLAIN_UTF8.asMediaType()
+  const val TEXT_PLAIN_UTF8 = "text/plain;charset=utf-8"
+  val TEXT_PLAIN_UTF8_MEDIA_TYPE = TEXT_PLAIN_UTF8.asMediaType()
 
-    const val ALL = "*/*"
-    val ALL_MEDIA_TYPE = ALL.asMediaType()
+  const val ALL = "*/*"
+  val ALL_MEDIA_TYPE = ALL.asMediaType()
 }
 
 fun String.asMediaType() = MediaType.parse(this)!!

--- a/misk/src/test/java/helpers/protos/Dinosaur.java
+++ b/misk/src/test/java/helpers/protos/Dinosaur.java
@@ -13,7 +13,8 @@ import static com.squareup.wire.internal.Internal.immutableCopyOf;
 import static com.squareup.wire.internal.Internal.newMutableList;
 
 public final class Dinosaur extends Message<Dinosaur, Dinosaur.Builder> {
-  public static final ProtoAdapter<Dinosaur> ADAPTER = ProtoAdapter.newMessageAdapter(Dinosaur.class);
+  public static final ProtoAdapter<Dinosaur> ADAPTER =
+      ProtoAdapter.newMessageAdapter(Dinosaur.class);
 
   private static final long serialVersionUID = 0L;
 

--- a/misk/src/test/kotlin/misk/ActionsTest.kt
+++ b/misk/src/test/kotlin/misk/ActionsTest.kt
@@ -6,33 +6,33 @@ import org.junit.jupiter.api.Test
 import kotlin.reflect.full.createType
 
 internal class ActionsTest {
-    @Test
-    fun methodAsAction() {
-        val action = TestAction::myActionMethod.asAction()
-        assertThat(action.name).isEqualTo("TestAction")
-        assertThat(action.parameterTypes).hasSize(1)
-        assertThat(action.parameterTypes[0]).isEqualTo(Int::class.createType())
-        assertThat(action.returnType).isEqualTo(String::class.createType())
-    }
+  @Test
+  fun methodAsAction() {
+    val action = TestAction::myActionMethod.asAction()
+    assertThat(action.name).isEqualTo("TestAction")
+    assertThat(action.parameterTypes).hasSize(1)
+    assertThat(action.parameterTypes[0]).isEqualTo(Int::class.createType())
+    assertThat(action.returnType).isEqualTo(String::class.createType())
+  }
 
-    @Test
-    fun methodReferenceNotAllowedAsAction() {
-        assertThrows(IllegalArgumentException::class.java) {
-            val t = TestAction()
-            t::myActionMethod.asAction()
-        }
+  @Test
+  fun methodReferenceNotAllowedAsAction() {
+    assertThrows(IllegalArgumentException::class.java) {
+      val t = TestAction()
+      t::myActionMethod.asAction()
     }
+  }
 
-    @Test
-    fun freeStandingFunctionNotAllowedAsAction() {
-        assertThrows(IllegalArgumentException::class.java) {
-            ::myActionHandler.asAction()
-        }
+  @Test
+  fun freeStandingFunctionNotAllowedAsAction() {
+    assertThrows(IllegalArgumentException::class.java) {
+      ::myActionHandler.asAction()
     }
+  }
 
-    class TestAction {
-        fun myActionMethod(n: Int): String = "foo$n"
-    }
+  class TestAction {
+    fun myActionMethod(n: Int): String = "foo$n"
+  }
 
-    fun myActionHandler(n: Int): String = "bar$n"
+  fun myActionHandler(n: Int): String = "bar$n"
 }

--- a/misk/src/test/kotlin/misk/MiskApplicationTest.kt
+++ b/misk/src/test/kotlin/misk/MiskApplicationTest.kt
@@ -8,98 +8,98 @@ import org.junit.jupiter.api.Test
 import javax.inject.Inject
 
 internal class MiskApplicationTest {
-    class WithRequiredArguments : MiskCommand("with-required-args") {
-        @Parameter(names = ["-f", "--file"], required = true)
-        var filename: String? = null
+  class WithRequiredArguments : MiskCommand("with-required-args") {
+    @Parameter(names = ["-f", "--file"], required = true)
+    var filename: String? = null
 
-        var run: Boolean = false
+    var run: Boolean = false
 
-        override fun run() {
-            run = true
-        }
+    override fun run() {
+      run = true
+    }
+  }
+
+  class WithPreconditions : MiskCommand("with-preconditions") {
+    @Parameter(names = ["-f", "--file"])
+    var filename: String? = null
+
+    @Parameter(names = ["-d", "--dir"])
+    var directory: String? = null
+
+    var run: Boolean = false
+    var preconditionsMet: Boolean = false
+
+    override fun run() {
+      run = true
+      requireCli(filename != null || directory != null) {
+        "one of -f or -d must be specified"
+      }
+      preconditionsMet = true
+    }
+  }
+
+  class WithModule : MiskCommand("with-module", AppNameModule()) {
+    @Inject
+    lateinit
+    var injectedValue: MyInjectedValue
+
+    var run: Boolean = false
+
+    override fun run() {
+      run = true
     }
 
-    class WithPreconditions : MiskCommand("with-preconditions") {
-        @Parameter(names = ["-f", "--file"])
-        var filename: String? = null
+    data class MyInjectedValue(val message: String)
 
-        @Parameter(names = ["-d", "--dir"])
-        var directory: String? = null
+    class AppNameModule : KAbstractModule() {
+      override fun configure() {
+        bind<MyInjectedValue>().toInstance(MyInjectedValue("foo"))
+      }
+    }
+  }
 
-        var run: Boolean = false
-        var preconditionsMet: Boolean = false
+  class Commands {
+    val withRequiredArguments = WithRequiredArguments()
+    val withPreconditions = WithPreconditions()
+    val withModule = WithModule()
+    val all = arrayOf(withRequiredArguments, withPreconditions, withModule)
+  }
 
-        override fun run() {
-            run = true
-            requireCli(filename != null || directory != null) {
-                "one of -f or -d must be specified"
-            }
-            preconditionsMet = true
-        }
+  @Test
+  fun withModule() {
+    val commands = Commands()
+    MiskApplication(*commands.all).doRun(arrayOf("with-module"))
+    assertThat(commands.withModule.run).isTrue()
+    assertThat(commands.withModule.injectedValue.message).isEqualTo("foo")
+  }
+
+  @Test
+  fun withRequiredArguments() {
+    val commands = Commands()
+    MiskApplication(*commands.all).doRun(arrayOf("with-required-args", "-f", "my-file"))
+    assertThat(commands.withRequiredArguments.run).isTrue()
+    assertThat(commands.withRequiredArguments.filename).isEqualTo("my-file")
+  }
+
+  @Test
+  fun withPreconditions() {
+    val commands = Commands()
+    MiskApplication(*commands.all).doRun(arrayOf("with-preconditions", "-f", "my-file"))
+    assertThat(commands.withPreconditions.run).isTrue()
+    assertThat(commands.withPreconditions.preconditionsMet).isTrue()
+    assertThat(commands.withPreconditions.filename).isEqualTo("my-file")
+  }
+
+  @Test
+  fun missingRequiredArgument() {
+    val exception = assertThrows(MiskApplication.CliException::class.java) {
+      val commands = Commands()
+      MiskApplication(*commands.all).doRun(arrayOf("with-required-args", "-f"))
     }
 
-    class WithModule : MiskCommand("with-module", AppNameModule()) {
-        @Inject
-        lateinit
-        var injectedValue: MyInjectedValue
-
-        var run: Boolean = false
-
-        override fun run() {
-            run = true
-        }
-
-        data class MyInjectedValue(val message: String)
-
-        class AppNameModule : KAbstractModule() {
-            override fun configure() {
-                bind<MyInjectedValue>().toInstance(MyInjectedValue("foo"))
-            }
-        }
-    }
-
-    class Commands {
-        val withRequiredArguments = WithRequiredArguments()
-        val withPreconditions = WithPreconditions()
-        val withModule = WithModule()
-        val all = arrayOf(withRequiredArguments, withPreconditions, withModule)
-    }
-
-    @Test
-    fun withModule() {
-        val commands = Commands()
-        MiskApplication(*commands.all).doRun(arrayOf("with-module"))
-        assertThat(commands.withModule.run).isTrue()
-        assertThat(commands.withModule.injectedValue.message).isEqualTo("foo")
-    }
-
-    @Test
-    fun withRequiredArguments() {
-        val commands = Commands()
-        MiskApplication(*commands.all).doRun(arrayOf("with-required-args", "-f", "my-file"))
-        assertThat(commands.withRequiredArguments.run).isTrue()
-        assertThat(commands.withRequiredArguments.filename).isEqualTo("my-file")
-    }
-
-    @Test
-    fun withPreconditions() {
-        val commands = Commands()
-        MiskApplication(*commands.all).doRun(arrayOf("with-preconditions", "-f", "my-file"))
-        assertThat(commands.withPreconditions.run).isTrue()
-        assertThat(commands.withPreconditions.preconditionsMet).isTrue()
-        assertThat(commands.withPreconditions.filename).isEqualTo("my-file")
-    }
-
-    @Test
-    fun missingRequiredArgument() {
-        val exception = assertThrows(MiskApplication.CliException::class.java) {
-            val commands = Commands()
-            MiskApplication(*commands.all).doRun(arrayOf("with-required-args", "-f"))
-        }
-
-        // Error message should be specific to the command
-        assertThat(exception.message).isEqualTo(
-"""
+    // Error message should be specific to the command
+    assertThat(exception.message).isEqualTo(
+        """
 Expected a value after parameter -f
 
 Usage: with-required-args [options]
@@ -107,19 +107,19 @@ Usage: with-required-args [options]
   * -f, --file
 
 """
-        )
+    )
+  }
+
+  @Test
+  fun unknownCommand() {
+    val exception = assertThrows(MiskApplication.CliException::class.java) {
+      val commands = Commands()
+      MiskApplication(*commands.all).doRun(arrayOf("unknown"))
     }
 
-    @Test
-    fun unknownCommand() {
-        val exception = assertThrows(MiskApplication.CliException::class.java) {
-            val commands = Commands()
-            MiskApplication(*commands.all).doRun(arrayOf("unknown"))
-        }
-
-        // Error message should include the entire usage
-        assertThat(exception.message).isEqualTo(
-"""
+    // Error message should include the entire usage
+    assertThat(exception.message).isEqualTo(
+        """
 Expected a command, got unknown
 
 Usage: <main class> [command] [command options]
@@ -142,19 +142,19 @@ Usage: <main class> [command] [command options]
       Usage: with-module
 
 """
-        )
+    )
+  }
+
+  @Test
+  fun commandPreconditionsNotMet() {
+    val exception = assertThrows(MiskApplication.CliException::class.java) {
+      val commands = Commands()
+      MiskApplication(*commands.all).doRun(arrayOf("with-preconditions"))
     }
 
-    @Test
-    fun commandPreconditionsNotMet() {
-        val exception = assertThrows(MiskApplication.CliException::class.java) {
-            val commands = Commands()
-            MiskApplication(*commands.all).doRun(arrayOf("with-preconditions"))
-        }
-
-        // Error message should be specific to the command
-        assertThat(exception.message).isEqualTo(
-"""
+    // Error message should be specific to the command
+    assertThat(exception.message).isEqualTo(
+        """
 one of -f or -d must be specified
 
 Usage: with-preconditions [options]
@@ -164,7 +164,7 @@ Usage: with-preconditions [options]
     -f, --file
 
 """
-        )
+    )
 
-    }
+  }
 }

--- a/misk/src/test/kotlin/misk/cloud/aws/environment/AwsInstanceMetadataProviderTest.kt
+++ b/misk/src/test/kotlin/misk/cloud/aws/environment/AwsInstanceMetadataProviderTest.kt
@@ -9,30 +9,30 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
 internal class AwsInstanceMetadataProviderTest {
-    @Test
-    fun resolvesMetadata() {
-        val routes = RoutingDispatcher {
-            when (it.requestUrl.path) {
-                "$AWS_INSTANCE_METADATA_PATH/instance-id" ->
-                    MockResponse().setBody("i-1234567890abcdef0")
-                "$AWS_INSTANCE_METADATA_PATH/placement/availability-zone" ->
-                    MockResponse().setBody("us-west-2c")
-                else -> MockResponse().setResponseCode(404)
-            }
-        }
-
-        val server = MockWebServer()
-        server.setDispatcher(routes)
-        server.start()
-
-        val provider = AwsInstanceMetadataProvider("http://${server.hostName}:${server.port}")
-
-        try {
-            val instanceMetadata = provider.get()
-            assertThat(instanceMetadata.instanceName).isEqualTo("i-1234567890abcdef0")
-            assertThat(instanceMetadata.zone).isEqualTo("us-west-2c")
-        } finally {
-            server.shutdown()
-        }
+  @Test
+  fun resolvesMetadata() {
+    val routes = RoutingDispatcher {
+      when (it.requestUrl.path) {
+        "$AWS_INSTANCE_METADATA_PATH/instance-id" ->
+          MockResponse().setBody("i-1234567890abcdef0")
+        "$AWS_INSTANCE_METADATA_PATH/placement/availability-zone" ->
+          MockResponse().setBody("us-west-2c")
+        else -> MockResponse().setResponseCode(404)
+      }
     }
+
+    val server = MockWebServer()
+    server.setDispatcher(routes)
+    server.start()
+
+    val provider = AwsInstanceMetadataProvider("http://${server.hostName}:${server.port}")
+
+    try {
+      val instanceMetadata = provider.get()
+      assertThat(instanceMetadata.instanceName).isEqualTo("i-1234567890abcdef0")
+      assertThat(instanceMetadata.zone).isEqualTo("us-west-2c")
+    } finally {
+      server.shutdown()
+    }
+  }
 }

--- a/misk/src/test/kotlin/misk/cloud/fake/security/keys/FakeKeyServiceTest.kt
+++ b/misk/src/test/kotlin/misk/cloud/fake/security/keys/FakeKeyServiceTest.kt
@@ -1,32 +1,32 @@
 package misk.cloud.fake.security.keys
 
-import org.assertj.core.api.Assertions.assertThat
 import okio.ByteString
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
 class FakeKeyServiceTest {
-    @Test
-    fun encryptDecryptSmallKeys() {
-        val keyManager = FakeKeyService()
-        val keyAlias = "my-small-key"
-        val plainText = ByteString.encodeUtf8("encrypt me!")
-        val cipherText = keyManager.encrypt(keyAlias, plainText)
-        assertThat(cipherText).isNotEqualTo(plainText)
+  @Test
+  fun encryptDecryptSmallKeys() {
+    val keyManager = FakeKeyService()
+    val keyAlias = "my-small-key"
+    val plainText = ByteString.encodeUtf8("encrypt me!")
+    val cipherText = keyManager.encrypt(keyAlias, plainText)
+    assertThat(cipherText).isNotEqualTo(plainText)
 
-        val recoveredPlainText = keyManager.decrypt(keyAlias, cipherText)
-        assertThat(recoveredPlainText).isEqualTo(plainText)
-    }
+    val recoveredPlainText = keyManager.decrypt(keyAlias, cipherText)
+    assertThat(recoveredPlainText).isEqualTo(plainText)
+  }
 
-    @Test
-    fun encryptDecyptLargeKeys() {
-        val keyManager = FakeKeyService()
-        val keyAlias = "my-very-long-key-which-exceeds-256-bytes-and-therefore-is-truncated"
-        val plainText = ByteString.encodeUtf8("encrypt me!")
-        val cipherText = keyManager.encrypt(keyAlias, plainText)
-        assertThat(cipherText).isNotEqualTo(plainText)
+  @Test
+  fun encryptDecyptLargeKeys() {
+    val keyManager = FakeKeyService()
+    val keyAlias = "my-very-long-key-which-exceeds-256-bytes-and-therefore-is-truncated"
+    val plainText = ByteString.encodeUtf8("encrypt me!")
+    val cipherText = keyManager.encrypt(keyAlias, plainText)
+    assertThat(cipherText).isNotEqualTo(plainText)
 
-        val recoveredPlainText = keyManager.decrypt(keyAlias, cipherText)
-        assertThat(recoveredPlainText).isEqualTo(plainText)
+    val recoveredPlainText = keyManager.decrypt(keyAlias, cipherText)
+    assertThat(recoveredPlainText).isEqualTo(plainText)
 
-    }
+  }
 }

--- a/misk/src/test/kotlin/misk/cloud/gcp/environment/GcpInstanceMetadataProviderTest.kt
+++ b/misk/src/test/kotlin/misk/cloud/gcp/environment/GcpInstanceMetadataProviderTest.kt
@@ -1,69 +1,69 @@
 package misk.cloud.gcp.environment
 
-import org.assertj.core.api.Assertions.assertThat
 import misk.cloud.gcp.environment.GcpInstanceMetadataProvider.Companion.GCP_INSTANCE_METADATA_PATH
 import misk.testing.okhttp.RoutingDispatcher
 import misk.testing.okhttp.path
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
 internal class GcpInstanceMetadataProviderTest {
 
-    @Test
-    fun withInstanceName() {
-        val routes = RoutingDispatcher {
-            when (it.requestUrl.path) {
-                "$GCP_INSTANCE_METADATA_PATH/name" ->
-                    MockResponse().setBody("devshell-vm-117c5946-edc9-4b32-9618-b23894057d2a")
-                "$GCP_INSTANCE_METADATA_PATH/id" ->
-                    MockResponse().setBody("6123015407874752934")
-                "$GCP_INSTANCE_METADATA_PATH/zone" ->
-                    MockResponse().setBody("projects/751522334863/zones/us-east1-c")
-                else -> MockResponse().setResponseCode(404)
-            }
-        }
-
-        val server = MockWebServer()
-        server.setDispatcher(routes)
-        server.start()
-
-        val provider = GcpInstanceMetadataProvider("http://${server.hostName}:${server.port}")
-
-        try {
-            val instanceMetadata = provider.get()
-            assertThat(instanceMetadata.instanceName)
-                    .isEqualTo("devshell-vm-117c5946-edc9-4b32-9618-b23894057d2a")
-            assertThat(instanceMetadata.zone).isEqualTo("us-east1-c")
-        } finally {
-            server.shutdown()
-        }
+  @Test
+  fun withInstanceName() {
+    val routes = RoutingDispatcher {
+      when (it.requestUrl.path) {
+        "$GCP_INSTANCE_METADATA_PATH/name" ->
+          MockResponse().setBody("devshell-vm-117c5946-edc9-4b32-9618-b23894057d2a")
+        "$GCP_INSTANCE_METADATA_PATH/id" ->
+          MockResponse().setBody("6123015407874752934")
+        "$GCP_INSTANCE_METADATA_PATH/zone" ->
+          MockResponse().setBody("projects/751522334863/zones/us-east1-c")
+        else -> MockResponse().setResponseCode(404)
+      }
     }
 
-    @Test
-    fun withInstanceId() {
-        val routes = RoutingDispatcher {
-            when (it.requestUrl.path) {
-                "$GCP_INSTANCE_METADATA_PATH/id" ->
-                    MockResponse().setBody("6123015407874752934")
-                "$GCP_INSTANCE_METADATA_PATH/zone" ->
-                    MockResponse().setBody("projects/751522334863/zones/us-east1-c")
-                else -> MockResponse().setResponseCode(404)
-            }
-        }
+    val server = MockWebServer()
+    server.setDispatcher(routes)
+    server.start()
 
-        val server = MockWebServer()
-        server.setDispatcher(routes)
-        server.start()
+    val provider = GcpInstanceMetadataProvider("http://${server.hostName}:${server.port}")
 
-        val provider = GcpInstanceMetadataProvider("http://${server.hostName}:${server.port}")
-
-        try {
-            val instanceMetadata = provider.get()
-            assertThat(instanceMetadata.instanceName).isEqualTo("6123015407874752934")
-            assertThat(instanceMetadata.zone).isEqualTo("us-east1-c")
-        } finally {
-            server.shutdown()
-        }
+    try {
+      val instanceMetadata = provider.get()
+      assertThat(instanceMetadata.instanceName)
+          .isEqualTo("devshell-vm-117c5946-edc9-4b32-9618-b23894057d2a")
+      assertThat(instanceMetadata.zone).isEqualTo("us-east1-c")
+    } finally {
+      server.shutdown()
     }
+  }
+
+  @Test
+  fun withInstanceId() {
+    val routes = RoutingDispatcher {
+      when (it.requestUrl.path) {
+        "$GCP_INSTANCE_METADATA_PATH/id" ->
+          MockResponse().setBody("6123015407874752934")
+        "$GCP_INSTANCE_METADATA_PATH/zone" ->
+          MockResponse().setBody("projects/751522334863/zones/us-east1-c")
+        else -> MockResponse().setResponseCode(404)
+      }
+    }
+
+    val server = MockWebServer()
+    server.setDispatcher(routes)
+    server.start()
+
+    val provider = GcpInstanceMetadataProvider("http://${server.hostName}:${server.port}")
+
+    try {
+      val instanceMetadata = provider.get()
+      assertThat(instanceMetadata.instanceName).isEqualTo("6123015407874752934")
+      assertThat(instanceMetadata.zone).isEqualTo("us-east1-c")
+    } finally {
+      server.shutdown()
+    }
+  }
 }

--- a/misk/src/test/kotlin/misk/cloud/gcp/security/keys/GcpKeyServiceTest.kt
+++ b/misk/src/test/kotlin/misk/cloud/gcp/security/keys/GcpKeyServiceTest.kt
@@ -4,59 +4,68 @@ import com.google.api.client.json.jackson2.JacksonFactory
 import com.google.api.services.cloudkms.v1.CloudKMS
 import com.google.api.services.cloudkms.v1.model.DecryptResponse
 import com.google.api.services.cloudkms.v1.model.EncryptResponse
-import org.assertj.core.api.Assertions.assertThat
 import misk.cloud.gcp.testing.FakeHttpRouter
 import misk.cloud.gcp.testing.FakeHttpRouter.Companion.respondWithError
 import misk.cloud.gcp.testing.FakeHttpRouter.Companion.respondWithJson
 import okio.ByteString
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Test
 
 internal class GcpKeyServiceTest {
-    private val config = GcpKmsConfig(
-            "my_project",
-            mapOf("foo" to GcpKeyLocation("system", "main_ring", "key1"),
-                    "bar" to GcpKeyLocation("system", "other_ring", "key2"),
-                    "zed" to GcpKeyLocation("system", "main_ring", "key5")))
+  private val config = GcpKmsConfig(
+      "my_project",
+      mapOf(
+          "foo" to GcpKeyLocation("system", "main_ring", "key1"),
+          "bar" to GcpKeyLocation("system", "other_ring", "key2"),
+          "zed" to GcpKeyLocation("system", "main_ring", "key5")
+      )
+  )
 
-    private val TARGET_RESOURCE_URL = "https://cloudkms.googleapis.com/v1/projects/my_project/locations/system/keyRings/main_ring/cryptoKeys/key1"
+  private val TARGET_RESOURCE_URL =
+      "https://cloudkms.googleapis.com/v1/projects/my_project/locations/system/keyRings/main_ring/cryptoKeys/key1"
 
-    private val transport = FakeHttpRouter {
-        when (it.url) {
-            "$TARGET_RESOURCE_URL:encrypt" -> respondWithJson(EncryptResponse()
-                    .encodeCiphertext("encrypted".toByteArray(Charsets.UTF_8)))
-            "$TARGET_RESOURCE_URL:decrypt" -> respondWithJson(DecryptResponse()
-                    .encodePlaintext("decrypted".toByteArray(Charsets.UTF_8)))
-            else -> respondWithError(404)
+  private val transport = FakeHttpRouter {
+    when (it.url) {
+      "$TARGET_RESOURCE_URL:encrypt" -> respondWithJson(
+          EncryptResponse()
+              .encodeCiphertext("encrypted".toByteArray(Charsets.UTF_8))
+      )
+      "$TARGET_RESOURCE_URL:decrypt" -> respondWithJson(
+          DecryptResponse()
+              .encodePlaintext("decrypted".toByteArray(Charsets.UTF_8))
+      )
+      else -> respondWithError(404)
 
-        }
     }
-    val kms = CloudKMS.Builder(transport, JacksonFactory(), null).build()
-    val keyManager = GcpKeyService(kms, config)
+  }
+  val kms = CloudKMS.Builder(transport, JacksonFactory(), null)
+      .build()
+  val keyManager = GcpKeyService(kms, config)
 
-    @Test
-    fun encrypt() {
-        val cipherText = keyManager.encrypt("foo", ByteString.encodeUtf8("encrypt me!"))
-        assertThat(cipherText.utf8()).isEqualTo("encrypted")
-    }
+  @Test
+  fun encrypt() {
+    val cipherText = keyManager.encrypt("foo", ByteString.encodeUtf8("encrypt me!"))
+    assertThat(cipherText.utf8()).isEqualTo("encrypted")
+  }
 
-    @Test
-    fun decrypt() {
-        val plainText = keyManager.decrypt("foo", ByteString.encodeUtf8("decrypt me!"))
-        assertThat(plainText.utf8()).isEqualTo("decrypted")
-    }
+  @Test
+  fun decrypt() {
+    val plainText = keyManager.decrypt("foo", ByteString.encodeUtf8("decrypt me!"))
+    assertThat(plainText.utf8()).isEqualTo("decrypted")
+  }
 
-    @Test
-    fun invalidEncryptKey() {
-        assertThrows(IllegalArgumentException::class.java) {
-            keyManager.encrypt("unknown_key", ByteString.encodeUtf8("should fail"))
-        }
+  @Test
+  fun invalidEncryptKey() {
+    assertThrows(IllegalArgumentException::class.java) {
+      keyManager.encrypt("unknown_key", ByteString.encodeUtf8("should fail"))
     }
+  }
 
-    @Test
-    fun invalidDecryptKey() {
-        assertThrows(IllegalArgumentException::class.java) {
-            keyManager.decrypt("unknown_key", ByteString.encodeUtf8("should fail"))
-        }
+  @Test
+  fun invalidDecryptKey() {
+    assertThrows(IllegalArgumentException::class.java) {
+      keyManager.decrypt("unknown_key", ByteString.encodeUtf8("should fail"))
     }
+  }
 }

--- a/misk/src/test/kotlin/misk/cloud/gcp/testing/FakeHttpRequest.kt
+++ b/misk/src/test/kotlin/misk/cloud/gcp/testing/FakeHttpRequest.kt
@@ -6,39 +6,42 @@ import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
 
 class FakeHttpRequest constructor(
-        val method: String,
-        val url: String,
-        private val router: (FakeHttpRequest) -> FakeHttpResponse
+    val method: String,
+    val url: String,
+    private val router: (FakeHttpRequest) -> FakeHttpResponse
 ) : LowLevelHttpRequest() {
-    private val headers = LinkedHashMap<String, String>()
-    private var contentBytes: ByteArray? = null
+  private val headers = LinkedHashMap<String, String>()
+  private var contentBytes: ByteArray? = null
 
-    override fun execute() = router.invoke(this)
+  override fun execute() = router.invoke(this)
 
-    override fun addHeader(name: String, value: String) {
-        headers.put(name, value)
+  override fun addHeader(
+      name: String,
+      value: String
+  ) {
+    headers.put(name, value)
+  }
+
+  fun header(name: String): String? = headers[name]
+
+  val content: ByteArray?
+    get() {
+      if (streamingContent == null) {
+        return null
+      }
+
+      if (contentBytes == null) {
+        val os = ByteArrayOutputStream()
+        streamingContent.writeTo(os)
+        contentBytes = os.toByteArray()
+      }
+
+      return contentBytes
     }
 
-    fun header(name: String): String? = headers[name]
+  val stringContent: String? get() = content?.toString(Charsets.UTF_8)
 
-    val content: ByteArray?
-        get() {
-            if (streamingContent == null) {
-                return null
-            }
-
-            if (contentBytes == null) {
-                val os = ByteArrayOutputStream()
-                streamingContent.writeTo(os)
-                contentBytes = os.toByteArray()
-            }
-
-            return contentBytes
-        }
-
-    val stringContent: String? get() = content?.toString(Charsets.UTF_8)
-
-    inline fun <reified T : Any> jsonContent(): T? = content.let {
-        JacksonFactory().fromInputStream(ByteArrayInputStream(it), T::class.java)
-    }
+  inline fun <reified T : Any> jsonContent(): T? = content.let {
+    JacksonFactory().fromInputStream(ByteArrayInputStream(it), T::class.java)
+  }
 }

--- a/misk/src/test/kotlin/misk/cloud/gcp/testing/FakeHttpResponse.kt
+++ b/misk/src/test/kotlin/misk/cloud/gcp/testing/FakeHttpResponse.kt
@@ -5,6 +5,6 @@ import com.google.api.client.testing.http.MockLowLevelHttpResponse
 
 typealias FakeHttpResponse = MockLowLevelHttpResponse
 
-fun FakeHttpResponse.setJsonContent(item: Any) : FakeHttpResponse =
+fun FakeHttpResponse.setJsonContent(item: Any): FakeHttpResponse =
     setContent(JacksonFactory.getDefaultInstance().toByteArray(item))
 

--- a/misk/src/test/kotlin/misk/cloud/gcp/testing/FakeHttpRouter.kt
+++ b/misk/src/test/kotlin/misk/cloud/gcp/testing/FakeHttpRouter.kt
@@ -3,19 +3,25 @@ package misk.cloud.gcp.testing
 import com.google.api.client.http.HttpTransport
 
 class FakeHttpRouter(val router: (FakeHttpRequest) -> FakeHttpResponse) : HttpTransport() {
-    companion object {
-        fun respondWithJson(item: Any) = FakeHttpResponse()
-                .setStatusCode(200)
-                .setJsonContent(item)
+  companion object {
+    fun respondWithJson(item: Any) = FakeHttpResponse()
+        .setStatusCode(200)
+        .setJsonContent(item)
 
-        fun respondWithError(statusCode: Int) = FakeHttpResponse().setStatusCode(statusCode)
+    fun respondWithError(statusCode: Int) = FakeHttpResponse().setStatusCode(statusCode)
 
-        fun respondWithText(text: String) = respondWithText(200, text)
+    fun respondWithText(text: String) = respondWithText(200, text)
 
-        fun respondWithText(statusCode: Int, text: String) =
-                FakeHttpResponse().setStatusCode(statusCode).setContent(text)
-    }
+    fun respondWithText(
+        statusCode: Int,
+        text: String
+    ) =
+        FakeHttpResponse().setStatusCode(statusCode).setContent(text)
+  }
 
-    override fun buildRequest(method: String, url: String) = FakeHttpRequest(method, url, router)
+  override fun buildRequest(
+      method: String,
+      url: String
+  ) = FakeHttpRequest(method, url, router)
 }
 

--- a/misk/src/test/kotlin/misk/cloud/gcp/testing/FakeHttpRouterTest.kt
+++ b/misk/src/test/kotlin/misk/cloud/gcp/testing/FakeHttpRouterTest.kt
@@ -4,93 +4,97 @@ import com.google.api.client.http.GenericUrl
 import com.google.api.client.http.HttpResponseException
 import com.google.api.client.json.jackson2.JacksonFactory
 import com.google.api.client.testing.http.MockHttpContent
-import org.assertj.core.api.Assertions.assertThat
 import misk.cloud.gcp.testing.FakeHttpRouter.Companion.respondWithError
 import misk.cloud.gcp.testing.FakeHttpRouter.Companion.respondWithText
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.fail
 import org.junit.jupiter.api.Test
 import java.io.ByteArrayInputStream
 
 internal class FakeHttpRouterTest {
-    private val transport = FakeHttpRouter {
-        when (it.url) {
-            "https://something.com/first" -> respondWithText("first!")
+  private val transport = FakeHttpRouter {
+    when (it.url) {
+      "https://something.com/first" -> respondWithText("first!")
 
-            "https://something.com/second" ->
-                when (it.jsonContent<Body>()?.message) {
-                    "HELLO", "BYE" -> respondWithText("${it.jsonContent<Body>()?.message} second!")
-                    else -> respondWithError(401)
-                }
-
-            else -> respondWithError(404)
+      "https://something.com/second" ->
+        when (it.jsonContent<Body>()?.message) {
+          "HELLO", "BYE" -> respondWithText("${it.jsonContent<Body>()?.message} second!")
+          else -> respondWithError(401)
         }
+
+      else -> respondWithError(404)
+    }
+  }
+
+  @Test
+  fun matchOnUrlAndBody() {
+    val response = transport.createRequestFactory()
+        .buildGetRequest(GenericUrl("https://something.com/second"))
+        .setContent(
+            MockHttpContent().setContent(JacksonFactory().toByteArray(Body("BYE")))
+        )
+        .execute()
+    assertThat(response.parseAsString()).isEqualTo("BYE second!")
+  }
+
+  @Test
+  fun matchOnUrl() {
+    try {
+      transport.createRequestFactory()
+          .buildGetRequest(GenericUrl("https://something.com/second"))
+          .setContent(
+              MockHttpContent().setContent(
+                  JacksonFactory().toByteArray(Body("UNKNOWN"))
+              )
+          )
+          .execute()
+      fail<Any>("allowed failing request")
+    } catch (e: HttpResponseException) {
+      assertThat(e.statusCode).isEqualTo(401)
+    }
+  }
+
+  @Test
+  fun noMatch() {
+    try {
+      transport.createRequestFactory()
+          .buildGetRequest(GenericUrl("https://something.com/unknown"))
+          .execute()
+    } catch (e: HttpResponseException) {
+      assertThat(e.statusCode).isEqualTo(404)
+    }
+  }
+
+  @Test
+  fun jsonContent() {
+    val request = FakeHttpRequest("GET", "https://something.com") {
+      throw IllegalArgumentException("should not execute")
+    }
+    request.setStreamingContent {
+      it.write(JacksonFactory().toByteArray(Body("BYE")))
     }
 
-    @Test
-    fun matchOnUrlAndBody() {
-        val response = transport.createRequestFactory()
-                .buildGetRequest(GenericUrl("https://something.com/second"))
-                .setContent(
-                        MockHttpContent().setContent(JacksonFactory().toByteArray(Body("BYE"))))
-                .execute()
-        assertThat(response.parseAsString()).isEqualTo("BYE second!")
+    assertThat(request.jsonContent<Body>()?.message).isEqualTo("BYE")
+    assertThat(request.jsonContent<Body>()?.message).isEqualTo("BYE")
+  }
+
+  @Test
+  fun returnsContentRepeatedly() {
+    val contents = "hello!".toByteArray(Charsets.UTF_8)
+    val stream = ByteArrayInputStream(contents)
+    val request = FakeHttpRequest("GET", "https://something.com") {
+      throw IllegalArgumentException("should not execute")
+    }
+    request.setStreamingContent {
+      // This drains the stream, thus making it unusable after a single call
+      var b = stream.read()
+      while (b != -1) {
+        it.write(b)
+        b = stream.read()
+      }
     }
 
-    @Test
-    fun matchOnUrl() {
-        try {
-            transport.createRequestFactory()
-                    .buildGetRequest(GenericUrl("https://something.com/second"))
-                    .setContent(MockHttpContent().setContent(
-                            JacksonFactory().toByteArray(Body("UNKNOWN"))))
-                    .execute()
-            fail<Any>("allowed failing request")
-        } catch (e: HttpResponseException) {
-            assertThat(e.statusCode).isEqualTo(401)
-        }
-    }
-
-    @Test
-    fun noMatch() {
-        try {
-            transport.createRequestFactory()
-                    .buildGetRequest(GenericUrl("https://something.com/unknown"))
-                    .execute()
-        } catch (e: HttpResponseException) {
-            assertThat(e.statusCode).isEqualTo(404)
-        }
-    }
-
-    @Test
-    fun jsonContent() {
-        val request = FakeHttpRequest("GET", "https://something.com") {
-            throw IllegalArgumentException("should not execute")
-        }
-        request.setStreamingContent {
-            it.write(JacksonFactory().toByteArray(Body("BYE")))
-        }
-
-        assertThat(request.jsonContent<Body>()?.message).isEqualTo("BYE")
-        assertThat(request.jsonContent<Body>()?.message).isEqualTo("BYE")
-    }
-
-    @Test
-    fun returnsContentRepeatedly() {
-        val contents = "hello!".toByteArray(Charsets.UTF_8)
-        val stream = ByteArrayInputStream(contents)
-        val request = FakeHttpRequest("GET", "https://something.com") {
-            throw IllegalArgumentException("should not execute")
-        }
-        request.setStreamingContent {
-            // This drains the stream, thus making it unusable after a single call
-            var b = stream.read()
-            while (b != -1) {
-                it.write(b)
-                b = stream.read()
-            }
-        }
-
-        assertThat(request.content).isEqualTo(contents)
-        assertThat(request.content).isEqualTo(contents)
-    }
+    assertThat(request.content).isEqualTo(contents)
+    assertThat(request.content).isEqualTo(contents)
+  }
 }

--- a/misk/src/test/kotlin/misk/concurrent/WrappingListeningExecutorServiceTest.kt
+++ b/misk/src/test/kotlin/misk/concurrent/WrappingListeningExecutorServiceTest.kt
@@ -1,8 +1,8 @@
 package misk.concurrent
 
-import org.assertj.core.api.Assertions.assertThat
 import com.google.common.util.concurrent.ListeningExecutorService
 import com.google.common.util.concurrent.MoreExecutors
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import java.util.concurrent.Callable
@@ -13,66 +13,70 @@ import java.util.concurrent.atomic.AtomicInteger
 
 internal class WrappingListeningExecutorServiceTest {
 
-    private val wrapCounter = AtomicInteger()
-    private val executor = object : WrappingListeningExecutorService() {
-        val wrapped = MoreExecutors.listeningDecorator(Executors.newSingleThreadExecutor())
+  private val wrapCounter = AtomicInteger()
+  private val executor = object : WrappingListeningExecutorService() {
+    val wrapped = MoreExecutors.listeningDecorator(Executors.newSingleThreadExecutor())
 
-        override fun <T> wrap(callable: Callable<T>): Callable<T> {
-            return Callable {
-                wrapCounter.incrementAndGet()
-                callable.call()
-            }
-        }
-
-        override fun delegate(): ListeningExecutorService = wrapped
+    override fun <T> wrap(callable: Callable<T>): Callable<T> {
+      return Callable {
+        wrapCounter.incrementAndGet()
+        callable.call()
+      }
     }
 
-    @BeforeEach
-    fun clearWrapped() {
-        wrapCounter.set(0)
-    }
+    override fun delegate(): ListeningExecutorService = wrapped
+  }
 
-    @Test
-    fun submit() {
-        val result = executor.submit(Callable { "foo" }).get()
-        assertThat(result).isEqualTo("foo")
-        assertThat(wrapCounter.get()).isEqualTo(1)
-    }
+  @BeforeEach
+  fun clearWrapped() {
+    wrapCounter.set(0)
+  }
 
-    @Test
-    fun submitRunnable() {
-        val executed = AtomicBoolean()
-        executor.submit({ executed.set(true)}).get()
-        assertThat(executed.get()).isTrue()
-        assertThat(wrapCounter.get()).isEqualTo(1)
-    }
+  @Test
+  fun submit() {
+    val result = executor.submit(Callable { "foo" })
+        .get()
+    assertThat(result).isEqualTo("foo")
+    assertThat(wrapCounter.get()).isEqualTo(1)
+  }
 
-    @Test
-    fun submitWithResult() {
-        val executed = AtomicBoolean()
-        val result = executor.submit({ executed.set(true) }, "foo").get()
-        assertThat(result).isEqualTo("foo")
-        assertThat(executed.get()).isTrue()
-        assertThat(wrapCounter.get()).isEqualTo(1)
-    }
+  @Test
+  fun submitRunnable() {
+    val executed = AtomicBoolean()
+    executor.submit({ executed.set(true) })
+        .get()
+    assertThat(executed.get()).isTrue()
+    assertThat(wrapCounter.get()).isEqualTo(1)
+  }
 
-    @Test
-    fun invokeAll() {
-        val results = executor.invokeAll(listOf(
-                Callable { "foo" },
-                Callable { "bar" },
-                Callable { "zed" }
-        )).map { it.get() }
+  @Test
+  fun submitWithResult() {
+    val executed = AtomicBoolean()
+    val result = executor.submit({ executed.set(true) }, "foo")
+        .get()
+    assertThat(result).isEqualTo("foo")
+    assertThat(executed.get()).isTrue()
+    assertThat(wrapCounter.get()).isEqualTo(1)
+  }
 
-        assertThat(results).containsExactly("foo", "bar", "zed")
-        assertThat(wrapCounter.get()).isEqualTo(3)
-    }
+  @Test
+  fun invokeAll() {
+    val results = executor.invokeAll(listOf(
+        Callable { "foo" },
+        Callable { "bar" },
+        Callable { "zed" }
+    ))
+        .map { it.get() }
 
-    @Test
-    fun execute() {
-        val latch = CountDownLatch(1)
-        executor.execute( { latch.countDown() })
-        latch.await()
-        assertThat(wrapCounter.get()).isEqualTo(1)
-    }
+    assertThat(results).containsExactly("foo", "bar", "zed")
+    assertThat(wrapCounter.get()).isEqualTo(3)
+  }
+
+  @Test
+  fun execute() {
+    val latch = CountDownLatch(1)
+    executor.execute({ latch.countDown() })
+    latch.await()
+    assertThat(wrapCounter.get()).isEqualTo(1)
+  }
 }

--- a/misk/src/test/kotlin/misk/config/ConfigTest.kt
+++ b/misk/src/test/kotlin/misk/config/ConfigTest.kt
@@ -18,102 +18,104 @@ import javax.inject.Named
 
 @MiskTest
 class ConfigTest {
-    @MiskTestModule
+  @MiskTestModule
+  val module = Modules.combine(
+      ConfigModule.create<TestConfig>("test_app"),
+      EnvironmentModule(TESTING)
+  )
+
+  @Inject
+  private lateinit var testConfig: TestConfig
+
+  @field:[Inject Named("consumer_a")]
+  lateinit var consumerA: ConsumerConfig
+
+  @field:[Inject Named("consumer_b")]
+  lateinit var consumerB: ConsumerConfig
+
+  @field:[Inject]
+  lateinit var webConfig: WebConfig
+
+  @Test
+  fun configIsProperlyParsed() {
+    assertThat(testConfig.web).isEqualTo(WebConfig(5678, 30_000))
+    assertThat(testConfig.consumer_a).isEqualTo(ConsumerConfig(0, 1))
+    assertThat(testConfig.consumer_b).isEqualTo(ConsumerConfig(1, 2))
+    assertThat(testConfig.duration).isEqualTo(DurationConfig(Duration.parse("PT1S")))
+  }
+
+  @Test
+  fun subConfigsWithDefaultNamesAreBoundUnqualified() {
+    assertThat(webConfig).isEqualTo(WebConfig(5678, 30_000))
+  }
+
+  @Test
+  fun subConfigsWithCustomNamesAreBoundWithNamedQualifiers() {
+    assertThat(consumerA).isEqualTo(ConsumerConfig(0, 1))
+    assertThat(consumerB).isEqualTo(ConsumerConfig(1, 2))
+  }
+
+  @Test
+  fun environmentConfigOverridesCommon() {
+    assertThat(testConfig.web.port).isEqualTo(5678)
+  }
+
+  @Test
+  fun defaultValuesAreUsed() {
+    assertThat(testConfig.consumer_a.min_items).isEqualTo(0)
+  }
+
+  @Test
+  fun friendlyErrorMessagesWhenFilesNotFound() {
     val module = Modules.combine(
-            ConfigModule.create<TestConfig>("test_app"),
-            EnvironmentModule(TESTING)
+        ConfigModule.create<TestConfig>("missing"),
+        EnvironmentModule(TESTING)
     )
 
-    @Inject
-    private lateinit var testConfig: TestConfig
-
-
-    @field:[Inject Named("consumer_a")]
-    lateinit var consumerA: ConsumerConfig
-
-    @field:[Inject Named("consumer_b")]
-    lateinit var consumerB: ConsumerConfig
-
-    @field:[Inject]
-    lateinit var webConfig: WebConfig
-
-    @Test
-    fun configIsProperlyParsed() {
-        assertThat(testConfig.web).isEqualTo(WebConfig(5678, 30_000))
-        assertThat(testConfig.consumer_a).isEqualTo(ConsumerConfig(0, 1))
-        assertThat(testConfig.consumer_b).isEqualTo(ConsumerConfig(1, 2))
-        assertThat(testConfig.duration).isEqualTo(DurationConfig(Duration.parse("PT1S")))
+    val exception = assertThrows(ProvisionException::class.java) {
+      Guice.createInjector(module)
+          .getInstance<TestConfig>()
     }
 
-    @Test
-    fun subConfigsWithDefaultNamesAreBoundUnqualified() {
-        assertThat(webConfig).isEqualTo(WebConfig(5678, 30_000))
+    assertThat(exception.errorMessages.map { it.message }).anySatisfy {
+      assertThat(it).contains(
+          "could not find configuration files - checked [missing-common.yaml, missing-testing.yaml]"
+      )
+    }
+  }
+
+  @Test
+  fun friendlyErrorMessageWhenConfigPropertyMissing() {
+    val module = Modules.combine(
+        ConfigModule.create<TestConfig>("partial_test_app"),
+        EnvironmentModule(TESTING)
+    )
+
+    val exception = assertThrows(ProvisionException::class.java) {
+      Guice.createInjector(module)
+          .getInstance<TestConfig>()
     }
 
-    @Test
-    fun subConfigsWithCustomNamesAreBoundWithNamedQualifiers() {
-        assertThat(consumerA).isEqualTo(ConsumerConfig(0, 1))
-        assertThat(consumerB).isEqualTo(ConsumerConfig(1, 2))
+    assertThat(exception.errorMessages.map { it.message }).anySatisfy {
+      assertThat(it).contains("could not find configuration for consumer_a")
+    }
+  }
+
+  @Test
+  fun friendlyErrorMessagesWhenFileUnparseable() {
+    val module = Modules.combine(
+        ConfigModule.create<TestConfig>("unparsable"),
+        EnvironmentModule(TESTING)
+    )
+
+    val exception = assertThrows(ProvisionException::class.java) {
+      Guice.createInjector(module)
+          .getInstance<TestConfig>()
     }
 
-    @Test
-    fun environmentConfigOverridesCommon() {
-        assertThat(testConfig.web.port).isEqualTo(5678)
+    assertThat(exception.errorMessages.map { it.message }).anySatisfy {
+      assertThat(it).contains("could not parse unparsable-common.yaml")
     }
-
-    @Test
-    fun defaultValuesAreUsed() {
-        assertThat(testConfig.consumer_a.min_items).isEqualTo(0)
-    }
-
-    @Test
-    fun friendlyErrorMessagesWhenFilesNotFound() {
-        val module = Modules.combine(
-                ConfigModule.create<TestConfig>("missing"),
-                EnvironmentModule(TESTING)
-        )
-
-        val exception = assertThrows(ProvisionException::class.java) {
-            Guice.createInjector(module).getInstance<TestConfig>()
-        }
-
-        assertThat(exception.errorMessages.map { it.message }).anySatisfy {
-            assertThat(it).contains(
-                    "could not find configuration files - checked [missing-common.yaml, missing-testing.yaml]"
-            )
-        }
-    }
-
-    @Test
-    fun friendlyErrorMessageWhenConfigPropertyMissing() {
-        val module = Modules.combine(
-                ConfigModule.create<TestConfig>("partial_test_app"),
-                EnvironmentModule(TESTING)
-        )
-
-        val exception  = assertThrows(ProvisionException::class.java) {
-            Guice.createInjector(module).getInstance<TestConfig>()
-        }
-
-        assertThat(exception.errorMessages.map { it.message }).anySatisfy {
-            assertThat(it).contains("could not find configuration for consumer_a")
-        }
-    }
-
-    @Test
-    fun friendlyErrorMessagesWhenFileUnparseable() {
-        val module = Modules.combine(
-                ConfigModule.create<TestConfig>("unparsable"),
-                EnvironmentModule(TESTING)
-        )
-
-        val exception = assertThrows(ProvisionException::class.java) {
-            Guice.createInjector(module).getInstance<TestConfig>()
-        }
-
-        assertThat(exception.errorMessages.map { it.message }).anySatisfy {
-            assertThat(it).contains("could not parse unparsable-common.yaml")
-        }
-    }
+  }
 
 }

--- a/misk/src/test/kotlin/misk/config/TestConfig.kt
+++ b/misk/src/test/kotlin/misk/config/TestConfig.kt
@@ -10,5 +10,9 @@ data class TestConfig(
     val duration: DurationConfig
 ) : Config
 
-data class ConsumerConfig(val min_items: Int = 0, val max_items: Int) : Config
+data class ConsumerConfig(
+    val min_items: Int = 0,
+    val max_items: Int
+) : Config
+
 data class DurationConfig(val interval: Duration) : Config

--- a/misk/src/test/kotlin/misk/healthchecks/FakeHealthCheck.kt
+++ b/misk/src/test/kotlin/misk/healthchecks/FakeHealthCheck.kt
@@ -4,15 +4,15 @@ import javax.inject.Singleton
 
 @Singleton
 class FakeHealthCheck : HealthCheck {
-    var status = HealthStatus.healthy()
+  var status = HealthStatus.healthy()
 
-    fun setHealthy() {
-        status = HealthStatus.healthy()
-    }
+  fun setHealthy() {
+    status = HealthStatus.healthy()
+  }
 
-    fun setUnhealthy(vararg messages: String) {
-        status = HealthStatus.unhealthy(*messages)
-    }
+  fun setUnhealthy(vararg messages: String) {
+    status = HealthStatus.unhealthy(*messages)
+  }
 
-    override fun status(): HealthStatus = status
+  override fun status(): HealthStatus = status
 }

--- a/misk/src/test/kotlin/misk/healthchecks/FakeHealthCheckModule.kt
+++ b/misk/src/test/kotlin/misk/healthchecks/FakeHealthCheckModule.kt
@@ -5,7 +5,8 @@ import misk.inject.addMultibinderBinding
 import misk.inject.to
 
 class FakeHealthCheckModule : AbstractModule() {
-    override fun configure() {
-        binder().addMultibinderBinding<HealthCheck>().to<FakeHealthCheck>()
-    }
+  override fun configure() {
+    binder().addMultibinderBinding<HealthCheck>()
+        .to<FakeHealthCheck>()
+  }
 }

--- a/misk/src/test/kotlin/misk/logging/LoggingTest.kt
+++ b/misk/src/test/kotlin/misk/logging/LoggingTest.kt
@@ -4,10 +4,10 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
 class LoggingTest {
-    private val logger = getLogger<LoggingTest>()
+  private val logger = getLogger<LoggingTest>()
 
-    @Test
-    fun loggerNameIsBasedOnTheOuterClass() {
-        assertThat(logger.name).isEqualTo("misk.logging.LoggingTest")
-    }
+  @Test
+  fun loggerNameIsBasedOnTheOuterClass() {
+    assertThat(logger.name).isEqualTo("misk.logging.LoggingTest")
+  }
 }

--- a/misk/src/test/kotlin/misk/metrics/MetricsTest.kt
+++ b/misk/src/test/kotlin/misk/metrics/MetricsTest.kt
@@ -9,71 +9,78 @@ import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicLong
 
 class MetricsTest {
-    @Test
-    fun counters() {
-        val metrics = buildMetrics()
-        metrics.counter("my_counter").inc(100)
-        assertThat(metrics.counters).containsKey("my_counter")
-        assertThat(metrics.counters["my_counter"]!!.count).isEqualTo(100)
-        metrics.counter("my_counter").inc(24)
-        assertThat(metrics.counters["my_counter"]!!.count).isEqualTo(124)
-    }
+  @Test
+  fun counters() {
+    val metrics = buildMetrics()
+    metrics.counter("my_counter")
+        .inc(100)
+    assertThat(metrics.counters).containsKey("my_counter")
+    assertThat(metrics.counters["my_counter"]!!.count).isEqualTo(100)
+    metrics.counter("my_counter")
+        .inc(24)
+    assertThat(metrics.counters["my_counter"]!!.count).isEqualTo(124)
+  }
 
-    @Test
-    fun timers() {
-        val metrics = buildMetrics()
-        metrics.timer("my_timer").update(10, TimeUnit.SECONDS)
-        assertThat(metrics.timers).containsKey("my_timer")
-        assertThat(metrics.timers["my_timer"]!!.count).isEqualTo(1)
-        metrics.timer("my_timer").update(23, TimeUnit.SECONDS)
-        assertThat(metrics.timers["my_timer"]!!.count).isEqualTo(2)
-    }
+  @Test
+  fun timers() {
+    val metrics = buildMetrics()
+    metrics.timer("my_timer")
+        .update(10, TimeUnit.SECONDS)
+    assertThat(metrics.timers).containsKey("my_timer")
+    assertThat(metrics.timers["my_timer"]!!.count).isEqualTo(1)
+    metrics.timer("my_timer")
+        .update(23, TimeUnit.SECONDS)
+    assertThat(metrics.timers["my_timer"]!!.count).isEqualTo(2)
+  }
 
-    @Test
-    fun gauges() {
-        val metrics = buildMetrics()
-        val n = AtomicLong()
+  @Test
+  fun gauges() {
+    val metrics = buildMetrics()
+    val n = AtomicLong()
 
-        metrics.gauge("my_gauge", { n.get() })
-        assertThat(metrics.gauges).containsKey("my_gauge")
-        assertThat(metrics.gauges["my_gauge"]!!.value).isEqualTo(0L)
-        n.set(254)
-        assertThat(metrics.gauges["my_gauge"]!!.value).isEqualTo(254L)
-    }
+    metrics.gauge("my_gauge", { n.get() })
+    assertThat(metrics.gauges).containsKey("my_gauge")
+    assertThat(metrics.gauges["my_gauge"]!!.value).isEqualTo(0L)
+    n.set(254)
+    assertThat(metrics.gauges["my_gauge"]!!.value).isEqualTo(254L)
+  }
 
-    @Test
-    fun settableGauges() {
-        val metrics = buildMetrics()
-        val gauge = metrics.settableGauge("my_gauge")
+  @Test
+  fun settableGauges() {
+    val metrics = buildMetrics()
+    val gauge = metrics.settableGauge("my_gauge")
 
-        assertThat(metrics.gauges).containsKey("my_gauge")
-        assertThat(metrics.gauges["my_gauge"]!!.value).isEqualTo(0L)
-        gauge.value.set(254)
-        assertThat(metrics.gauges["my_gauge"]!!.value).isEqualTo(254L)
-    }
+    assertThat(metrics.gauges).containsKey("my_gauge")
+    assertThat(metrics.gauges["my_gauge"]!!.value).isEqualTo(0L)
+    gauge.value.set(254)
+    assertThat(metrics.gauges["my_gauge"]!!.value).isEqualTo(254L)
+  }
 
-    @Test
-    fun cacheableGauges() {
-        val metrics = buildMetrics()
-        val n = AtomicLong()
+  @Test
+  fun cacheableGauges() {
+    val metrics = buildMetrics()
+    val n = AtomicLong()
 
-        metrics.cachedGauge("my_gauge", Duration.ofMillis(100), n::get)
-        assertThat(metrics.gauges).containsKey("my_gauge")
-        assertThat(metrics.gauges["my_gauge"]!!.value).isEqualTo(0L)
-        n.set(254)
-        assertThat(metrics.gauges["my_gauge"]!!.value).isEqualTo(0L)
-        Thread.sleep(120)
-        assertThat(metrics.gauges["my_gauge"]!!.value).isEqualTo(254L)
-    }
+    metrics.cachedGauge("my_gauge", Duration.ofMillis(100), n::get)
+    assertThat(metrics.gauges).containsKey("my_gauge")
+    assertThat(metrics.gauges["my_gauge"]!!.value).isEqualTo(0L)
+    n.set(254)
+    assertThat(metrics.gauges["my_gauge"]!!.value).isEqualTo(0L)
+    Thread.sleep(120)
+    assertThat(metrics.gauges["my_gauge"]!!.value).isEqualTo(254L)
+  }
 
-    @Test
-    fun scoping() {
-        val metrics = buildMetrics()
-        metrics.scope("   \t", "foo_zed", "", "bar_zed").counter("my_counter").inc(100)
-        assertThat(metrics.counters).containsKey("foo_zed.bar_zed.my_counter")
-    }
+  @Test
+  fun scoping() {
+    val metrics = buildMetrics()
+    metrics.scope("   \t", "foo_zed", "", "bar_zed")
+        .counter("my_counter")
+        .inc(100)
+    assertThat(metrics.counters).containsKey("foo_zed.bar_zed.my_counter")
+  }
 
-    fun buildMetrics(): Metrics {
-        return Guice.createInjector(MetricsModule()).getInstance()
-    }
+  fun buildMetrics(): Metrics {
+    return Guice.createInjector(MetricsModule())
+        .getInstance()
+  }
 }

--- a/misk/src/test/kotlin/misk/metrics/backends/stackdriver/StackDriverReporterTest.kt
+++ b/misk/src/test/kotlin/misk/metrics/backends/stackdriver/StackDriverReporterTest.kt
@@ -25,262 +25,297 @@ import javax.inject.Singleton
 
 @MiskTest
 internal class StackDriverReporterTest {
-    companion object {
-        val APP_NAME = "my_app"
-        val INSTANCE_METADATA = InstanceMetadata("165.33.45.25", "us-west2")
-        val METRIC_PREFIX = "custom.googleapis.com/dw/$APP_NAME/${INSTANCE_METADATA.zone}/${INSTANCE_METADATA.instanceName}"
-        val START_TIME = DateTime("2017-11-23T16:46:32Z")
-        val NOW = DateTime("2017-11-24T21:56:30Z")
+  companion object {
+    val APP_NAME = "my_app"
+    val INSTANCE_METADATA = InstanceMetadata("165.33.45.25", "us-west2")
+    val METRIC_PREFIX =
+        "custom.googleapis.com/dw/$APP_NAME/${INSTANCE_METADATA.zone}/${INSTANCE_METADATA.instanceName}"
+    val START_TIME = DateTime("2017-11-23T16:46:32Z")
+    val NOW = DateTime("2017-11-24T21:56:30Z")
 
-        fun assertGauge(timeSeries: TimeSeries, expected: Double) {
-            assertThat(timeSeries.metricKind).isEqualTo("GAUGE")
-            assertThat(timeSeries.points).hasSize(1)
-            assertThat(timeSeries.points[0].value.doubleValue).isCloseTo(expected, Percentage.withPercentage(0.1))
-            assertThat(timeSeries.points[0].interval.startTime).isNull()
-            assertThat(timeSeries.points[0].interval.endTime).isEqualTo(NOW.toStringRfc3339())
-        }
-
-        fun assertGauge(timeSeries: TimeSeries, expected: Long) {
-            assertThat(timeSeries.metricKind).isEqualTo("GAUGE")
-            assertThat(timeSeries.points).hasSize(1)
-            assertThat(timeSeries.points[0].value.int64Value).isEqualTo(expected)
-            assertThat(timeSeries.points[0].interval.startTime).isNull()
-            assertThat(timeSeries.points[0].interval.endTime).isEqualTo(NOW.toStringRfc3339())
-        }
-
-        fun assertCumulative(timeSeries: TimeSeries, expected: Long) {
-            assertThat(timeSeries.metricKind).isEqualTo("CUMULATIVE")
-            assertThat(timeSeries.points).hasSize(1)
-            assertThat(timeSeries.points[0].value.int64Value).isEqualTo(expected)
-            assertThat(timeSeries.points[0].interval.startTime)
-                    .isEqualTo(START_TIME.toStringRfc3339())
-            assertThat(timeSeries.points[0].interval.endTime).isEqualTo(NOW.toStringRfc3339())
-        }
+    fun assertGauge(
+        timeSeries: TimeSeries,
+        expected: Double
+    ) {
+      assertThat(timeSeries.metricKind).isEqualTo("GAUGE")
+      assertThat(timeSeries.points).hasSize(1)
+      assertThat(timeSeries.points[0].value.doubleValue).isCloseTo(
+          expected, Percentage.withPercentage(0.1)
+      )
+      assertThat(timeSeries.points[0].interval.startTime).isNull()
+      assertThat(timeSeries.points[0].interval.endTime).isEqualTo(NOW.toStringRfc3339())
     }
 
-    @MiskTestModule
-    val module = Modules.combine(
-            MetricsModule(),
-            FakeClockModule(),
-            TestModule()
+    fun assertGauge(
+        timeSeries: TimeSeries,
+        expected: Long
+    ) {
+      assertThat(timeSeries.metricKind).isEqualTo("GAUGE")
+      assertThat(timeSeries.points).hasSize(1)
+      assertThat(timeSeries.points[0].value.int64Value).isEqualTo(expected)
+      assertThat(timeSeries.points[0].interval.startTime).isNull()
+      assertThat(timeSeries.points[0].interval.endTime).isEqualTo(NOW.toStringRfc3339())
+    }
+
+    fun assertCumulative(
+        timeSeries: TimeSeries,
+        expected: Long
+    ) {
+      assertThat(timeSeries.metricKind).isEqualTo("CUMULATIVE")
+      assertThat(timeSeries.points).hasSize(1)
+      assertThat(timeSeries.points[0].value.int64Value).isEqualTo(expected)
+      assertThat(timeSeries.points[0].interval.startTime)
+          .isEqualTo(START_TIME.toStringRfc3339())
+      assertThat(timeSeries.points[0].interval.endTime).isEqualTo(NOW.toStringRfc3339())
+    }
+  }
+
+  @MiskTestModule
+  val module = Modules.combine(
+      MetricsModule(),
+      FakeClockModule(),
+      TestModule()
+  )
+
+  @Inject internal lateinit var metrics: Metrics
+  @Inject internal lateinit var clock: FakeClock
+  @Inject internal lateinit var reporter: StackDriverReporter
+
+  @Test
+  fun timer() {
+    val timer = metrics.timer("foo")
+    timer.update(10, TimeUnit.SECONDS)
+    timer.update(11, TimeUnit.SECONDS)
+    timer.update(9, TimeUnit.SECONDS)
+    timer.update(12, TimeUnit.SECONDS)
+
+    val timeSeries = reporter.toTimeSeries("foo", timer, START_TIME, NOW)
+    val byType = timeSeries.map { it.metric.type to it }
+        .toMap()
+
+    assertCumulative(byType["$METRIC_PREFIX/foo/count"]!!, 4)
+    assertGauge(byType["$METRIC_PREFIX/foo/max"]!!, 12000.0)
+    assertGauge(byType["$METRIC_PREFIX/foo/min"]!!, 9000.0)
+    assertGauge(byType["$METRIC_PREFIX/foo/mean"]!!, 10500.0)
+    assertGauge(byType["$METRIC_PREFIX/foo/stdDev"]!!, 1118.0339)
+    assertGauge(byType["$METRIC_PREFIX/foo/p50"]!!, 11000.0)
+    assertGauge(byType["$METRIC_PREFIX/foo/p75"]!!, 12000.0)
+    assertGauge(byType["$METRIC_PREFIX/foo/p95"]!!, 12000.0)
+    assertGauge(byType["$METRIC_PREFIX/foo/p98"]!!, 12000.0)
+    assertGauge(byType["$METRIC_PREFIX/foo/p99"]!!, 12000.0)
+    assertGauge(byType["$METRIC_PREFIX/foo/p999"]!!, 12000.0)
+  }
+
+  @Test
+  fun counter() {
+    val counter = metrics.counter("foo")
+    counter.inc(75)
+
+    val timeSeries = reporter.toTimeSeries("foo", counter, START_TIME, NOW)
+    val byType = timeSeries.map { it.metric.type to it }
+        .toMap()
+    assertCumulative(byType["$METRIC_PREFIX/foo/count"]!!, 75)
+  }
+
+  @Test
+  fun histogram() {
+    val hist = metrics.histogram("foo")
+    hist.update(10000)
+    hist.update(11000)
+    hist.update(9000)
+    hist.update(12000)
+
+    val timeSeries = reporter.toTimeSeries("foo", hist, START_TIME, NOW)
+    val byType = timeSeries.map { it.metric.type to it }
+        .toMap()
+
+    assertCumulative(byType["$METRIC_PREFIX/foo/count"]!!, 4)
+    assertGauge(byType["$METRIC_PREFIX/foo/max"]!!, 12000.0)
+    assertGauge(byType["$METRIC_PREFIX/foo/min"]!!, 9000.0)
+    assertGauge(byType["$METRIC_PREFIX/foo/mean"]!!, 10500.0)
+    assertGauge(byType["$METRIC_PREFIX/foo/stdDev"]!!, 1118.0339)
+    assertGauge(byType["$METRIC_PREFIX/foo/p50"]!!, 11000.0)
+    assertGauge(byType["$METRIC_PREFIX/foo/p75"]!!, 12000.0)
+    assertGauge(byType["$METRIC_PREFIX/foo/p95"]!!, 12000.0)
+    assertGauge(byType["$METRIC_PREFIX/foo/p98"]!!, 12000.0)
+    assertGauge(byType["$METRIC_PREFIX/foo/p99"]!!, 12000.0)
+    assertGauge(byType["$METRIC_PREFIX/foo/p999"]!!, 12000.0)
+  }
+
+  @Test
+  fun longGauge() {
+    val f: () -> Long = { 42 }
+    val gauge: Gauge<Any> = metrics.gauge("foo", f)
+
+    val timeSeries = reporter.toTimeSeries("foo", gauge, START_TIME, NOW)
+    val byType = timeSeries.map { it.metric.type to it }
+        .toMap()
+    assertGauge(byType["$METRIC_PREFIX/foo/value"]!!, 42)
+  }
+
+  @Test
+  fun intGauge() {
+    val f: () -> Int = { 42 }
+    val gauge: Gauge<Any> = metrics.gauge("foo", f)
+
+    val timeSeries = reporter.toTimeSeries("foo", gauge, START_TIME, NOW)
+    val byType = timeSeries.map { it.metric.type to it }
+        .toMap()
+    assertGauge(byType["$METRIC_PREFIX/foo/value"]!!, 42)
+  }
+
+  @Test
+  fun doubleGauge() {
+    val f: () -> Double = { 42.4 }
+    val gauge: Gauge<Any> = metrics.gauge("foo", f)
+
+    val timeSeries = reporter.toTimeSeries("foo", gauge, START_TIME, NOW)
+    val byType = timeSeries.map { it.metric.type to it }
+        .toMap()
+    assertGauge(byType["$METRIC_PREFIX/foo/value"]!!, 42.4)
+
+  }
+
+  @Test
+  fun floatGauge() {
+    val f: () -> Float = { 42.4f }
+    val gauge: Gauge<Any> = metrics.gauge("foo", f)
+
+    val timeSeries = reporter.toTimeSeries("foo", gauge, START_TIME, NOW)
+    val byType = timeSeries.map { it.metric.type to it }
+        .toMap()
+    assertGauge(byType["$METRIC_PREFIX/foo/value"]!!, 42.4)
+  }
+
+  @Test
+  fun byteGauge() {
+    val f: () -> Byte = { 42 }
+    val gauge: Gauge<Any> = metrics.gauge("foo", f)
+
+    val timeSeries = reporter.toTimeSeries("foo", gauge, START_TIME, NOW)
+    val byType = timeSeries.map { it.metric.type to it }
+        .toMap()
+    assertGauge(byType["$METRIC_PREFIX/foo/value"]!!, 42)
+  }
+
+  @Test
+  fun bigDecimalGauge() {
+    val f: () -> BigDecimal = { BigDecimal.valueOf(42.4) }
+    val gauge: Gauge<Any> = metrics.gauge("foo", f)
+
+    val timeSeries = reporter.toTimeSeries("foo", gauge, START_TIME, NOW)
+    val byType = timeSeries.map { it.metric.type to it }
+        .toMap()
+    assertGauge(byType["$METRIC_PREFIX/foo/value"]!!, 42.4)
+  }
+
+  @Test
+  fun bigIntegerGauge() {
+    val f: () -> BigInteger = { BigInteger.valueOf(42) }
+    val gauge: Gauge<Any> = metrics.gauge("foo", f)
+
+    val timeSeries = reporter.toTimeSeries("foo", gauge, START_TIME, NOW)
+    val byType = timeSeries.map { it.metric.type to it }
+        .toMap()
+    assertGauge(byType["$METRIC_PREFIX/foo/value"]!!, 42.toDouble())
+  }
+
+  @Test
+  fun toTimeSeries() {
+    metrics.timer("fiddy")
+        .update(10, TimeUnit.MILLISECONDS)
+    metrics.timer("fiddy")
+        .update(23, TimeUnit.MILLISECONDS)
+    metrics.counter("fenty")
+        .inc(245)
+    metrics.counter("rent")
+        .inc(744)
+    metrics.counter("kent")
+        .inc(95)
+    metrics.gauge("im-basic", { 42 })
+    metrics.histogram("histy")
+        .update(65)
+    metrics.histogram("histy")
+        .update(66)
+    metrics.histogram("histy")
+        .update(67)
+    metrics.histogram("crows")
+        .update(99)
+    metrics.histogram("crows")
+        .update(102)
+
+    val timeSeries = reporter.toTimeSeries(
+        metrics.gauges,
+        metrics.counters,
+        metrics.histograms,
+        null,
+        metrics.timers,
+        START_TIME, NOW
     )
 
-    @Inject internal lateinit var metrics: Metrics
-    @Inject internal lateinit var clock: FakeClock
-    @Inject internal lateinit var reporter: StackDriverReporter
+    val names = timeSeries.map { it.metric.type to it }
+        .toMap()
+    assertThat(names.keys).containsExactly(
+        "custom.googleapis.com/dw/my_app/us-west2/165.33.45.25/im-basic/value",
+        "custom.googleapis.com/dw/my_app/us-west2/165.33.45.25/fenty/count",
+        "custom.googleapis.com/dw/my_app/us-west2/165.33.45.25/kent/count",
+        "custom.googleapis.com/dw/my_app/us-west2/165.33.45.25/rent/count",
+        "custom.googleapis.com/dw/my_app/us-west2/165.33.45.25/crows/count",
+        "custom.googleapis.com/dw/my_app/us-west2/165.33.45.25/crows/max",
+        "custom.googleapis.com/dw/my_app/us-west2/165.33.45.25/crows/min",
+        "custom.googleapis.com/dw/my_app/us-west2/165.33.45.25/crows/mean",
+        "custom.googleapis.com/dw/my_app/us-west2/165.33.45.25/crows/stdDev",
+        "custom.googleapis.com/dw/my_app/us-west2/165.33.45.25/crows/p50",
+        "custom.googleapis.com/dw/my_app/us-west2/165.33.45.25/crows/p75",
+        "custom.googleapis.com/dw/my_app/us-west2/165.33.45.25/crows/p95",
+        "custom.googleapis.com/dw/my_app/us-west2/165.33.45.25/crows/p98",
+        "custom.googleapis.com/dw/my_app/us-west2/165.33.45.25/crows/p99",
+        "custom.googleapis.com/dw/my_app/us-west2/165.33.45.25/crows/p999",
+        "custom.googleapis.com/dw/my_app/us-west2/165.33.45.25/histy/count",
+        "custom.googleapis.com/dw/my_app/us-west2/165.33.45.25/histy/max",
+        "custom.googleapis.com/dw/my_app/us-west2/165.33.45.25/histy/min",
+        "custom.googleapis.com/dw/my_app/us-west2/165.33.45.25/histy/mean",
+        "custom.googleapis.com/dw/my_app/us-west2/165.33.45.25/histy/stdDev",
+        "custom.googleapis.com/dw/my_app/us-west2/165.33.45.25/histy/p50",
+        "custom.googleapis.com/dw/my_app/us-west2/165.33.45.25/histy/p75",
+        "custom.googleapis.com/dw/my_app/us-west2/165.33.45.25/histy/p95",
+        "custom.googleapis.com/dw/my_app/us-west2/165.33.45.25/histy/p98",
+        "custom.googleapis.com/dw/my_app/us-west2/165.33.45.25/histy/p99",
+        "custom.googleapis.com/dw/my_app/us-west2/165.33.45.25/histy/p999",
+        "custom.googleapis.com/dw/my_app/us-west2/165.33.45.25/fiddy/max",
+        "custom.googleapis.com/dw/my_app/us-west2/165.33.45.25/fiddy/min",
+        "custom.googleapis.com/dw/my_app/us-west2/165.33.45.25/fiddy/mean",
+        "custom.googleapis.com/dw/my_app/us-west2/165.33.45.25/fiddy/stdDev",
+        "custom.googleapis.com/dw/my_app/us-west2/165.33.45.25/fiddy/p50",
+        "custom.googleapis.com/dw/my_app/us-west2/165.33.45.25/fiddy/p75",
+        "custom.googleapis.com/dw/my_app/us-west2/165.33.45.25/fiddy/p95",
+        "custom.googleapis.com/dw/my_app/us-west2/165.33.45.25/fiddy/p98",
+        "custom.googleapis.com/dw/my_app/us-west2/165.33.45.25/fiddy/p99",
+        "custom.googleapis.com/dw/my_app/us-west2/165.33.45.25/fiddy/p999",
+        "custom.googleapis.com/dw/my_app/us-west2/165.33.45.25/fiddy/count",
+        "custom.googleapis.com/dw/my_app/us-west2/165.33.45.25/fiddy/m1_rate",
+        "custom.googleapis.com/dw/my_app/us-west2/165.33.45.25/fiddy/mean_rate",
+        "custom.googleapis.com/dw/my_app/us-west2/165.33.45.25/fiddy/m5_rate",
+        "custom.googleapis.com/dw/my_app/us-west2/165.33.45.25/fiddy/m15_rate"
+    )
+  }
 
-    @Test
-    fun timer() {
-        val timer = metrics.timer("foo")
-        timer.update(10, TimeUnit.SECONDS)
-        timer.update(11, TimeUnit.SECONDS)
-        timer.update(9, TimeUnit.SECONDS)
-        timer.update(12, TimeUnit.SECONDS)
-
-        val timeSeries = reporter.toTimeSeries("foo", timer, START_TIME, NOW)
-        val byType = timeSeries.map { it.metric.type to it }.toMap()
-
-        assertCumulative(byType["$METRIC_PREFIX/foo/count"]!!, 4)
-        assertGauge(byType["$METRIC_PREFIX/foo/max"]!!, 12000.0)
-        assertGauge(byType["$METRIC_PREFIX/foo/min"]!!, 9000.0)
-        assertGauge(byType["$METRIC_PREFIX/foo/mean"]!!, 10500.0)
-        assertGauge(byType["$METRIC_PREFIX/foo/stdDev"]!!, 1118.0339)
-        assertGauge(byType["$METRIC_PREFIX/foo/p50"]!!, 11000.0)
-        assertGauge(byType["$METRIC_PREFIX/foo/p75"]!!, 12000.0)
-        assertGauge(byType["$METRIC_PREFIX/foo/p95"]!!, 12000.0)
-        assertGauge(byType["$METRIC_PREFIX/foo/p98"]!!, 12000.0)
-        assertGauge(byType["$METRIC_PREFIX/foo/p99"]!!, 12000.0)
-        assertGauge(byType["$METRIC_PREFIX/foo/p999"]!!, 12000.0)
+  class TestModule : AbstractModule() {
+    override fun configure() {
     }
 
-    @Test
-    fun counter() {
-        val counter = metrics.counter("foo")
-        counter.inc(75)
-
-        val timeSeries = reporter.toTimeSeries("foo", counter, START_TIME, NOW)
-        val byType = timeSeries.map { it.metric.type to it }.toMap()
-        assertCumulative(byType["$METRIC_PREFIX/foo/count"]!!, 75)
+    @Provides
+    @Singleton
+    fun stackDriverSender(): StackDriverSender = object : StackDriverSender {
+      override fun send(timeSeries: List<TimeSeries>) {}
     }
 
-    @Test
-    fun histogram() {
-        val hist = metrics.histogram("foo")
-        hist.update(10000)
-        hist.update(11000)
-        hist.update(9000)
-        hist.update(12000)
+    @Provides
+    @Singleton
+    fun instanceMetadata(): InstanceMetadata = INSTANCE_METADATA
 
-        val timeSeries = reporter.toTimeSeries("foo", hist, START_TIME, NOW)
-        val byType = timeSeries.map { it.metric.type to it }.toMap()
-
-        assertCumulative(byType["$METRIC_PREFIX/foo/count"]!!, 4)
-        assertGauge(byType["$METRIC_PREFIX/foo/max"]!!, 12000.0)
-        assertGauge(byType["$METRIC_PREFIX/foo/min"]!!, 9000.0)
-        assertGauge(byType["$METRIC_PREFIX/foo/mean"]!!, 10500.0)
-        assertGauge(byType["$METRIC_PREFIX/foo/stdDev"]!!, 1118.0339)
-        assertGauge(byType["$METRIC_PREFIX/foo/p50"]!!, 11000.0)
-        assertGauge(byType["$METRIC_PREFIX/foo/p75"]!!, 12000.0)
-        assertGauge(byType["$METRIC_PREFIX/foo/p95"]!!, 12000.0)
-        assertGauge(byType["$METRIC_PREFIX/foo/p98"]!!, 12000.0)
-        assertGauge(byType["$METRIC_PREFIX/foo/p99"]!!, 12000.0)
-        assertGauge(byType["$METRIC_PREFIX/foo/p999"]!!, 12000.0)
-    }
-
-    @Test
-    fun longGauge() {
-        val f: () -> Long = { 42 }
-        val gauge: Gauge<Any> = metrics.gauge("foo", f)
-
-        val timeSeries = reporter.toTimeSeries("foo", gauge, START_TIME, NOW)
-        val byType = timeSeries.map { it.metric.type to it }.toMap()
-        assertGauge(byType["$METRIC_PREFIX/foo/value"]!!, 42)
-    }
-
-    @Test
-    fun intGauge() {
-        val f: () -> Int = { 42 }
-        val gauge: Gauge<Any> = metrics.gauge("foo", f)
-
-        val timeSeries = reporter.toTimeSeries("foo", gauge, START_TIME, NOW)
-        val byType = timeSeries.map { it.metric.type to it }.toMap()
-        assertGauge(byType["$METRIC_PREFIX/foo/value"]!!, 42)
-    }
-
-    @Test
-    fun doubleGauge() {
-        val f: () -> Double = { 42.4 }
-        val gauge: Gauge<Any> = metrics.gauge("foo", f)
-
-        val timeSeries = reporter.toTimeSeries("foo", gauge, START_TIME, NOW)
-        val byType = timeSeries.map { it.metric.type to it }.toMap()
-        assertGauge(byType["$METRIC_PREFIX/foo/value"]!!, 42.4)
-
-    }
-
-    @Test
-    fun floatGauge() {
-        val f: () -> Float = { 42.4f }
-        val gauge: Gauge<Any> = metrics.gauge("foo", f)
-
-        val timeSeries = reporter.toTimeSeries("foo", gauge, START_TIME, NOW)
-        val byType = timeSeries.map { it.metric.type to it }.toMap()
-        assertGauge(byType["$METRIC_PREFIX/foo/value"]!!, 42.4)
-    }
-
-    @Test
-    fun byteGauge() {
-        val f: () -> Byte = { 42 }
-        val gauge: Gauge<Any> = metrics.gauge("foo", f)
-
-        val timeSeries = reporter.toTimeSeries("foo", gauge, START_TIME, NOW)
-        val byType = timeSeries.map { it.metric.type to it }.toMap()
-        assertGauge(byType["$METRIC_PREFIX/foo/value"]!!, 42)
-    }
-
-    @Test
-    fun bigDecimalGauge() {
-        val f: () -> BigDecimal = { BigDecimal.valueOf(42.4) }
-        val gauge: Gauge<Any> = metrics.gauge("foo", f)
-
-        val timeSeries = reporter.toTimeSeries("foo", gauge, START_TIME, NOW)
-        val byType = timeSeries.map { it.metric.type to it }.toMap()
-        assertGauge(byType["$METRIC_PREFIX/foo/value"]!!, 42.4)
-    }
-
-    @Test
-    fun bigIntegerGauge() {
-        val f: () -> BigInteger = { BigInteger.valueOf(42) }
-        val gauge: Gauge<Any> = metrics.gauge("foo", f)
-
-        val timeSeries = reporter.toTimeSeries("foo", gauge, START_TIME, NOW)
-        val byType = timeSeries.map { it.metric.type to it }.toMap()
-        assertGauge(byType["$METRIC_PREFIX/foo/value"]!!, 42.toDouble())
-    }
-
-    @Test
-    fun toTimeSeries() {
-        metrics.timer("fiddy").update(10, TimeUnit.MILLISECONDS)
-        metrics.timer("fiddy").update(23, TimeUnit.MILLISECONDS)
-        metrics.counter("fenty").inc(245)
-        metrics.counter("rent").inc(744)
-        metrics.counter("kent").inc(95)
-        metrics.gauge("im-basic", { 42 })
-        metrics.histogram("histy").update(65)
-        metrics.histogram("histy").update(66)
-        metrics.histogram("histy").update(67)
-        metrics.histogram("crows").update(99)
-        metrics.histogram("crows").update(102)
-
-        val timeSeries = reporter.toTimeSeries(
-                metrics.gauges,
-                metrics.counters,
-                metrics.histograms,
-                null,
-                metrics.timers,
-                START_TIME, NOW)
-
-        val names = timeSeries.map { it.metric.type to it }.toMap()
-        assertThat(names.keys).containsExactly(
-                "custom.googleapis.com/dw/my_app/us-west2/165.33.45.25/im-basic/value",
-                "custom.googleapis.com/dw/my_app/us-west2/165.33.45.25/fenty/count",
-                "custom.googleapis.com/dw/my_app/us-west2/165.33.45.25/kent/count",
-                "custom.googleapis.com/dw/my_app/us-west2/165.33.45.25/rent/count",
-                "custom.googleapis.com/dw/my_app/us-west2/165.33.45.25/crows/count",
-                "custom.googleapis.com/dw/my_app/us-west2/165.33.45.25/crows/max",
-                "custom.googleapis.com/dw/my_app/us-west2/165.33.45.25/crows/min",
-                "custom.googleapis.com/dw/my_app/us-west2/165.33.45.25/crows/mean",
-                "custom.googleapis.com/dw/my_app/us-west2/165.33.45.25/crows/stdDev",
-                "custom.googleapis.com/dw/my_app/us-west2/165.33.45.25/crows/p50",
-                "custom.googleapis.com/dw/my_app/us-west2/165.33.45.25/crows/p75",
-                "custom.googleapis.com/dw/my_app/us-west2/165.33.45.25/crows/p95",
-                "custom.googleapis.com/dw/my_app/us-west2/165.33.45.25/crows/p98",
-                "custom.googleapis.com/dw/my_app/us-west2/165.33.45.25/crows/p99",
-                "custom.googleapis.com/dw/my_app/us-west2/165.33.45.25/crows/p999",
-                "custom.googleapis.com/dw/my_app/us-west2/165.33.45.25/histy/count",
-                "custom.googleapis.com/dw/my_app/us-west2/165.33.45.25/histy/max",
-                "custom.googleapis.com/dw/my_app/us-west2/165.33.45.25/histy/min",
-                "custom.googleapis.com/dw/my_app/us-west2/165.33.45.25/histy/mean",
-                "custom.googleapis.com/dw/my_app/us-west2/165.33.45.25/histy/stdDev",
-                "custom.googleapis.com/dw/my_app/us-west2/165.33.45.25/histy/p50",
-                "custom.googleapis.com/dw/my_app/us-west2/165.33.45.25/histy/p75",
-                "custom.googleapis.com/dw/my_app/us-west2/165.33.45.25/histy/p95",
-                "custom.googleapis.com/dw/my_app/us-west2/165.33.45.25/histy/p98",
-                "custom.googleapis.com/dw/my_app/us-west2/165.33.45.25/histy/p99",
-                "custom.googleapis.com/dw/my_app/us-west2/165.33.45.25/histy/p999",
-                "custom.googleapis.com/dw/my_app/us-west2/165.33.45.25/fiddy/max",
-                "custom.googleapis.com/dw/my_app/us-west2/165.33.45.25/fiddy/min",
-                "custom.googleapis.com/dw/my_app/us-west2/165.33.45.25/fiddy/mean",
-                "custom.googleapis.com/dw/my_app/us-west2/165.33.45.25/fiddy/stdDev",
-                "custom.googleapis.com/dw/my_app/us-west2/165.33.45.25/fiddy/p50",
-                "custom.googleapis.com/dw/my_app/us-west2/165.33.45.25/fiddy/p75",
-                "custom.googleapis.com/dw/my_app/us-west2/165.33.45.25/fiddy/p95",
-                "custom.googleapis.com/dw/my_app/us-west2/165.33.45.25/fiddy/p98",
-                "custom.googleapis.com/dw/my_app/us-west2/165.33.45.25/fiddy/p99",
-                "custom.googleapis.com/dw/my_app/us-west2/165.33.45.25/fiddy/p999",
-                "custom.googleapis.com/dw/my_app/us-west2/165.33.45.25/fiddy/count",
-                "custom.googleapis.com/dw/my_app/us-west2/165.33.45.25/fiddy/m1_rate",
-                "custom.googleapis.com/dw/my_app/us-west2/165.33.45.25/fiddy/mean_rate",
-                "custom.googleapis.com/dw/my_app/us-west2/165.33.45.25/fiddy/m5_rate",
-                "custom.googleapis.com/dw/my_app/us-west2/165.33.45.25/fiddy/m15_rate")
-    }
-
-    class TestModule : AbstractModule() {
-        override fun configure() {
-        }
-
-        @Provides
-        @Singleton
-        fun stackDriverSender(): StackDriverSender = object : StackDriverSender {
-            override fun send(timeSeries: List<TimeSeries>) {}
-        }
-
-        @Provides
-        @Singleton
-        fun instanceMetadata(): InstanceMetadata = INSTANCE_METADATA
-
-        @Provides
-        @AppName
-        fun appName(): String = APP_NAME
-    }
+    @Provides
+    @AppName
+    fun appName(): String = APP_NAME
+  }
 }

--- a/misk/src/test/kotlin/misk/metrics/web/MetricsJsonActionTest.kt
+++ b/misk/src/test/kotlin/misk/metrics/web/MetricsJsonActionTest.kt
@@ -11,30 +11,38 @@ import javax.inject.Inject
 
 @MiskTest
 internal class MetricsJsonActionTest {
-    @MiskTestModule
-    val module = MetricsModule()
+  @MiskTestModule
+  val module = MetricsModule()
 
-    @Inject internal lateinit var metrics: Metrics
-    @Inject internal lateinit var metricsAction: MetricsJsonAction
+  @Inject internal lateinit var metrics: Metrics
+  @Inject internal lateinit var metricsAction: MetricsJsonAction
 
-    @Test
-    fun exposeMetrics() {
-        metrics.counter("myfav").inc(32)
-        metrics.counter("banana").inc(17)
-        metrics.counter("joist").inc(5)
-        metrics.timer("slow").update(392, TimeUnit.MILLISECONDS)
-        metrics.timer("slow").update(256, TimeUnit.MILLISECONDS)
-        metrics.histogram("mork").update(24)
-        metrics.histogram("mork").update(17)
-        metrics.histogram("mork").update(27)
-        metrics.gauge("g1", { 42 })
-        metrics.gauge("g2", { 3.14 })
-        metrics.gauge("g3", { "howdy pardner" })
+  @Test
+  fun exposeMetrics() {
+    metrics.counter("myfav")
+        .inc(32)
+    metrics.counter("banana")
+        .inc(17)
+    metrics.counter("joist")
+        .inc(5)
+    metrics.timer("slow")
+        .update(392, TimeUnit.MILLISECONDS)
+    metrics.timer("slow")
+        .update(256, TimeUnit.MILLISECONDS)
+    metrics.histogram("mork")
+        .update(24)
+    metrics.histogram("mork")
+        .update(17)
+    metrics.histogram("mork")
+        .update(27)
+    metrics.gauge("g1", { 42 })
+    metrics.gauge("g2", { 3.14 })
+    metrics.gauge("g3", { "howdy pardner" })
 
-        val json = metricsAction.getMetrics()
-        assertThat(json.counters.keys).containsExactlyInAnyOrder("myfav", "banana", "joist")
-        assertThat(json.timers.keys).containsExactly("slow")
-        assertThat(json.histograms.keys).containsExactly("mork")
-        assertThat(json.gauges.keys).containsExactlyInAnyOrder("g1", "g2", "g3")
-    }
+    val json = metricsAction.getMetrics()
+    assertThat(json.counters.keys).containsExactlyInAnyOrder("myfav", "banana", "joist")
+    assertThat(json.timers.keys).containsExactly("slow")
+    assertThat(json.histograms.keys).containsExactly("mork")
+    assertThat(json.gauges.keys).containsExactlyInAnyOrder("g1", "g2", "g3")
+  }
 }

--- a/misk/src/test/kotlin/misk/resources/ResourceLoaderTest.kt
+++ b/misk/src/test/kotlin/misk/resources/ResourceLoaderTest.kt
@@ -4,14 +4,14 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
 class ResourceLoaderTest {
-    @Test
-    fun loadResource() {
-        val resource = ResourceLoader.utf8("misk/resources/ResourceLoaderTest.txt")!!
-        assertThat(resource).isEqualTo("69e0753934d2838d1953602ca7722444\n")
-    }
+  @Test
+  fun loadResource() {
+    val resource = ResourceLoader.utf8("misk/resources/ResourceLoaderTest.txt")!!
+    assertThat(resource).isEqualTo("69e0753934d2838d1953602ca7722444\n")
+  }
 
-    @Test
-    fun absentResource() {
-        assertThat(ResourceLoader.utf8("misk/resources/NoSuchResource.txt")).isNull()
-    }
+  @Test
+  fun absentResource() {
+    assertThat(ResourceLoader.utf8("misk/resources/NoSuchResource.txt")).isNull()
+  }
 }

--- a/misk/src/test/kotlin/misk/scope/ActionScopePropagationTest.kt
+++ b/misk/src/test/kotlin/misk/scope/ActionScopePropagationTest.kt
@@ -1,11 +1,11 @@
 package misk.scope
 
-import org.assertj.core.api.Assertions.assertThat
 import com.google.inject.Guice
 import com.google.inject.Key
 import com.google.inject.name.Named
 import com.google.inject.name.Names
 import misk.inject.keyOf
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import java.util.concurrent.Callable
 import java.util.concurrent.Executors
@@ -13,72 +13,81 @@ import javax.inject.Inject
 import kotlin.reflect.KFunction
 
 internal class ActionScopePropagationTest {
-    class Tester {
-        @Inject
-        @Named("foo") lateinit var foo: ActionScoped<String>
+  class Tester {
+    @Inject
+    @Named("foo") lateinit var foo: ActionScoped<String>
 
-        fun fooValue(): String = foo.get()
-    }
+    fun fooValue(): String = foo.get()
+  }
 
-    private val executor = Executors.newSingleThreadExecutor()
+  private val executor = Executors.newSingleThreadExecutor()
 
-    @Test
-    fun propagatesScopeOnNewThreadForCallable() {
-        val injector = Guice.createInjector(TestActionScopedProviderModule())
-        val scope = injector.getInstance(ActionScope::class.java)
-        val tester = injector.getInstance(Tester::class.java)
+  @Test
+  fun propagatesScopeOnNewThreadForCallable() {
+    val injector = Guice.createInjector(TestActionScopedProviderModule())
+    val scope = injector.getInstance(ActionScope::class.java)
+    val tester = injector.getInstance(Tester::class.java)
 
-        val seedData: Map<Key<*>, Any> = mapOf(
-                keyOf<String>(Names.named("from-seed")) to "my seed data")
+    val seedData: Map<Key<*>, Any> = mapOf(
+        keyOf<String>(Names.named("from-seed")) to "my seed data"
+    )
 
-        val callable = scope.enter(seedData).use {
-            scope.propagate(Callable { tester.fooValue() })
+    val callable = scope.enter(seedData)
+        .use {
+          scope.propagate(Callable { tester.fooValue() })
         }
 
-        // Submit to other thread after we've exited the scope
-        val result = executor.submit(callable).get()
-        assertThat(result).isEqualTo("my seed data and bar and foo!")
-    }
+    // Submit to other thread after we've exited the scope
+    val result = executor.submit(callable)
+        .get()
+    assertThat(result).isEqualTo("my seed data and bar and foo!")
+  }
 
-    @Test
-    fun propagatesScopeOnNewThreadForKFunction() {
-        val injector = Guice.createInjector(TestActionScopedProviderModule())
-        val scope = injector.getInstance(ActionScope::class.java)
-        val tester = injector.getInstance(Tester::class.java)
+  @Test
+  fun propagatesScopeOnNewThreadForKFunction() {
+    val injector = Guice.createInjector(TestActionScopedProviderModule())
+    val scope = injector.getInstance(ActionScope::class.java)
+    val tester = injector.getInstance(Tester::class.java)
 
-        val seedData: Map<Key<*>, Any> = mapOf(
-                keyOf<String>(Names.named("from-seed")) to "my seed data")
+    val seedData: Map<Key<*>, Any> = mapOf(
+        keyOf<String>(Names.named("from-seed")) to "my seed data"
+    )
 
-        // Propagate on the the KCallable directly
-        val f : KFunction<String> = tester::fooValue
-        val callable = scope.enter(seedData).use {
-            scope.propagate(f)
+    // Propagate on the the KCallable directly
+    val f: KFunction<String> = tester::fooValue
+    val callable = scope.enter(seedData)
+        .use {
+          scope.propagate(f)
         }
 
-        // Submit to other thread after we've exited the scope
-        val result = executor.submit(Callable {
-            callable.call()
-        }).get()
-        assertThat(result).isEqualTo("my seed data and bar and foo!")
-    }
+    // Submit to other thread after we've exited the scope
+    val result = executor.submit(Callable {
+      callable.call()
+    })
+        .get()
+    assertThat(result).isEqualTo("my seed data and bar and foo!")
+  }
 
-    @Test
-    fun propagatesScopeOnNewThreadForLambda() {
-        val injector = Guice.createInjector(TestActionScopedProviderModule())
-        val scope = injector.getInstance(ActionScope::class.java)
-        val tester = injector.getInstance(Tester::class.java)
+  @Test
+  fun propagatesScopeOnNewThreadForLambda() {
+    val injector = Guice.createInjector(TestActionScopedProviderModule())
+    val scope = injector.getInstance(ActionScope::class.java)
+    val tester = injector.getInstance(Tester::class.java)
 
-        val seedData: Map<Key<*>, Any> = mapOf(
-                keyOf<String>(Names.named("from-seed")) to "my seed data")
+    val seedData: Map<Key<*>, Any> = mapOf(
+        keyOf<String>(Names.named("from-seed")) to "my seed data"
+    )
 
-        // Propagate on a lambda directly
-        val function = scope.enter(seedData).use {
-            scope.propagate( { tester.fooValue() })
+    // Propagate on a lambda directly
+    val function = scope.enter(seedData)
+        .use {
+          scope.propagate({ tester.fooValue() })
         }
 
-        // Submit to other thread after we've exited the scope
-        val result = executor.submit(Callable { function() }).get()
-        assertThat(result).isEqualTo("my seed data and bar and foo!")
-    }
+    // Submit to other thread after we've exited the scope
+    val result = executor.submit(Callable { function() })
+        .get()
+    assertThat(result).isEqualTo("my seed data and bar and foo!")
+  }
 
 }

--- a/misk/src/test/kotlin/misk/scope/ActionScopedTest.kt
+++ b/misk/src/test/kotlin/misk/scope/ActionScopedTest.kt
@@ -1,72 +1,76 @@
 package misk.scope
 
-import org.assertj.core.api.Assertions.assertThat
 import com.google.inject.Guice
 import com.google.inject.Key
 import com.google.inject.name.Named
 import com.google.inject.name.Names
 import misk.inject.keyOf
 import misk.inject.uninject
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import javax.inject.Inject
 
 class ActionScopedTest {
-    @Inject @Named("foo")
-    private lateinit var foo : ActionScoped<String>
+  @Inject @Named("foo")
+  private lateinit var foo: ActionScoped<String>
 
-    @Inject private lateinit var scope: ActionScope
+  @Inject private lateinit var scope: ActionScope
 
-    @BeforeEach
-    fun clearInjections() {
-        uninject(this)
-    }
+  @BeforeEach
+  fun clearInjections() {
+    uninject(this)
+  }
 
-    @Test
-    fun resolvedChainedActionScoped() {
-        val injector = Guice.createInjector(TestActionScopedProviderModule())
-        injector.injectMembers(this)
+  @Test
+  fun resolvedChainedActionScoped() {
+    val injector = Guice.createInjector(TestActionScopedProviderModule())
+    injector.injectMembers(this)
 
-        val seedData: Map<Key<*>, Any> = mapOf(
-                keyOf<String>(Names.named("from-seed")) to "seed-value"
+    val seedData: Map<Key<*>, Any> = mapOf(
+        keyOf<String>(Names.named("from-seed")) to "seed-value"
 
-        )
-        scope.enter(seedData).use {
-            assertThat(foo.get()).isEqualTo("seed-value and bar and foo!")
+    )
+    scope.enter(seedData)
+        .use {
+          assertThat(foo.get()).isEqualTo("seed-value and bar and foo!")
         }
+  }
+
+  @Test
+  fun doubleEnterScopeFails() {
+    assertThrows(IllegalStateException::class.java) {
+      val injector = Guice.createInjector(TestActionScopedProviderModule())
+      injector.injectMembers(this)
+
+      scope.enter(mapOf())
+          .use {
+            scope.enter(mapOf())
+                .use { }
+          }
     }
+  }
 
-    @Test
-    fun doubleEnterScopeFails() {
-        assertThrows(IllegalStateException::class.java) {
-            val injector = Guice.createInjector(TestActionScopedProviderModule())
-            injector.injectMembers(this)
+  @Test
+  fun resolveOutsideOfScopeFails() {
+    assertThrows(IllegalStateException::class.java) {
+      val injector = Guice.createInjector(TestActionScopedProviderModule())
+      injector.injectMembers(this)
 
-            scope.enter(mapOf()).use {
-                scope.enter(mapOf()).use { }
-            }
-        }
+      foo.get()
     }
+  }
 
-    @Test
-    fun resolveOutsideOfScopeFails() {
-        assertThrows(IllegalStateException::class.java) {
-            val injector = Guice.createInjector(TestActionScopedProviderModule())
-            injector.injectMembers(this)
+  @Test
+  fun seedDataNotFoundFails() {
+    assertThrows(IllegalStateException::class.java) {
+      val injector = Guice.createInjector(TestActionScopedProviderModule())
+      injector.injectMembers(this)
 
-            foo.get()
-        }
+      // NB(mmihic): Seed data not specified
+      scope.enter(mapOf())
+          .use { foo.get() }
     }
-
-    @Test
-    fun seedDataNotFoundFails() {
-        assertThrows(IllegalStateException::class.java) {
-            val injector = Guice.createInjector(TestActionScopedProviderModule())
-            injector.injectMembers(this)
-
-            // NB(mmihic): Seed data not specified
-            scope.enter(mapOf()).use { foo.get() }
-        }
-    }
+  }
 }

--- a/misk/src/test/kotlin/misk/scope/TestActionScopedProviderModule.kt
+++ b/misk/src/test/kotlin/misk/scope/TestActionScopedProviderModule.kt
@@ -5,21 +5,21 @@ import com.google.inject.name.Names
 import javax.inject.Inject
 
 class TestActionScopedProviderModule : ActionScopedProviderModule() {
-    override fun configureProviders() {
-        bindSeedData(String::class, Names.named("from-seed"))
-        bindProvider(String::class, Names.named("foo"), FooProvider::class)
-        bindProvider(String::class, Names.named("bar"), BarProvider::class)
-    }
+  override fun configureProviders() {
+    bindSeedData(String::class, Names.named("from-seed"))
+    bindProvider(String::class, Names.named("foo"), FooProvider::class)
+    bindProvider(String::class, Names.named("bar"), BarProvider::class)
+  }
 
-    class BarProvider @Inject internal constructor(
-            @Named("from-seed") val seedData: ActionScoped<String>
-    ) : ActionScopedProvider<String> {
-        override fun get(): String = "${seedData.get()} and bar"
-    }
+  class BarProvider @Inject internal constructor(
+      @Named("from-seed") val seedData: ActionScoped<String>
+  ) : ActionScopedProvider<String> {
+    override fun get(): String = "${seedData.get()} and bar"
+  }
 
-    class FooProvider @Inject internal constructor(
-            @Named("bar") val bar: ActionScoped<String>
-    ) : ActionScopedProvider<String> {
-        override fun get(): String = "${bar.get()} and foo!"
-    }
+  class FooProvider @Inject internal constructor(
+      @Named("bar") val bar: ActionScoped<String>
+  ) : ActionScopedProvider<String> {
+    override fun get(): String = "${bar.get()} and foo!"
+  }
 }

--- a/misk/src/test/kotlin/misk/services/FakeService.kt
+++ b/misk/src/test/kotlin/misk/services/FakeService.kt
@@ -5,9 +5,9 @@ import javax.inject.Singleton
 
 @Singleton
 class FakeService : AbstractIdleService() {
-    override fun startUp() {
-    }
+  override fun startUp() {
+  }
 
-    override fun shutDown() {
-    }
+  override fun shutDown() {
+  }
 }

--- a/misk/src/test/kotlin/misk/services/FakeServiceModule.kt
+++ b/misk/src/test/kotlin/misk/services/FakeServiceModule.kt
@@ -6,7 +6,8 @@ import misk.inject.addMultibinderBinding
 import misk.inject.to
 
 class FakeServiceModule : AbstractModule() {
-    override fun configure() {
-        binder().addMultibinderBinding<Service>().to<FakeService>()
-    }
+  override fun configure() {
+    binder().addMultibinderBinding<Service>()
+        .to<FakeService>()
+  }
 }

--- a/misk/src/test/kotlin/misk/testing.Assertions.kt
+++ b/misk/src/test/kotlin/misk/testing.Assertions.kt
@@ -4,7 +4,7 @@ import org.assertj.core.api.MapAssert
 import org.assertj.core.data.MapEntry
 
 fun <KEY, VALUE> MapAssert<KEY, VALUE>.containsExactly(
-        vararg p: Pair<KEY, VALUE>
+    vararg p: Pair<KEY, VALUE>
 ): MapAssert<KEY, VALUE> {
-    return containsExactly(*p.map { MapEntry.entry(it.first, it.second) }.toTypedArray())
+  return containsExactly(*p.map { MapEntry.entry(it.first, it.second) }.toTypedArray())
 }

--- a/misk/src/test/kotlin/misk/testing/okhttp/HttpRequestUrl.kt
+++ b/misk/src/test/kotlin/misk/testing/okhttp/HttpRequestUrl.kt
@@ -3,4 +3,4 @@ package misk.testing.okhttp
 import com.google.common.base.Joiner
 import okhttp3.HttpUrl
 
-val HttpUrl.path : String get() = Joiner.on('/').join(pathSegments())
+val HttpUrl.path: String get() = Joiner.on('/').join(pathSegments())

--- a/misk/src/test/kotlin/misk/testing/okhttp/RoutingDispatcher.kt
+++ b/misk/src/test/kotlin/misk/testing/okhttp/RoutingDispatcher.kt
@@ -5,5 +5,5 @@ import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.RecordedRequest
 
 class RoutingDispatcher(val routes: (RecordedRequest) -> MockResponse) : Dispatcher() {
-    override fun dispatch(request: RecordedRequest): MockResponse = routes.invoke(request)
+  override fun dispatch(request: RecordedRequest): MockResponse = routes.invoke(request)
 }

--- a/misk/src/test/kotlin/misk/time/FakeClockTest.kt
+++ b/misk/src/test/kotlin/misk/time/FakeClockTest.kt
@@ -9,27 +9,27 @@ import java.util.concurrent.TimeUnit
 
 internal class FakeClockTest {
 
-    @Test
-    fun adjustTime() {
-        val clock = FakeClock()
-        assertThat(clock.millis()).isEqualTo(0L)
+  @Test
+  fun adjustTime() {
+    val clock = FakeClock()
+    assertThat(clock.millis()).isEqualTo(0L)
 
-        clock.add(Duration.ofSeconds(20))
-        assertThat(clock.millis()).isEqualTo(20000L)
+    clock.add(Duration.ofSeconds(20))
+    assertThat(clock.millis()).isEqualTo(20000L)
 
-        clock.add(45, TimeUnit.HOURS)
-        assertThat(clock.millis()).isEqualTo(162020000L)
-    }
+    clock.add(45, TimeUnit.HOURS)
+    assertThat(clock.millis()).isEqualTo(162020000L)
+  }
 
-    @Test
-    fun differentTimeZones() {
-        val clock = FakeClock(zone = ZoneId.of("America/Los_Angeles"))
-        assertThat(clock.zone.id).isEqualTo("America/Los_Angeles")
+  @Test
+  fun differentTimeZones() {
+    val clock = FakeClock(zone = ZoneId.of("America/Los_Angeles"))
+    assertThat(clock.zone.id).isEqualTo("America/Los_Angeles")
 
-        clock.add(45, TimeUnit.HOURS)
+    clock.add(45, TimeUnit.HOURS)
 
-        val newClock = clock.withZone(ZoneId.of("America/New_York"))
-        assertThat(newClock.zone.id).isEqualTo("America/New_York")
-        assertThat(newClock.instant()).isEqualTo(Instant.ofEpochMilli(162000000L))
-    }
+    val newClock = clock.withZone(ZoneId.of("America/New_York"))
+    assertThat(newClock.zone.id).isEqualTo("America/New_York")
+    assertThat(newClock.instant()).isEqualTo(Instant.ofEpochMilli(162000000L))
+  }
 }

--- a/misk/src/test/kotlin/misk/web/ActionScopedWebDispatchTest.kt
+++ b/misk/src/test/kotlin/misk/web/ActionScopedWebDispatchTest.kt
@@ -21,53 +21,56 @@ import javax.inject.Singleton
 
 @MiskTest(startService = true)
 internal class ActionScopedWebDispatchTest {
-    @MiskTestModule
-    val module = Modules.combine(
-            MiskModule(),
-            WebModule(),
-            TestWebModule(),
-            TestModule())
+  @MiskTestModule
+  val module = Modules.combine(
+      MiskModule(),
+      WebModule(),
+      TestWebModule(),
+      TestModule()
+  )
 
-    private @Inject lateinit var jettyService: JettyService
+  private @Inject lateinit var jettyService: JettyService
 
-    @Test
-    fun exposesActionScopedInInterceptors() {
-        val httpClient = OkHttpClient()
-        val response = httpClient.newCall(okhttp3.Request.Builder()
-                .url(jettyService.serverUrl.newBuilder().encodedPath("/hello").build())
-                .addHeader("Security-ID", "Thor")
-                .build())
-                .execute()
-        assertThat(response.code()).isEqualTo(200)
-        assertThat(response.body()!!.string()).isEqualTo("hello Thor")
+  @Test
+  fun exposesActionScopedInInterceptors() {
+    val httpClient = OkHttpClient()
+    val response = httpClient.newCall(
+        okhttp3.Request.Builder()
+            .url(jettyService.serverUrl.newBuilder().encodedPath("/hello").build())
+            .addHeader("Security-ID", "Thor")
+            .build()
+    )
+        .execute()
+    assertThat(response.code()).isEqualTo(200)
+    assertThat(response.body()!!.string()).isEqualTo("hello Thor")
+  }
+
+  @Singleton
+  class FakeIdentityActionScopedProvider @Inject internal constructor(
+      private val request: ActionScoped<Request>
+  ) : ActionScopedProvider<Principal> {
+    override fun get(): Principal = Principal {
+      request.get().headers["Security-Id"] ?: ""
     }
+  }
 
-    @Singleton
-    class FakeIdentityActionScopedProvider @Inject internal constructor(
-            private val request: ActionScoped<Request>
-    ) : ActionScopedProvider<Principal> {
-        override fun get(): Principal = Principal {
-            request.get().headers["Security-Id"] ?: ""
+  @Singleton
+  class Hello @Inject internal constructor(
+      private val principal: @JvmSuppressWildcards ActionScoped<Principal>
+  ) : WebAction {
+    @Get("/hello")
+    @ResponseContentType(MediaTypes.TEXT_PLAIN_UTF8)
+    fun hello(): String = "hello ${principal.get().name}"
+  }
+
+  class TestModule : KAbstractModule() {
+    override fun configure() {
+      install(WebActionModule.create<Hello>())
+      install(object : ActionScopedProviderModule() {
+        override fun configureProviders() {
+          bindProvider(Principal::class, FakeIdentityActionScopedProvider::class)
         }
+      })
     }
-
-    @Singleton
-    class Hello @Inject internal constructor(
-            private val principal: @JvmSuppressWildcards ActionScoped<Principal>
-    ) : WebAction {
-        @Get("/hello")
-        @ResponseContentType(MediaTypes.TEXT_PLAIN_UTF8)
-        fun hello(): String = "hello ${principal.get().name}"
-    }
-
-    class TestModule : KAbstractModule() {
-        override fun configure() {
-            install(WebActionModule.create<Hello>())
-            install(object : ActionScopedProviderModule() {
-                override fun configureProviders() {
-                    bindProvider(Principal::class, FakeIdentityActionScopedProvider::class)
-                }
-            })
-        }
-    }
+  }
 }

--- a/misk/src/test/kotlin/misk/web/ContentBasedDispatchTest.kt
+++ b/misk/src/test/kotlin/misk/web/ContentBasedDispatchTest.kt
@@ -21,113 +21,118 @@ import javax.inject.Inject
 
 @MiskTest(startService = true)
 internal class ContentBasedDispatchTest {
-    @MiskTestModule
-    val module = Modules.combine(
-            MiskModule(),
-            WebModule(),
-            TestWebModule(),
-            TestModule())
+  @MiskTestModule
+  val module = Modules.combine(
+      MiskModule(),
+      WebModule(),
+      TestWebModule(),
+      TestModule()
+  )
 
-    data class Packet(val message: String)
+  data class Packet(val message: String)
 
-    private val jsonMediaType = MediaTypes.APPLICATION_JSON.asMediaType()
-    private val plainTextMediaType = MediaTypes.TEXT_PLAIN_UTF8.asMediaType()
-    private val weirdTextMediaType = "text/weird".asMediaType()
+  private val jsonMediaType = MediaTypes.APPLICATION_JSON.asMediaType()
+  private val plainTextMediaType = MediaTypes.TEXT_PLAIN_UTF8.asMediaType()
+  private val weirdTextMediaType = "text/weird".asMediaType()
 
-    private @Inject lateinit var moshi: Moshi
-    private @Inject lateinit var jettyService: JettyService
-    private val packetJsonAdapter get() = moshi.adapter(Packet::class.java)
+  private @Inject lateinit var moshi: Moshi
+  private @Inject lateinit var jettyService: JettyService
+  private val packetJsonAdapter get() = moshi.adapter(Packet::class.java)
 
-    @Test
-    fun postJsonExpectJson() {
-        val requestContent = packetJsonAdapter.toJson(Packet("my friend"))
-        val responseContent = post(jsonMediaType, requestContent, jsonMediaType).source()
-        assertThat(packetJsonAdapter.fromJson(responseContent)!!.message)
-                .isEqualTo("json->json my friend")
+  @Test
+  fun postJsonExpectJson() {
+    val requestContent = packetJsonAdapter.toJson(Packet("my friend"))
+    val responseContent = post(jsonMediaType, requestContent, jsonMediaType).source()
+    assertThat(packetJsonAdapter.fromJson(responseContent)!!.message)
+        .isEqualTo("json->json my friend")
+  }
+
+  @Test
+  fun postJsonExpectText() {
+    val requestContent = packetJsonAdapter.toJson(Packet("my friend"))
+    val responseContent = post(jsonMediaType, requestContent, plainTextMediaType).source()
+    assertThat(responseContent.readUtf8()).isEqualTo("json->text my friend")
+  }
+
+  @Test
+  fun postTextExpectJson() {
+    val responseContent = post(plainTextMediaType, "my friend", jsonMediaType).source()
+    assertThat(packetJsonAdapter.fromJson(responseContent)!!.message)
+        .isEqualTo("text->json my friend")
+  }
+
+  @Test
+  fun postArbitraryExpectJson() {
+    val responseContent = post(weirdTextMediaType, "my friend", jsonMediaType).source()
+    assertThat(packetJsonAdapter.fromJson(responseContent)!!.message)
+        .isEqualTo("*->json my friend")
+  }
+
+  @Test
+  fun postArbitraryExpectArbitrary() {
+    val responseContent = post(weirdTextMediaType, "my friend", weirdTextMediaType).source()
+    assertThat(responseContent.readUtf8()).isEqualTo("*->* my friend")
+  }
+
+  class TestModule : KAbstractModule() {
+    override fun configure() {
+      install(WebActionModule.create<PostJsonReturnJson>())
+      install(WebActionModule.create<PostTextReturnJson>())
+      install(WebActionModule.create<PostJsonReturnText>())
+      install(WebActionModule.create<PostAnythingReturnJson>())
+      install(WebActionModule.create<PostAnythingReturnAnything>())
+    }
+  }
+
+  class PostJsonReturnJson : WebAction {
+    @Post("/hello")
+    @RequestContentType("application/json")
+    @ResponseContentType("application/json")
+    fun hello(@misk.web.RequestBody request: Packet) = Packet("json->json ${request.message}")
+  }
+
+  class PostTextReturnJson : WebAction {
+    @Post("/hello")
+    @RequestContentType("text/plain")
+    @ResponseContentType("application/json")
+    fun hello(@misk.web.RequestBody message: String) = Packet("text->json $message")
+  }
+
+  class PostJsonReturnText : WebAction {
+    @Post("/hello")
+    @RequestContentType("application/json")
+    @ResponseContentType("text/plain")
+    fun hello(@misk.web.RequestBody request: Packet) = "json->text ${request.message}"
+  }
+
+  class PostAnythingReturnJson : WebAction {
+    @Post("/hello")
+    @ResponseContentType("application/json")
+    fun hello(@misk.web.RequestBody message: String) = Packet("*->json $message")
+  }
+
+  class PostAnythingReturnAnything : WebAction {
+    @Post("/hello")
+    fun hello(@misk.web.RequestBody message: String) = "*->* $message"
+  }
+
+  private fun post(
+      contentType: MediaType,
+      content: String,
+      acceptedMediaType: MediaType? = null
+  ): okhttp3.ResponseBody {
+    val httpClient = OkHttpClient()
+    val request = Request.Builder()
+        .post(RequestBody.create(contentType, content))
+        .url(jettyService.serverUrl.newBuilder().encodedPath("/hello").build())
+
+    if (acceptedMediaType != null) {
+      request.header("Accept", acceptedMediaType.toString())
     }
 
-    @Test
-    fun postJsonExpectText() {
-        val requestContent = packetJsonAdapter.toJson(Packet("my friend"))
-        val responseContent = post(jsonMediaType, requestContent, plainTextMediaType).source()
-        assertThat(responseContent.readUtf8()).isEqualTo("json->text my friend")
-    }
-
-    @Test
-    fun postTextExpectJson() {
-        val responseContent = post(plainTextMediaType, "my friend", jsonMediaType).source()
-        assertThat(packetJsonAdapter.fromJson(responseContent)!!.message)
-                .isEqualTo("text->json my friend")
-    }
-
-    @Test
-    fun postArbitraryExpectJson() {
-        val responseContent = post(weirdTextMediaType, "my friend", jsonMediaType).source()
-        assertThat(packetJsonAdapter.fromJson(responseContent)!!.message)
-                .isEqualTo("*->json my friend")
-    }
-
-    @Test
-    fun postArbitraryExpectArbitrary() {
-        val responseContent = post(weirdTextMediaType, "my friend", weirdTextMediaType).source()
-        assertThat(responseContent.readUtf8()).isEqualTo("*->* my friend")
-    }
-
-    class TestModule : KAbstractModule() {
-        override fun configure() {
-            install(WebActionModule.create<PostJsonReturnJson>())
-            install(WebActionModule.create<PostTextReturnJson>())
-            install(WebActionModule.create<PostJsonReturnText>())
-            install(WebActionModule.create<PostAnythingReturnJson>())
-            install(WebActionModule.create<PostAnythingReturnAnything>())
-        }
-    }
-
-    class PostJsonReturnJson : WebAction {
-        @Post("/hello")
-        @RequestContentType("application/json")
-        @ResponseContentType("application/json")
-        fun hello(@misk.web.RequestBody request: Packet) = Packet("json->json ${request.message}")
-    }
-
-    class PostTextReturnJson : WebAction {
-        @Post("/hello")
-        @RequestContentType("text/plain")
-        @ResponseContentType("application/json")
-        fun hello(@misk.web.RequestBody message: String) = Packet("text->json $message")
-    }
-
-    class PostJsonReturnText : WebAction {
-        @Post("/hello")
-        @RequestContentType("application/json")
-        @ResponseContentType("text/plain")
-        fun hello(@misk.web.RequestBody request: Packet) = "json->text ${request.message}"
-    }
-
-    class PostAnythingReturnJson : WebAction {
-        @Post("/hello")
-        @ResponseContentType("application/json")
-        fun hello(@misk.web.RequestBody message: String) = Packet("*->json $message")
-    }
-
-    class PostAnythingReturnAnything : WebAction {
-        @Post("/hello")
-        fun hello(@misk.web.RequestBody message: String) = "*->* $message"
-    }
-
-    private fun post(contentType: MediaType, content: String,
-            acceptedMediaType: MediaType? = null): okhttp3.ResponseBody {
-        val httpClient = OkHttpClient()
-        val request = Request.Builder()
-                .post(RequestBody.create(contentType, content))
-                .url(jettyService.serverUrl.newBuilder().encodedPath("/hello").build())
-
-        if (acceptedMediaType != null) {
-            request.header("Accept", acceptedMediaType.toString())
-        }
-
-        val response = httpClient.newCall(request.build()).execute()
-        assertThat(response.code()).isEqualTo(200)
-        return response.body()!!
-    }
+    val response = httpClient.newCall(request.build())
+        .execute()
+    assertThat(response.code()).isEqualTo(200)
+    return response.body()!!
+  }
 }

--- a/misk/src/test/kotlin/misk/web/DeterministicRoutingTest.kt
+++ b/misk/src/test/kotlin/misk/web/DeterministicRoutingTest.kt
@@ -18,76 +18,80 @@ import javax.inject.Inject
 
 @MiskTest(startService = true)
 internal class DeterministicRoutingTest {
-    @MiskTestModule
-    val module = Modules.combine(
-            MiskModule(),
-            WebModule(),
-            TestWebModule(),
-            TestModule())
+  @MiskTestModule
+  val module = Modules.combine(
+      MiskModule(),
+      WebModule(),
+      TestWebModule(),
+      TestModule()
+  )
 
-    private @Inject lateinit var jettyService: JettyService
+  private @Inject lateinit var jettyService: JettyService
 
-    @Test
-    fun picksMostSpecificPaths() {
-        assertThat(get("/org/admin/users")).isEqualTo("specific-path-action")
-        assertThat(get("/org/admin/foo")).isEqualTo("subsection-action")
-        assertThat(get("/org/foo/bar")).isEqualTo("section-action")
-        assertThat(get("/org/admin/users/bar")).isEqualTo("remainder-path-action")
-        assertThat(get("/org/unknown/caller/deep/path")).isEqualTo("whole-path")
+  @Test
+  fun picksMostSpecificPaths() {
+    assertThat(get("/org/admin/users")).isEqualTo("specific-path-action")
+    assertThat(get("/org/admin/foo")).isEqualTo("subsection-action")
+    assertThat(get("/org/foo/bar")).isEqualTo("section-action")
+    assertThat(get("/org/admin/users/bar")).isEqualTo("remainder-path-action")
+    assertThat(get("/org/unknown/caller/deep/path")).isEqualTo("whole-path")
+  }
+
+  class SpecificPathAction : WebAction {
+    @Get("/org/admin/users")
+    @ResponseContentType(MediaTypes.TEXT_PLAIN_UTF8)
+    fun handle() = "specific-path-action"
+  }
+
+  class SubsectionAction : WebAction {
+    @Get("/org/admin/{subsection}")
+    @ResponseContentType(MediaTypes.TEXT_PLAIN_UTF8)
+    fun handle() = "subsection-action"
+  }
+
+  class SectionAction : WebAction {
+    @Get("/org/{section}/{subsection}")
+    @ResponseContentType(MediaTypes.TEXT_PLAIN_UTF8)
+    fun handle() = "section-action"
+  }
+
+  class RemainderPathAction : WebAction {
+    @Get("/org/admin/{path:.*}")
+    @ResponseContentType(MediaTypes.TEXT_PLAIN_UTF8)
+    fun handle() = "remainder-path-action"
+  }
+
+  class WholePathAction : WebAction {
+    @Get("/{path:.*}")
+    @ResponseContentType(MediaTypes.TEXT_PLAIN_UTF8)
+    fun handle() = "whole-path"
+  }
+
+  class TestModule : KAbstractModule() {
+    override fun configure() {
+      val webActionModules = mutableListOf(
+          WebActionModule.create<WholePathAction>(),
+          WebActionModule.create<RemainderPathAction>(),
+          WebActionModule.create<SectionAction>(),
+          WebActionModule.create<SubsectionAction>(),
+          WebActionModule.create<SpecificPathAction>()
+      )
+      shuffle(webActionModules)
+      webActionModules.forEach { install(it) }
     }
+  }
 
-    class SpecificPathAction : WebAction {
-        @Get("/org/admin/users")
-        @ResponseContentType(MediaTypes.TEXT_PLAIN_UTF8)
-        fun handle() = "specific-path-action"
-    }
+  private fun get(path: String): String = call(
+      Request.Builder()
+          .url(jettyService.serverUrl.newBuilder().encodedPath(path).build())
+          .get()
+  )
 
-    class SubsectionAction : WebAction {
-        @Get("/org/admin/{subsection}")
-        @ResponseContentType(MediaTypes.TEXT_PLAIN_UTF8)
-        fun handle() = "subsection-action"
-    }
-
-    class SectionAction : WebAction {
-        @Get("/org/{section}/{subsection}")
-        @ResponseContentType(MediaTypes.TEXT_PLAIN_UTF8)
-        fun handle() = "section-action"
-    }
-
-    class RemainderPathAction : WebAction {
-        @Get("/org/admin/{path:.*}")
-        @ResponseContentType(MediaTypes.TEXT_PLAIN_UTF8)
-        fun handle() = "remainder-path-action"
-    }
-
-    class WholePathAction : WebAction {
-        @Get("/{path:.*}")
-        @ResponseContentType(MediaTypes.TEXT_PLAIN_UTF8)
-        fun handle() = "whole-path"
-    }
-
-    class TestModule : KAbstractModule() {
-        override fun configure() {
-            val webActionModules = mutableListOf(
-                    WebActionModule.create<WholePathAction>(),
-                    WebActionModule.create<RemainderPathAction>(),
-                    WebActionModule.create<SectionAction>(),
-                    WebActionModule.create<SubsectionAction>(),
-                    WebActionModule.create<SpecificPathAction>()
-            )
-            shuffle(webActionModules)
-            webActionModules.forEach { install(it) }
-        }
-    }
-
-    private fun get(path: String): String = call(Request.Builder()
-            .url(jettyService.serverUrl.newBuilder().encodedPath(path).build())
-            .get())
-
-    private fun call(request: Request.Builder): String {
-        val httpClient = OkHttpClient()
-        val response = httpClient.newCall(request.build()).execute()
-        return response.body()!!.string()
-    }
+  private fun call(request: Request.Builder): String {
+    val httpClient = OkHttpClient()
+    val response = httpClient.newCall(request.build())
+        .execute()
+    return response.body()!!.string()
+  }
 
 }

--- a/misk/src/test/kotlin/misk/web/PathPatternTest.kt
+++ b/misk/src/test/kotlin/misk/web/PathPatternTest.kt
@@ -5,109 +5,109 @@ import org.junit.jupiter.api.Test
 import java.util.Collections.shuffle
 
 internal class PathPatternTest {
-    @Test
-    fun withOnlyConstants() {
-        val p = PathPattern.parse("/a/b/c/d/e/f/g")
-        assertThat(p.pattern.toString()).isEqualTo("\\Q/a/b/c/d/e/f/g\\E")
-        assertThat(p.numSegments).isEqualTo(7)
-        assertThat(p.numRegexVariables).isEqualTo(0)
-        assertThat(p.matchesWildcardPath).isFalse()
-        assertThat(p.variableNames).isEmpty()
-    }
+  @Test
+  fun withOnlyConstants() {
+    val p = PathPattern.parse("/a/b/c/d/e/f/g")
+    assertThat(p.pattern.toString()).isEqualTo("\\Q/a/b/c/d/e/f/g\\E")
+    assertThat(p.numSegments).isEqualTo(7)
+    assertThat(p.numRegexVariables).isEqualTo(0)
+    assertThat(p.matchesWildcardPath).isFalse()
+    assertThat(p.variableNames).isEmpty()
+  }
 
-    @Test
-    fun withSimpleVariableMatches() {
-        val p = PathPattern.parse("/abc/{jeff}/def/{jesse}")
-        assertThat(p.pattern.toString()).isEqualTo("\\Q/abc/\\E([^/]*)\\Q/def/\\E([^/]*)")
-        assertThat(p.numSegments).isEqualTo(4)
-        assertThat(p.numRegexVariables).isEqualTo(0)
-        assertThat(p.matchesWildcardPath).isFalse()
-        assertThat(p.variableNames).containsExactly("jeff", "jesse")
+  @Test
+  fun withSimpleVariableMatches() {
+    val p = PathPattern.parse("/abc/{jeff}/def/{jesse}")
+    assertThat(p.pattern.toString()).isEqualTo("\\Q/abc/\\E([^/]*)\\Q/def/\\E([^/]*)")
+    assertThat(p.numSegments).isEqualTo(4)
+    assertThat(p.numRegexVariables).isEqualTo(0)
+    assertThat(p.matchesWildcardPath).isFalse()
+    assertThat(p.variableNames).containsExactly("jeff", "jesse")
 
-        val m1 = p.pattern.matcher("/abc/moo/def/bark")
-        assertThat(m1.matches()).isTrue()
-        assertThat(m1.group(1)).isEqualTo("moo")
-        assertThat(m1.group(2)).isEqualTo("bark")
+    val m1 = p.pattern.matcher("/abc/moo/def/bark")
+    assertThat(m1.matches()).isTrue()
+    assertThat(m1.group(1)).isEqualTo("moo")
+    assertThat(m1.group(2)).isEqualTo("bark")
 
-        assertThat(p.pattern.matcher("/abc/moo/def").matches()).isFalse()
-        assertThat(p.pattern.matcher("/abc/moo/def/bark/more").matches()).isFalse()
-    }
+    assertThat(p.pattern.matcher("/abc/moo/def").matches()).isFalse()
+    assertThat(p.pattern.matcher("/abc/moo/def/bark/more").matches()).isFalse()
+  }
 
-    @Test
-    fun withRegexMatches() {
-        val p = PathPattern.parse("/org/admin/{folder:[a-z]+}/{object:[a-z0-9]+}")
-        assertThat(p.pattern.toString()).isEqualTo("\\Q/org/admin/\\E([a-z]+)\\Q/\\E([a-z0-9]+)")
-        assertThat(p.numSegments).isEqualTo(4)
-        assertThat(p.numRegexVariables).isEqualTo(2)
-        assertThat(p.matchesWildcardPath).isFalse()
-        assertThat(p.variableNames).containsExactly("folder", "object")
+  @Test
+  fun withRegexMatches() {
+    val p = PathPattern.parse("/org/admin/{folder:[a-z]+}/{object:[a-z0-9]+}")
+    assertThat(p.pattern.toString()).isEqualTo("\\Q/org/admin/\\E([a-z]+)\\Q/\\E([a-z0-9]+)")
+    assertThat(p.numSegments).isEqualTo(4)
+    assertThat(p.numRegexVariables).isEqualTo(2)
+    assertThat(p.matchesWildcardPath).isFalse()
+    assertThat(p.variableNames).containsExactly("folder", "object")
 
-        val m1 = p.pattern.matcher("/org/admin/oranges/foo")
-        assertThat(m1.matches()).isTrue()
-        assertThat(m1.group(1)).isEqualTo("oranges")
-        assertThat(m1.group(2)).isEqualTo("foo")
+    val m1 = p.pattern.matcher("/org/admin/oranges/foo")
+    assertThat(m1.matches()).isTrue()
+    assertThat(m1.group(1)).isEqualTo("oranges")
+    assertThat(m1.group(2)).isEqualTo("foo")
 
-        val m2 = p.pattern.matcher("/org/admin/apples/bar75")
-        assertThat(m2.matches()).isTrue()
-        assertThat(m2.group(1)).isEqualTo("apples")
-        assertThat(m2.group(2)).isEqualTo("bar75")
+    val m2 = p.pattern.matcher("/org/admin/apples/bar75")
+    assertThat(m2.matches()).isTrue()
+    assertThat(m2.group(1)).isEqualTo("apples")
+    assertThat(m2.group(2)).isEqualTo("bar75")
 
-        assertThat(p.pattern.matcher("/org/admin/239034/bar75").matches()).isFalse()
-        assertThat(p.pattern.matcher("/org/admin/apples/_admin").matches()).isFalse()
-        assertThat(p.pattern.matcher("/org/admin/apples/_admin").matches()).isFalse()
-        assertThat(p.pattern.matcher("/org/admin/apples/bar75/zod").matches()).isFalse()
-    }
+    assertThat(p.pattern.matcher("/org/admin/239034/bar75").matches()).isFalse()
+    assertThat(p.pattern.matcher("/org/admin/apples/_admin").matches()).isFalse()
+    assertThat(p.pattern.matcher("/org/admin/apples/_admin").matches()).isFalse()
+    assertThat(p.pattern.matcher("/org/admin/apples/bar75/zod").matches()).isFalse()
+  }
 
-    @Test
-    fun withFullPathCapture() {
-        val p = PathPattern.parse("/org/admin/{object_type:o.*}/{path:.*}")
-        assertThat(p.pattern.toString()).isEqualTo("\\Q/org/admin/\\E(o[^/]*)\\Q/\\E(.*)")
-        assertThat(p.numSegments).isEqualTo(4)
-        assertThat(p.numRegexVariables).isEqualTo(2)
-        assertThat(p.matchesWildcardPath).isTrue()
-        assertThat(p.variableNames).containsExactly("object_type", "path")
+  @Test
+  fun withFullPathCapture() {
+    val p = PathPattern.parse("/org/admin/{object_type:o.*}/{path:.*}")
+    assertThat(p.pattern.toString()).isEqualTo("\\Q/org/admin/\\E(o[^/]*)\\Q/\\E(.*)")
+    assertThat(p.numSegments).isEqualTo(4)
+    assertThat(p.numRegexVariables).isEqualTo(2)
+    assertThat(p.matchesWildcardPath).isTrue()
+    assertThat(p.variableNames).containsExactly("object_type", "path")
 
-        val m1 = p.pattern.matcher("/org/admin/oranges/foo")
-        assertThat(m1.matches()).isTrue()
-        assertThat(m1.group(1)).isEqualTo("oranges")
-        assertThat(m1.group(2)).isEqualTo("foo")
+    val m1 = p.pattern.matcher("/org/admin/oranges/foo")
+    assertThat(m1.matches()).isTrue()
+    assertThat(m1.group(1)).isEqualTo("oranges")
+    assertThat(m1.group(2)).isEqualTo("foo")
 
-        val m2 = p.pattern.matcher("/org/admin/oranges/foo/bar")
-        assertThat(m2.matches()).isTrue()
-        assertThat(m2.group(1)).isEqualTo("oranges")
-        assertThat(m2.group(2)).isEqualTo("foo/bar")
+    val m2 = p.pattern.matcher("/org/admin/oranges/foo/bar")
+    assertThat(m2.matches()).isTrue()
+    assertThat(m2.group(1)).isEqualTo("oranges")
+    assertThat(m2.group(2)).isEqualTo("foo/bar")
 
-        assertThat(p.pattern.matcher("/org/admin/users/foo").matches()).isFalse()
-    }
+    assertThat(p.pattern.matcher("/org/admin/users/foo").matches()).isFalse()
+  }
 
-    @Test
-    fun withWildcardCaptureInMiddle() {
-        val p = PathPattern.parse("/org/admin/{object_type:.*}/get")
-        assertThat(p.pattern.toString()).isEqualTo("\\Q/org/admin/\\E([^/]*)\\Q/get\\E")
-        assertThat(p.numSegments).isEqualTo(4)
-        assertThat(p.numRegexVariables).isEqualTo(1)
-        assertThat(p.matchesWildcardPath).isFalse()
-        assertThat(p.variableNames).containsExactly("object_type")
+  @Test
+  fun withWildcardCaptureInMiddle() {
+    val p = PathPattern.parse("/org/admin/{object_type:.*}/get")
+    assertThat(p.pattern.toString()).isEqualTo("\\Q/org/admin/\\E([^/]*)\\Q/get\\E")
+    assertThat(p.numSegments).isEqualTo(4)
+    assertThat(p.numRegexVariables).isEqualTo(1)
+    assertThat(p.matchesWildcardPath).isFalse()
+    assertThat(p.variableNames).containsExactly("object_type")
 
-        assertThat(p.pattern.matcher("/org/admin/users/get").matches()).isTrue()
-        assertThat(p.pattern.matcher("/org/admin/get").matches()).isFalse()
-        assertThat(p.pattern.matcher("/org/admin/users/floozers").matches()).isFalse()
-    }
+    assertThat(p.pattern.matcher("/org/admin/users/get").matches()).isTrue()
+    assertThat(p.pattern.matcher("/org/admin/get").matches()).isFalse()
+    assertThat(p.pattern.matcher("/org/admin/users/floozers").matches()).isFalse()
+  }
 
-    @Test
-    fun ordering() {
-        val p1 = PathPattern.parse("/org/{folder}/{type}")
-        val p2 = PathPattern.parse("/org/admin/{type}")
-        val p3 = PathPattern.parse("/org/admin/users")
-        val p4 = PathPattern.parse("/org/admin/{path:.*}")
-        val p5 = PathPattern.parse("/org/admin/{type:.*}/values")
+  @Test
+  fun ordering() {
+    val p1 = PathPattern.parse("/org/{folder}/{type}")
+    val p2 = PathPattern.parse("/org/admin/{type}")
+    val p3 = PathPattern.parse("/org/admin/users")
+    val p4 = PathPattern.parse("/org/admin/{path:.*}")
+    val p5 = PathPattern.parse("/org/admin/{type:.*}/values")
 
-        val patterns = mutableListOf(p1, p2, p3, p4, p5)
-        shuffle(patterns)
+    val patterns = mutableListOf(p1, p2, p3, p4, p5)
+    shuffle(patterns)
 
-        val sortedBySpecificity = patterns.sorted()
-        assertThat(sortedBySpecificity).containsExactly(p5, p3, p2, p1, p4)
-    }
+    val sortedBySpecificity = patterns.sorted()
+    assertThat(sortedBySpecificity).containsExactly(p5, p3, p2, p1, p4)
+  }
 }
 
 

--- a/misk/src/test/kotlin/misk/web/WebDispatchTest.kt
+++ b/misk/src/test/kotlin/misk/web/WebDispatchTest.kt
@@ -19,120 +19,130 @@ import javax.inject.Inject
 
 @MiskTest(startService = true)
 internal class WebDispatchTest {
-    @MiskTestModule
-    val module = Modules.combine(
-            MiskModule(),
-            WebModule(),
-            TestWebModule(),
-            TestModule())
+  @MiskTestModule
+  val module = Modules.combine(
+      MiskModule(),
+      WebModule(),
+      TestWebModule(),
+      TestModule()
+  )
 
-    data class HelloBye(val message: String)
+  data class HelloBye(val message: String)
 
-    @Inject
-    lateinit var moshi: Moshi
+  @Inject
+  lateinit var moshi: Moshi
 
-    @Inject
-    lateinit var jettyService: JettyService
+  @Inject
+  lateinit var jettyService: JettyService
 
-    private val helloByeJsonAdapter get() = moshi.adapter(HelloBye::class.java)
+  private val helloByeJsonAdapter get() = moshi.adapter(HelloBye::class.java)
 
-    @Test
-    fun post() {
-        val requestContent = helloByeJsonAdapter.toJson(HelloBye("my friend"))
-        val httpClient = OkHttpClient()
-        val request = Request.Builder()
-                .post(okhttp3.RequestBody.create(MediaTypes.APPLICATION_JSON_MEDIA_TYPE,
-                        requestContent))
-                .url(serverUrlBuilder().encodedPath("/hello").build())
-                .build()
+  @Test
+  fun post() {
+    val requestContent = helloByeJsonAdapter.toJson(HelloBye("my friend"))
+    val httpClient = OkHttpClient()
+    val request = Request.Builder()
+        .post(
+            okhttp3.RequestBody.create(
+                MediaTypes.APPLICATION_JSON_MEDIA_TYPE,
+                requestContent
+            )
+        )
+        .url(serverUrlBuilder().encodedPath("/hello").build())
+        .build()
 
-        val response = httpClient.newCall(request).execute()
-        assertThat(response.code()).isEqualTo(200)
+    val response = httpClient.newCall(request)
+        .execute()
+    assertThat(response.code()).isEqualTo(200)
 
-        val responseContent = response.body()!!.source()
-        assertThat(helloByeJsonAdapter.fromJson(responseContent)!!.message).isEqualTo(
-                "post hello my friend")
+    val responseContent = response.body()!!.source()
+    assertThat(helloByeJsonAdapter.fromJson(responseContent)!!.message).isEqualTo(
+        "post hello my friend"
+    )
+  }
+
+  @Test
+  fun get() {
+    val httpClient = OkHttpClient()
+    val request = Request.Builder()
+        .get()
+        .url(serverUrlBuilder().encodedPath("/hello/my_friend").build())
+        .build()
+
+    val response = httpClient.newCall(request)
+        .execute()
+    assertThat(response.code()).isEqualTo(200)
+
+    val responseContent = response.body()!!.source()
+        .readString(Charsets.UTF_8)
+    assertThat(helloByeJsonAdapter.fromJson(responseContent)!!.message)
+        .isEqualTo("get hello my_friend")
+  }
+
+  @Test
+  fun getNothing() {
+    val httpClient = OkHttpClient()
+    val request = Request.Builder()
+        .get()
+        .url(serverUrlBuilder().encodedPath("/nothing").build())
+        .build()
+
+    val response = httpClient.newCall(request)
+        .execute()
+
+    // we expect this to fail since we threw an error; what we are trying to avoid is a
+    // binding time error due to missing marshaller
+    assertThat(response.code()).isEqualTo(500)
+  }
+
+  class TestModule : KAbstractModule() {
+    override fun configure() {
+      install(WebActionModule.create<PostHello>())
+      install(WebActionModule.create<GetHello>())
+      install(WebActionModule.create<PostBye>())
+      install(WebActionModule.create<GetBye>())
+      install(WebActionModule.create<GetNothing>())
     }
+  }
 
-    @Test
-    fun get() {
-        val httpClient = OkHttpClient()
-        val request = Request.Builder()
-                .get()
-                .url(serverUrlBuilder().encodedPath("/hello/my_friend").build())
-                .build()
+  class PostHello : WebAction {
+    @Post("/hello")
+    @RequestContentType(MediaTypes.APPLICATION_JSON)
+    @ResponseContentType(MediaTypes.APPLICATION_JSON)
+    fun hello(@misk.web.RequestBody request: HelloBye) =
+        HelloBye("post hello ${request.message}")
+  }
 
-        val response = httpClient.newCall(request).execute()
-        assertThat(response.code()).isEqualTo(200)
+  class GetHello : WebAction {
+    @Get("/hello/{message}")
+    @ResponseContentType(MediaTypes.APPLICATION_JSON)
+    fun hello(@PathParam("message") message: String) =
+        HelloBye("get hello $message")
+  }
 
-        val responseContent = response.body()!!.source().readString(Charsets.UTF_8)
-        assertThat(helloByeJsonAdapter.fromJson(responseContent)!!.message)
-                .isEqualTo("get hello my_friend")
+  class PostBye : WebAction {
+    @Post("/bye")
+    @RequestContentType(MediaTypes.APPLICATION_JSON)
+    @ResponseContentType(MediaTypes.APPLICATION_JSON)
+    fun bye(@misk.web.RequestBody request: HelloBye) =
+        HelloBye("post bye ${request.message}")
+  }
+
+  class GetBye : WebAction {
+    @Get("/bye/{message}")
+    @ResponseContentType(MediaTypes.APPLICATION_JSON)
+    fun bye(@PathParam("message") message: String) =
+        HelloBye("get bye $message")
+  }
+
+  class GetNothing : WebAction {
+    @Get("/nothing")
+    fun doNothing(): Nothing {
+      throw UnsupportedOperationException("we did nothing")
     }
+  }
 
-    @Test
-    fun getNothing() {
-        val httpClient = OkHttpClient()
-        val request = Request.Builder()
-                .get()
-                .url(serverUrlBuilder().encodedPath("/nothing").build())
-                .build()
-
-        val response = httpClient.newCall(request).execute()
-
-        // we expect this to fail since we threw an error; what we are trying to avoid is a
-        // binding time error due to missing marshaller
-        assertThat(response.code()).isEqualTo(500)
-    }
-
-    class TestModule : KAbstractModule() {
-        override fun configure() {
-            install(WebActionModule.create<PostHello>())
-            install(WebActionModule.create<GetHello>())
-            install(WebActionModule.create<PostBye>())
-            install(WebActionModule.create<GetBye>())
-            install(WebActionModule.create<GetNothing>())
-        }
-    }
-
-    class PostHello : WebAction {
-        @Post("/hello")
-        @RequestContentType(MediaTypes.APPLICATION_JSON)
-        @ResponseContentType(MediaTypes.APPLICATION_JSON)
-        fun hello(@misk.web.RequestBody request: HelloBye) =
-                HelloBye("post hello ${request.message}")
-    }
-
-    class GetHello : WebAction {
-        @Get("/hello/{message}")
-        @ResponseContentType(MediaTypes.APPLICATION_JSON)
-        fun hello(@PathParam("message") message: String) =
-                HelloBye("get hello $message")
-    }
-
-    class PostBye : WebAction {
-        @Post("/bye")
-        @RequestContentType(MediaTypes.APPLICATION_JSON)
-        @ResponseContentType(MediaTypes.APPLICATION_JSON)
-        fun bye(@misk.web.RequestBody request: HelloBye) =
-                HelloBye("post bye ${request.message}")
-    }
-
-    class GetBye : WebAction {
-        @Get("/bye/{message}")
-        @ResponseContentType(MediaTypes.APPLICATION_JSON)
-        fun bye(@PathParam("message") message: String) =
-                HelloBye("get bye $message")
-    }
-
-    class GetNothing : WebAction {
-        @Get("/nothing")
-        fun doNothing(): Nothing {
-            throw UnsupportedOperationException("we did nothing")
-        }
-    }
-
-    private fun serverUrlBuilder(): HttpUrl.Builder {
-        return jettyService.serverUrl.newBuilder()
-    }
+  private fun serverUrlBuilder(): HttpUrl.Builder {
+    return jettyService.serverUrl.newBuilder()
+  }
 }

--- a/misk/src/test/kotlin/misk/web/actions/LivenessCheckActionTest.kt
+++ b/misk/src/test/kotlin/misk/web/actions/LivenessCheckActionTest.kt
@@ -1,33 +1,33 @@
 package misk.web.actions
 
-import org.assertj.core.api.Assertions.assertThat
 import com.google.common.util.concurrent.ServiceManager
 import com.google.inject.util.Modules
 import misk.MiskModule
 import misk.services.FakeServiceModule
 import misk.testing.MiskTest
 import misk.testing.MiskTestModule
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import javax.inject.Inject
 
 @MiskTest
 class LivenessCheckActionTest {
-    @MiskTestModule
-    val module = Modules.combine(
-            MiskModule(),
-            FakeServiceModule()
-    )
+  @MiskTestModule
+  val module = Modules.combine(
+      MiskModule(),
+      FakeServiceModule()
+  )
 
-    @Inject lateinit var livenessCheckAction: LivenessCheckAction
-    @Inject lateinit var serviceManager: ServiceManager
+  @Inject lateinit var livenessCheckAction: LivenessCheckAction
+  @Inject lateinit var serviceManager: ServiceManager
 
-    @Test
-    fun livenessDependsOnServiceState() {
-        serviceManager.startAsync()
-        serviceManager.awaitHealthy()
-        assertThat(livenessCheckAction.livenessCheck().statusCode).isEqualTo(200)
-        serviceManager.stopAsync()
-        serviceManager.awaitStopped()
-        assertThat(livenessCheckAction.livenessCheck().statusCode).isEqualTo(503)
-    }
+  @Test
+  fun livenessDependsOnServiceState() {
+    serviceManager.startAsync()
+    serviceManager.awaitHealthy()
+    assertThat(livenessCheckAction.livenessCheck().statusCode).isEqualTo(200)
+    serviceManager.stopAsync()
+    serviceManager.awaitStopped()
+    assertThat(livenessCheckAction.livenessCheck().statusCode).isEqualTo(503)
+  }
 }

--- a/misk/src/test/kotlin/misk/web/actions/NotFoundActionTest.kt
+++ b/misk/src/test/kotlin/misk/web/actions/NotFoundActionTest.kt
@@ -1,17 +1,19 @@
 package misk.web.actions
 
-import org.assertj.core.api.Assertions.assertThat
 import misk.testing.MiskTest
 import misk.web.Response
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import javax.inject.Inject
 
 @MiskTest
 class NotFoundActionTest {
-    @Inject lateinit var notFoundAction: NotFoundAction
+  @Inject lateinit var notFoundAction: NotFoundAction
 
-    @Test
-    fun test() {
-        assertThat(notFoundAction.notFound("notfound")).isEqualTo(Response("Nothing found at /notfound", statusCode = 404))
-    }
+  @Test
+  fun test() {
+    assertThat(notFoundAction.notFound("notfound")).isEqualTo(
+        Response("Nothing found at /notfound", statusCode = 404)
+    )
+  }
 }

--- a/misk/src/test/kotlin/misk/web/actions/ReadinessCheckActionTest.kt
+++ b/misk/src/test/kotlin/misk/web/actions/ReadinessCheckActionTest.kt
@@ -1,6 +1,5 @@
 package misk.web.actions
 
-import org.assertj.core.api.Assertions.assertThat
 import com.google.common.util.concurrent.ServiceManager
 import com.google.inject.util.Modules
 import misk.MiskModule
@@ -9,35 +8,36 @@ import misk.healthchecks.FakeHealthCheckModule
 import misk.services.FakeServiceModule
 import misk.testing.MiskTest
 import misk.testing.MiskTestModule
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import javax.inject.Inject
 
 @MiskTest
 class ReadinessCheckActionTest {
-    @MiskTestModule
-    val module = Modules.combine(
-            MiskModule(),
-            FakeServiceModule(),
-            FakeHealthCheckModule()
-    )
+  @MiskTestModule
+  val module = Modules.combine(
+      MiskModule(),
+      FakeServiceModule(),
+      FakeHealthCheckModule()
+  )
 
-    @Inject lateinit var readinessCheckAction: ReadinessCheckAction
-    @Inject lateinit var serviceManager: ServiceManager
-    @Inject lateinit var healthCheck: FakeHealthCheck
+  @Inject lateinit var readinessCheckAction: ReadinessCheckAction
+  @Inject lateinit var serviceManager: ServiceManager
+  @Inject lateinit var healthCheck: FakeHealthCheck
 
-    @Test
-    fun readinessDependsOnServiceStateAndHealthChecksPassing() {
-        serviceManager.startAsync()
-        serviceManager.awaitHealthy()
-        assertThat(readinessCheckAction.readinessCheck().statusCode).isEqualTo(200)
+  @Test
+  fun readinessDependsOnServiceStateAndHealthChecksPassing() {
+    serviceManager.startAsync()
+    serviceManager.awaitHealthy()
+    assertThat(readinessCheckAction.readinessCheck().statusCode).isEqualTo(200)
 
-        healthCheck.setUnhealthy()
-        assertThat(readinessCheckAction.readinessCheck().statusCode).isEqualTo(503)
-        healthCheck.setHealthy()
-        assertThat(readinessCheckAction.readinessCheck().statusCode).isEqualTo(200)
+    healthCheck.setUnhealthy()
+    assertThat(readinessCheckAction.readinessCheck().statusCode).isEqualTo(503)
+    healthCheck.setHealthy()
+    assertThat(readinessCheckAction.readinessCheck().statusCode).isEqualTo(200)
 
-        serviceManager.stopAsync()
-        serviceManager.awaitStopped()
-        assertThat(readinessCheckAction.readinessCheck().statusCode).isEqualTo(503)
-    }
+    serviceManager.stopAsync()
+    serviceManager.awaitStopped()
+    assertThat(readinessCheckAction.readinessCheck().statusCode).isEqualTo(503)
+  }
 }

--- a/misk/src/test/kotlin/misk/web/exceptions/ExceptionMapperTest.kt
+++ b/misk/src/test/kotlin/misk/web/exceptions/ExceptionMapperTest.kt
@@ -27,73 +27,75 @@ import javax.inject.Inject
 @MiskTest(startService = true)
 internal class ExceptionMapperTest {
 
-    @MiskTestModule
-    val module = Modules.combine(
-            MiskModule(),
-            WebModule(),
-            TestWebModule(),
-            TestModule())
+  @MiskTestModule
+  val module = Modules.combine(
+      MiskModule(),
+      WebModule(),
+      TestWebModule(),
+      TestModule()
+  )
 
-    @Inject
-    lateinit var moshi: Moshi
+  @Inject
+  lateinit var moshi: Moshi
 
-    @Inject
-    lateinit var jettyService: JettyService
+  @Inject
+  lateinit var jettyService: JettyService
 
-    private fun serverUrlBuilder(): HttpUrl.Builder {
-        return jettyService.serverUrl.newBuilder()
+  private fun serverUrlBuilder(): HttpUrl.Builder {
+    return jettyService.serverUrl.newBuilder()
+  }
+
+  @Test
+  fun masksMessageOnServerError() {
+    val response = get("/throws/action/SERVICE_UNAVAILABLE")
+    assertThat(response.code()).isEqualTo(StatusCode.SERVICE_UNAVAILABLE.code)
+    assertThat(response.body()?.string()).isEqualTo(StatusCode.SERVICE_UNAVAILABLE.name)
+  }
+
+  @Test
+  fun returnsMessageOnClientErrors() {
+    val response = get("/throws/action/FORBIDDEN")
+    assertThat(response.code()).isEqualTo(StatusCode.FORBIDDEN.code)
+    assertThat(response.body()?.string()).isEqualTo("you asked for an error")
+  }
+
+  @Test
+  fun handlesUnmappedErrorsAsInternalServerError() {
+    val response = get("/throws/unmapped-error")
+    assertThat(response.code()).isEqualTo(StatusCode.INTERNAL_SERVER_ERROR.code)
+    assertThat(response.body()?.string()).isEqualTo("internal server error")
+  }
+
+  fun get(path: String): okhttp3.Response {
+    val httpClient = OkHttpClient()
+    val request = Request.Builder()
+        .get()
+        .url(serverUrlBuilder().encodedPath(path).build())
+        .build()
+    return httpClient.newCall(request)
+        .execute()
+  }
+
+  class ThrowsActionException : WebAction {
+    @Get("/throws/action/{statusCode}")
+    @ResponseContentType(MediaTypes.TEXT_PLAIN_UTF8)
+    fun throwsActionException(@PathParam statusCode: StatusCode): Nothing {
+      throw ActionException(statusCode, "you asked for an error")
     }
+  }
 
-    @Test
-    fun masksMessageOnServerError() {
-        val response = get("/throws/action/SERVICE_UNAVAILABLE")
-        assertThat(response.code()).isEqualTo(StatusCode.SERVICE_UNAVAILABLE.code)
-        assertThat(response.body()?.string()).isEqualTo(StatusCode.SERVICE_UNAVAILABLE.name)
+  class ThrowsUnmappedError : WebAction {
+    @Get("/throws/unmapped-error")
+    @ResponseContentType(MediaTypes.TEXT_PLAIN_UTF8)
+    fun throwsUnmappedException() {
+      throw AssertionError("this was bad")
     }
+  }
 
-    @Test
-    fun returnsMessageOnClientErrors() {
-        val response = get("/throws/action/FORBIDDEN")
-        assertThat(response.code()).isEqualTo(StatusCode.FORBIDDEN.code)
-        assertThat(response.body()?.string()).isEqualTo("you asked for an error")
+  class TestModule : KAbstractModule() {
+    override fun configure() {
+      install(WebActionModule.create<ThrowsActionException>())
+      install(WebActionModule.create<ThrowsUnmappedError>())
     }
-
-    @Test
-    fun handlesUnmappedErrorsAsInternalServerError() {
-        val response = get("/throws/unmapped-error")
-        assertThat(response.code()).isEqualTo(StatusCode.INTERNAL_SERVER_ERROR.code)
-        assertThat(response.body()?.string()).isEqualTo("internal server error")
-    }
-
-    fun get(path: String): okhttp3.Response {
-        val httpClient = OkHttpClient()
-        val request = Request.Builder()
-                .get()
-                .url(serverUrlBuilder().encodedPath(path).build())
-                .build()
-        return httpClient.newCall(request).execute()
-    }
-
-    class ThrowsActionException : WebAction {
-        @Get("/throws/action/{statusCode}")
-        @ResponseContentType(MediaTypes.TEXT_PLAIN_UTF8)
-        fun throwsActionException(@PathParam statusCode: StatusCode): Nothing {
-            throw ActionException(statusCode, "you asked for an error")
-        }
-    }
-
-    class ThrowsUnmappedError : WebAction {
-        @Get("/throws/unmapped-error")
-        @ResponseContentType(MediaTypes.TEXT_PLAIN_UTF8)
-        fun throwsUnmappedException() {
-            throw AssertionError("this was bad")
-        }
-    }
-
-    class TestModule : KAbstractModule() {
-        override fun configure() {
-            install(WebActionModule.create<ThrowsActionException>())
-            install(WebActionModule.create<ThrowsUnmappedError>())
-        }
-    }
+  }
 }

--- a/misk/src/test/kotlin/misk/web/extractors/QueryStringParameterProcessorTest.kt
+++ b/misk/src/test/kotlin/misk/web/extractors/QueryStringParameterProcessorTest.kt
@@ -5,205 +5,231 @@ import org.junit.jupiter.api.Test
 import kotlin.reflect.KParameter
 
 internal class QueryStringParameterProcessorTest {
-    @Test
-    fun simpleString() {
-        val queryStringProcessor = QueryStringParameterProcessor(TestMemberStore.stringParameter())
-        val extractedResult = queryStringProcessor.extractFunctionArgumentValue(listOf("foo"))
-        assertThat(extractedResult).isNotNull()
-        assertThat(extractedResult).isEqualTo("foo")
+  @Test
+  fun simpleString() {
+    val queryStringProcessor = QueryStringParameterProcessor(TestMemberStore.stringParameter())
+    val extractedResult = queryStringProcessor.extractFunctionArgumentValue(listOf("foo"))
+    assertThat(extractedResult).isNotNull()
+    assertThat(extractedResult).isEqualTo("foo")
+  }
+
+  @Test
+  fun optionalStringPresent() {
+    val queryStringProcessor =
+        QueryStringParameterProcessor(TestMemberStore.optionalStringParameter())
+    val extractedResult = queryStringProcessor.extractFunctionArgumentValue(listOf("foo"))
+    assertThat(extractedResult).isNotNull()
+    assertThat(extractedResult).isEqualTo("foo")
+  }
+
+  @Test
+  fun optionalStringNotPresent() {
+    val queryStringProcessor =
+        QueryStringParameterProcessor(TestMemberStore.optionalStringParameter())
+    val extractedResult = queryStringProcessor.extractFunctionArgumentValue(listOf())
+    assertThat(extractedResult).isNull()
+  }
+
+  @Test
+  fun stringList() {
+    val queryStringProcessor = QueryStringParameterProcessor(
+        TestMemberStore.stringListParameter()
+    )
+    val extractedResult = queryStringProcessor.extractFunctionArgumentValue(
+        listOf("foo", "bar")
+    )
+    assertThat(extractedResult).isNotNull()
+    assertThat(extractedResult).isEqualTo(listOf("foo", "bar"))
+  }
+
+  @Test
+  fun optionalStringListPresent() {
+    val queryStringProcessor = QueryStringParameterProcessor(
+        TestMemberStore.optionalStringListParameter()
+    )
+    val extractedResult = queryStringProcessor.extractFunctionArgumentValue(
+        listOf("foo", "bar")
+    )
+    assertThat(extractedResult).isNotNull()
+    assertThat(extractedResult).isEqualTo(listOf("foo", "bar"))
+  }
+
+  @Test
+  fun optionalStringListNotPresent() {
+    val queryStringProcessor = QueryStringParameterProcessor(
+        TestMemberStore.optionalStringListParameter()
+    )
+    val extractedResult = queryStringProcessor.extractFunctionArgumentValue(listOf())
+    assertThat(extractedResult).isNull()
+  }
+
+  @Test
+  fun simpleInt() {
+    val queryStringProcessor = QueryStringParameterProcessor(TestMemberStore.intParameter())
+    val extractedResult = queryStringProcessor.extractFunctionArgumentValue(listOf("42"))
+    assertThat(extractedResult).isNotNull()
+    assertThat(extractedResult).isEqualTo(42)
+  }
+
+  @Test
+  fun invalidInt() {
+    val queryStringProcessor = QueryStringParameterProcessor(TestMemberStore.intParameter())
+    try {
+      queryStringProcessor.extractFunctionArgumentValue(listOf("forty two"))
+      assert(false)
+    } catch (e: IllegalArgumentException) {
+      // expected
+    }
+  }
+
+  @Test
+  fun optionalIntPresent() {
+    val queryStringProcessor = QueryStringParameterProcessor(TestMemberStore.optionalIntParameter())
+    val extractedResult = queryStringProcessor.extractFunctionArgumentValue(listOf("42"))
+    assertThat(extractedResult).isNotNull()
+    assertThat(extractedResult).isEqualTo(42)
+  }
+
+  @Test
+  fun optionalIntNotPresent() {
+    val queryStringProcessor = QueryStringParameterProcessor(TestMemberStore.optionalIntParameter())
+    val extractedResult = queryStringProcessor.extractFunctionArgumentValue(listOf())
+    assertThat(extractedResult).isNull()
+  }
+
+  @Test
+  fun intList() {
+    val queryStringProcessor = QueryStringParameterProcessor(TestMemberStore.intListParameter())
+    val extractedResult = queryStringProcessor.extractFunctionArgumentValue(listOf("42", "23"))
+    assertThat(extractedResult).isNotNull()
+    assertThat(extractedResult).isEqualTo(listOf(42, 23))
+  }
+
+  @Test
+  fun optionalIntListPresent() {
+    val queryStringProcessor = QueryStringParameterProcessor(
+        TestMemberStore.optionalIntListParameter()
+    )
+    val extractedResult = queryStringProcessor.extractFunctionArgumentValue(
+        listOf("42", "23")
+    )
+    assertThat(extractedResult).isNotNull()
+    assertThat(extractedResult).isEqualTo(listOf(42, 23))
+  }
+
+  @Test
+  fun optionalIntListNotPresent() {
+    val queryStringProcessor = QueryStringParameterProcessor(
+        TestMemberStore.optionalIntListParameter()
+    )
+    val extractedResult = queryStringProcessor.extractFunctionArgumentValue(listOf())
+    assertThat(extractedResult).isNull()
+  }
+
+  @Test
+  fun simpleLong() {
+    val queryStringProcessor = QueryStringParameterProcessor(TestMemberStore.longParameter())
+    val extractedResult = queryStringProcessor.extractFunctionArgumentValue(listOf("42"))
+    assertThat(extractedResult).isNotNull()
+    assertThat(extractedResult).isEqualTo(42L)
+  }
+
+  @Test
+  fun simpleEnum() {
+    val queryStringProcessor = QueryStringParameterProcessor(TestMemberStore.enumParameter())
+    val extractedResult = queryStringProcessor.extractFunctionArgumentValue(listOf("ONE"))
+    assertThat(extractedResult).isNotNull()
+    assertThat(extractedResult).isEqualTo(TestEnum.ONE)
+  }
+
+  @Test
+  fun optionalEnumPresent() {
+    val queryStringProcessor = QueryStringParameterProcessor(
+        TestMemberStore.optionalEnumParameter()
+    )
+    val extractedResult = queryStringProcessor.extractFunctionArgumentValue(listOf("ONE"))
+    assertThat(extractedResult).isNotNull()
+    assertThat(extractedResult).isEqualTo(TestEnum.ONE)
+  }
+
+  @Test
+  fun optionalEnumNotPresent() {
+    val queryStringProcessor = QueryStringParameterProcessor(
+        TestMemberStore.optionalEnumParameter()
+    )
+    val extractedResult = queryStringProcessor.extractFunctionArgumentValue(listOf())
+    assertThat(extractedResult).isNull()
+  }
+
+  @Test
+  fun defaultEnumPresent() {
+    val queryStringProcessor = QueryStringParameterProcessor(
+        TestMemberStore.defaultEnumParameter()
+    )
+    val extractedResult = queryStringProcessor.extractFunctionArgumentValue(listOf())
+    assertThat(extractedResult).isNull()
+  }
+
+  @Test
+  fun unsupportedClass() {
+    try {
+      QueryStringParameterProcessor(TestMemberStore.unsupportedParameter())
+      assert(false)
+    } catch (e: IllegalArgumentException) {
+      // should be thrown
+    }
+  }
+
+  enum class TestEnum {
+    ONE,
+    TWO
+  }
+
+  @Suppress("UNUSED_PARAMETER")
+  internal class TestMemberStore {
+    fun strTest(
+        str: String,
+        optStr: String?,
+        listStr: List<String>,
+        optListStr: List<String>?
+    ) {
     }
 
-    @Test
-    fun optionalStringPresent() {
-        val queryStringProcessor = QueryStringParameterProcessor(TestMemberStore.optionalStringParameter())
-        val extractedResult = queryStringProcessor.extractFunctionArgumentValue(listOf("foo"))
-        assertThat(extractedResult).isNotNull()
-        assertThat(extractedResult).isEqualTo("foo")
+    fun intTest(
+        int: Int,
+        optInt: Int?,
+        listInt: List<Int>,
+        optListInt: List<Int>?
+    ) {
     }
 
-    @Test
-    fun optionalStringNotPresent() {
-        val queryStringProcessor = QueryStringParameterProcessor(TestMemberStore.optionalStringParameter())
-        val extractedResult = queryStringProcessor.extractFunctionArgumentValue(listOf())
-        assertThat(extractedResult).isNull()
+    fun longTest(long: Long) {
     }
 
-    @Test
-    fun stringList() {
-        val queryStringProcessor = QueryStringParameterProcessor(
-                TestMemberStore.stringListParameter())
-        val extractedResult = queryStringProcessor.extractFunctionArgumentValue(
-                listOf("foo", "bar"))
-        assertThat(extractedResult).isNotNull()
-        assertThat(extractedResult).isEqualTo(listOf("foo", "bar"))
+    fun enumTest(
+        anEnum: TestEnum,
+        optEnum: TestEnum?,
+        defaultEnum: TestEnum = TestEnum.ONE
+    ) {
     }
 
-    @Test
-    fun optionalStringListPresent() {
-        val queryStringProcessor = QueryStringParameterProcessor(
-                TestMemberStore.optionalStringListParameter())
-        val extractedResult = queryStringProcessor.extractFunctionArgumentValue(
-                listOf("foo", "bar"))
-        assertThat(extractedResult).isNotNull()
-        assertThat(extractedResult).isEqualTo(listOf("foo", "bar"))
+    fun unsupportedTest(hashMap: Map<String, String>) {
     }
 
-    @Test
-    fun optionalStringListNotPresent() {
-        val queryStringProcessor = QueryStringParameterProcessor(
-                TestMemberStore.optionalStringListParameter())
-        val extractedResult = queryStringProcessor.extractFunctionArgumentValue(listOf())
-        assertThat(extractedResult).isNull()
+    companion object {
+      fun stringParameter(): KParameter = TestMemberStore::strTest.parameters.get(1)
+      fun optionalStringParameter(): KParameter = TestMemberStore::strTest.parameters.get(2)
+      fun stringListParameter(): KParameter = TestMemberStore::strTest.parameters.get(3)
+      fun optionalStringListParameter(): KParameter = TestMemberStore::strTest.parameters.get(4)
+      fun intParameter(): KParameter = TestMemberStore::intTest.parameters.get(1)
+      fun optionalIntParameter(): KParameter = TestMemberStore::intTest.parameters.get(2)
+      fun intListParameter(): KParameter = TestMemberStore::intTest.parameters.get(3)
+      fun optionalIntListParameter(): KParameter = TestMemberStore::intTest.parameters.get(4)
+      fun longParameter(): KParameter = TestMemberStore::longTest.parameters.get(1)
+      fun enumParameter(): KParameter = TestMemberStore::enumTest.parameters.get(1)
+      fun optionalEnumParameter(): KParameter = TestMemberStore::enumTest.parameters.get(2)
+      fun defaultEnumParameter(): KParameter = TestMemberStore::enumTest.parameters.get(3)
+      fun unsupportedParameter(): KParameter = TestMemberStore::unsupportedTest.parameters.get(1)
     }
-
-    @Test
-    fun simpleInt() {
-        val queryStringProcessor = QueryStringParameterProcessor(TestMemberStore.intParameter())
-        val extractedResult = queryStringProcessor.extractFunctionArgumentValue(listOf("42"))
-        assertThat(extractedResult).isNotNull()
-        assertThat(extractedResult).isEqualTo(42)
-    }
-
-    @Test
-    fun invalidInt() {
-        val queryStringProcessor = QueryStringParameterProcessor(TestMemberStore.intParameter())
-        try {
-            queryStringProcessor.extractFunctionArgumentValue(listOf("forty two"))
-            assert(false)
-        } catch(e: IllegalArgumentException) {
-            // expected
-        }
-    }
-
-    @Test
-    fun optionalIntPresent() {
-        val queryStringProcessor = QueryStringParameterProcessor(TestMemberStore.optionalIntParameter())
-        val extractedResult = queryStringProcessor.extractFunctionArgumentValue(listOf("42"))
-        assertThat(extractedResult).isNotNull()
-        assertThat(extractedResult).isEqualTo(42)
-    }
-
-    @Test
-    fun optionalIntNotPresent() {
-        val queryStringProcessor = QueryStringParameterProcessor(TestMemberStore.optionalIntParameter())
-        val extractedResult = queryStringProcessor.extractFunctionArgumentValue(listOf())
-        assertThat(extractedResult).isNull()
-    }
-
-    @Test
-    fun intList() {
-        val queryStringProcessor = QueryStringParameterProcessor(TestMemberStore.intListParameter())
-        val extractedResult = queryStringProcessor.extractFunctionArgumentValue(listOf("42", "23"))
-        assertThat(extractedResult).isNotNull()
-        assertThat(extractedResult).isEqualTo(listOf(42, 23))
-    }
-
-    @Test
-    fun optionalIntListPresent() {
-        val queryStringProcessor = QueryStringParameterProcessor(
-                TestMemberStore.optionalIntListParameter())
-        val extractedResult = queryStringProcessor.extractFunctionArgumentValue(
-                listOf("42", "23"))
-        assertThat(extractedResult).isNotNull()
-        assertThat(extractedResult).isEqualTo(listOf(42, 23))
-    }
-
-    @Test
-    fun optionalIntListNotPresent() {
-        val queryStringProcessor = QueryStringParameterProcessor(
-                TestMemberStore.optionalIntListParameter())
-        val extractedResult = queryStringProcessor.extractFunctionArgumentValue(listOf())
-        assertThat(extractedResult).isNull()
-    }
-
-    @Test
-    fun simpleLong() {
-        val queryStringProcessor = QueryStringParameterProcessor(TestMemberStore.longParameter())
-        val extractedResult = queryStringProcessor.extractFunctionArgumentValue(listOf("42"))
-        assertThat(extractedResult).isNotNull()
-        assertThat(extractedResult).isEqualTo(42L)
-    }
-
-    @Test
-    fun simpleEnum() {
-        val queryStringProcessor = QueryStringParameterProcessor(TestMemberStore.enumParameter())
-        val extractedResult = queryStringProcessor.extractFunctionArgumentValue(listOf("ONE"))
-        assertThat(extractedResult).isNotNull()
-        assertThat(extractedResult).isEqualTo(TestEnum.ONE)
-    }
-
-    @Test
-    fun optionalEnumPresent() {
-        val queryStringProcessor = QueryStringParameterProcessor(
-            TestMemberStore.optionalEnumParameter())
-        val extractedResult = queryStringProcessor.extractFunctionArgumentValue(listOf("ONE"))
-        assertThat(extractedResult).isNotNull()
-        assertThat(extractedResult).isEqualTo(TestEnum.ONE)
-    }
-
-    @Test
-    fun optionalEnumNotPresent() {
-        val queryStringProcessor = QueryStringParameterProcessor(
-            TestMemberStore.optionalEnumParameter())
-        val extractedResult = queryStringProcessor.extractFunctionArgumentValue(listOf())
-        assertThat(extractedResult).isNull()
-    }
-
-    @Test
-    fun defaultEnumPresent() {
-        val queryStringProcessor = QueryStringParameterProcessor(
-            TestMemberStore.defaultEnumParameter())
-        val extractedResult = queryStringProcessor.extractFunctionArgumentValue(listOf())
-        assertThat(extractedResult).isNull()
-    }
-
-    @Test
-    fun unsupportedClass() {
-        try {
-            QueryStringParameterProcessor(TestMemberStore.unsupportedParameter())
-            assert(false)
-        } catch(e: IllegalArgumentException) {
-            // should be thrown
-        }
-    }
-
-    enum class TestEnum {
-        ONE,
-        TWO
-    }
-
-    @Suppress("UNUSED_PARAMETER")
-    internal class TestMemberStore {
-        fun strTest(str: String, optStr: String?, listStr: List<String>, optListStr: List<String>?) {
-        }
-
-        fun intTest(int: Int, optInt: Int?, listInt: List<Int>, optListInt: List<Int>?) {
-        }
-
-        fun longTest(long: Long) {
-        }
-
-        fun enumTest(anEnum: TestEnum, optEnum: TestEnum?, defaultEnum: TestEnum = TestEnum.ONE) {
-        }
-
-        fun unsupportedTest(hashMap: Map<String, String>) {
-        }
-
-        companion object {
-            fun stringParameter(): KParameter = TestMemberStore::strTest.parameters.get(1)
-            fun optionalStringParameter(): KParameter = TestMemberStore::strTest.parameters.get(2)
-            fun stringListParameter(): KParameter = TestMemberStore::strTest.parameters.get(3)
-            fun optionalStringListParameter(): KParameter
-                    = TestMemberStore::strTest.parameters.get(4)
-            fun intParameter(): KParameter = TestMemberStore::intTest.parameters.get(1)
-            fun optionalIntParameter(): KParameter = TestMemberStore::intTest.parameters.get(2)
-            fun intListParameter(): KParameter = TestMemberStore::intTest.parameters.get(3)
-            fun optionalIntListParameter(): KParameter = TestMemberStore::intTest.parameters.get(4)
-            fun longParameter(): KParameter = TestMemberStore::longTest.parameters.get(1)
-            fun enumParameter(): KParameter = TestMemberStore::enumTest.parameters.get(1)
-            fun optionalEnumParameter(): KParameter = TestMemberStore::enumTest.parameters.get(2)
-            fun defaultEnumParameter(): KParameter = TestMemberStore::enumTest.parameters.get(3)
-            fun unsupportedParameter(): KParameter = TestMemberStore::unsupportedTest.parameters.get(1)
-        }
-    }
+  }
 }

--- a/misk/src/test/kotlin/misk/web/extractors/QueryStringRequestTest.kt
+++ b/misk/src/test/kotlin/misk/web/extractors/QueryStringRequestTest.kt
@@ -7,7 +7,11 @@ import misk.inject.KAbstractModule
 import misk.testing.MiskTest
 import misk.testing.MiskTestModule
 import misk.testing.TestWebModule
-import misk.web.*
+import misk.web.Get
+import misk.web.QueryParam
+import misk.web.ResponseContentType
+import misk.web.WebActionModule
+import misk.web.WebModule
 import misk.web.actions.WebAction
 import misk.web.jetty.JettyService
 import misk.web.mediatype.MediaTypes
@@ -19,114 +23,123 @@ import javax.inject.Inject
 
 @MiskTest(startService = true)
 internal class QueryStringRequestTest {
-    data class Packet(val message: String)
+  data class Packet(val message: String)
 
-    @MiskTestModule
-    val module = Modules.combine(
-            MiskModule(),
-            WebModule(),
-            TestWebModule(),
-            TestModule())
+  @MiskTestModule
+  val module = Modules.combine(
+      MiskModule(),
+      WebModule(),
+      TestWebModule(),
+      TestModule()
+  )
 
-    private @Inject lateinit var moshi: Moshi
-    private @Inject lateinit var jettyService: JettyService
-    private val packetJsonAdapter get() = moshi.adapter(Packet::class.java)
+  private @Inject lateinit var moshi: Moshi
+  private @Inject lateinit var jettyService: JettyService
+  private val packetJsonAdapter get() = moshi.adapter(Packet::class.java)
 
-    @Test
-    fun basicParams() {
-        assertThat(get("/basic-params", "str=foo&something=stuff&int=12&testEnum=ONE").message)
-                .isEqualTo("foo stuff 12 ONE basic-params")
+  @Test
+  fun basicParams() {
+    assertThat(get("/basic-params", "str=foo&something=stuff&int=12&testEnum=ONE").message)
+        .isEqualTo("foo stuff 12 ONE basic-params")
+  }
+
+  @Test
+  fun optionalParamsPresent() {
+    assertThat(get("/optional-params", "str=foo&int=12").message)
+        .isEqualTo("foo 12 optional-params")
+  }
+
+  @Test
+  fun optionalParamsNotPresent() {
+    assertThat(get("/optional-params", "").message).isEqualTo("null null optional-params")
+  }
+
+  @Test
+  fun defaultParamsPresent() {
+    assertThat(get("/default-params", "str=foo&int=12&testEnum=ONE").message)
+        .isEqualTo("foo 12 ONE default-params")
+  }
+
+  @Test
+  fun defaultParamsNotPresent() {
+    assertThat(get("/default-params", "").message).isEqualTo("square 23 TWO default-params")
+  }
+
+  @Test
+  fun listParams() {
+    assertThat(get("/list-params", "strs=foo&strs=bar&ints=12&ints=42&strs=baz").message)
+        .isEqualTo("foo bar baz 12 42 list-params")
+  }
+
+  enum class TestEnum {
+    ONE,
+    TWO
+  }
+
+  class BasicParamsAction : WebAction {
+    @Get("/basic-params")
+    @ResponseContentType(MediaTypes.APPLICATION_JSON)
+    fun call(
+        @QueryParam str: String,
+        @QueryParam("something") other: String,
+        @QueryParam int: Int,
+        @QueryParam testEnum: TestEnum
+    ) = Packet("${str} ${other} ${int} ${testEnum} basic-params")
+  }
+
+  class OptionalParamsAction : WebAction {
+    @Get("/optional-params")
+    @ResponseContentType(MediaTypes.APPLICATION_JSON)
+    fun call(@QueryParam str: String?, @QueryParam int: Int?) = Packet(
+        "${str} ${int} optional-params"
+    )
+  }
+
+  class DefaultParamsAction : WebAction {
+    @Get("/default-params")
+    @ResponseContentType(MediaTypes.APPLICATION_JSON)
+    fun call(
+        @QueryParam str: String = "square",
+        @QueryParam int: Int = 23,
+        @QueryParam testEnum: TestEnum = TestEnum.TWO
+    ) = Packet("${str} ${int} ${testEnum} default-params")
+  }
+
+  class ListParamsAction : WebAction {
+    @Get("/list-params")
+    @ResponseContentType(MediaTypes.APPLICATION_JSON)
+    fun call(@QueryParam strs: List<String>, @QueryParam ints: List<Int>) = Packet(
+        "${strs.joinToString(separator = " ")} " +
+            "${ints.joinToString(separator = " ")} list-params"
+    )
+  }
+
+  class TestModule : KAbstractModule() {
+    override fun configure() {
+      install(WebActionModule.create<BasicParamsAction>())
+      install(WebActionModule.create<OptionalParamsAction>())
+      install(WebActionModule.create<DefaultParamsAction>())
+      install(WebActionModule.create<ListParamsAction>())
     }
+  }
 
-    @Test
-    fun optionalParamsPresent() {
-        assertThat(get("/optional-params", "str=foo&int=12").message)
-                .isEqualTo("foo 12 optional-params")
-    }
+  private fun get(
+      path: String,
+      query: String
+  ): Packet = call(
+      Request.Builder()
+          .url(jettyService.serverUrl.newBuilder().encodedPath(path).query(query).build())
+          .get()
+  )
 
-    @Test
-    fun optionalParamsNotPresent() {
-        assertThat(get("/optional-params", "").message).isEqualTo("null null optional-params")
-    }
+  private fun call(request: Request.Builder): Packet {
+    request.header("Accept", MediaTypes.APPLICATION_JSON)
 
-    @Test
-    fun defaultParamsPresent() {
-        assertThat(get("/default-params", "str=foo&int=12&testEnum=ONE").message)
-                .isEqualTo("foo 12 ONE default-params")
-    }
-
-    @Test
-    fun defaultParamsNotPresent() {
-        assertThat(get("/default-params", "").message).isEqualTo("square 23 TWO default-params")
-    }
-
-    @Test
-    fun listParams() {
-        assertThat(get("/list-params", "strs=foo&strs=bar&ints=12&ints=42&strs=baz").message)
-                .isEqualTo("foo bar baz 12 42 list-params")
-    }
-
-    enum class TestEnum {
-        ONE,
-        TWO
-    }
-
-    class BasicParamsAction : WebAction {
-        @Get("/basic-params")
-        @ResponseContentType(MediaTypes.APPLICATION_JSON)
-        fun call(
-                @QueryParam str: String,
-                @QueryParam("something") other: String,
-                @QueryParam int: Int,
-                @QueryParam testEnum: TestEnum
-        ) = Packet("${str} ${other} ${int} ${testEnum} basic-params")
-    }
-
-    class OptionalParamsAction : WebAction {
-        @Get("/optional-params")
-        @ResponseContentType(MediaTypes.APPLICATION_JSON)
-        fun call(@QueryParam str: String?, @QueryParam int: Int?)
-                = Packet("${str} ${int} optional-params")
-    }
-
-    class DefaultParamsAction : WebAction {
-        @Get("/default-params")
-        @ResponseContentType(MediaTypes.APPLICATION_JSON)
-        fun call(
-            @QueryParam str: String = "square",
-            @QueryParam int: Int = 23,
-            @QueryParam testEnum: TestEnum = TestEnum.TWO)
-                = Packet("${str} ${int} ${testEnum} default-params")
-    }
-
-    class ListParamsAction : WebAction {
-        @Get("/list-params")
-        @ResponseContentType(MediaTypes.APPLICATION_JSON)
-        fun call(@QueryParam strs: List<String>, @QueryParam ints: List<Int>)
-                = Packet("${strs.joinToString(separator = " ")} " +
-                        "${ints.joinToString(separator = " ")} list-params")
-    }
-
-    class TestModule : KAbstractModule() {
-        override fun configure() {
-            install(WebActionModule.create<BasicParamsAction>())
-            install(WebActionModule.create<OptionalParamsAction>())
-            install(WebActionModule.create<DefaultParamsAction>())
-            install(WebActionModule.create<ListParamsAction>())
-        }
-    }
-
-    private fun get(path: String, query: String): Packet = call(Request.Builder()
-            .url(jettyService.serverUrl.newBuilder().encodedPath(path).query(query).build())
-            .get())
-
-    private fun call(request: Request.Builder): Packet {
-        request.header("Accept", MediaTypes.APPLICATION_JSON)
-
-        val httpClient = OkHttpClient()
-        val response = httpClient.newCall(request.build()).execute()
-        assertThat(response.code()).isEqualTo(200)
-        assertThat(response.header("Content-Type")).isEqualTo(MediaTypes.APPLICATION_JSON)
-        return packetJsonAdapter.fromJson(response.body()!!.source())!!
-    }
+    val httpClient = OkHttpClient()
+    val response = httpClient.newCall(request.build())
+        .execute()
+    assertThat(response.code()).isEqualTo(200)
+    assertThat(response.header("Content-Type")).isEqualTo(MediaTypes.APPLICATION_JSON)
+    return packetJsonAdapter.fromJson(response.body()!!.source())!!
+  }
 }

--- a/misk/src/test/kotlin/misk/web/interceptors/MetricsInterceptorTest.kt
+++ b/misk/src/test/kotlin/misk/web/interceptors/MetricsInterceptorTest.kt
@@ -1,6 +1,5 @@
 package misk.web.interceptors
 
-import org.assertj.core.api.Assertions.assertThat
 import misk.asAction
 import misk.metrics.Metrics
 import misk.metrics.MetricsModule
@@ -10,62 +9,65 @@ import misk.web.Get
 import misk.web.Response
 import misk.web.actions.WebAction
 import misk.web.actions.asChain
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import javax.inject.Inject
 
 @MiskTest
 class MetricsInterceptorTest {
-    @MiskTestModule
-    val module = MetricsModule()
+  @MiskTestModule
+  val module = MetricsModule()
 
-    @Inject internal lateinit var metricsInterceptorFactory: MetricsInterceptor.Factory
-    @Inject internal lateinit var testAction: TestAction
-    @Inject internal lateinit var metrics: Metrics
+  @Inject internal lateinit var metricsInterceptorFactory: MetricsInterceptor.Factory
+  @Inject internal lateinit var testAction: TestAction
+  @Inject internal lateinit var metrics: Metrics
 
-    @BeforeEach
-    fun sendRequests() {
-        assertThat(invoke(200).statusCode).isEqualTo(200)
-        assertThat(invoke(200).statusCode).isEqualTo(200)
-        assertThat(invoke(202).statusCode).isEqualTo(202)
-        assertThat(invoke(404).statusCode).isEqualTo(404)
-        assertThat(invoke(403).statusCode).isEqualTo(403)
-        assertThat(invoke(403).statusCode).isEqualTo(403)
-    }
+  @BeforeEach
+  fun sendRequests() {
+    assertThat(invoke(200).statusCode).isEqualTo(200)
+    assertThat(invoke(200).statusCode).isEqualTo(200)
+    assertThat(invoke(202).statusCode).isEqualTo(202)
+    assertThat(invoke(404).statusCode).isEqualTo(404)
+    assertThat(invoke(403).statusCode).isEqualTo(403)
+    assertThat(invoke(403).statusCode).isEqualTo(403)
+  }
 
-    @Test
-    fun requests() {
-        assertThat(metrics.counters["web.TestAction.requests"]!!.count).isEqualTo(6)
-    }
+  @Test
+  fun requests() {
+    assertThat(metrics.counters["web.TestAction.requests"]!!.count).isEqualTo(6)
+  }
 
-    @Test
-    fun responseCodes() {
-        assertThat(metrics.counters["web.TestAction.responses.2xx"]!!.count).isEqualTo(3)
-        assertThat(metrics.counters["web.TestAction.responses.200"]!!.count).isEqualTo(2)
-        assertThat(metrics.counters["web.TestAction.responses.202"]!!.count).isEqualTo(1)
-        assertThat(metrics.counters["web.TestAction.responses.4xx"]!!.count).isEqualTo(3)
-        assertThat(metrics.counters["web.TestAction.responses.404"]!!.count).isEqualTo(1)
-        assertThat(metrics.counters["web.TestAction.responses.403"]!!.count).isEqualTo(2)
-    }
+  @Test
+  fun responseCodes() {
+    assertThat(metrics.counters["web.TestAction.responses.2xx"]!!.count).isEqualTo(3)
+    assertThat(metrics.counters["web.TestAction.responses.200"]!!.count).isEqualTo(2)
+    assertThat(metrics.counters["web.TestAction.responses.202"]!!.count).isEqualTo(1)
+    assertThat(metrics.counters["web.TestAction.responses.4xx"]!!.count).isEqualTo(3)
+    assertThat(metrics.counters["web.TestAction.responses.404"]!!.count).isEqualTo(1)
+    assertThat(metrics.counters["web.TestAction.responses.403"]!!.count).isEqualTo(2)
+  }
 
-    @Test
-    fun timing() {
-        assertThat(metrics.timers["web.TestAction.timing"]!!.count).isEqualTo(6)
-    }
+  @Test
+  fun timing() {
+    assertThat(metrics.timers["web.TestAction.timing"]!!.count).isEqualTo(6)
+  }
 
-    fun invoke(desiredStatusCode: Int): Response<String> {
-        val metricsInterceptor = metricsInterceptorFactory.create(TestAction::call.asAction())!!
-        val chain = testAction.asChain(TestAction::call, listOf(desiredStatusCode),
-                metricsInterceptor)
+  fun invoke(desiredStatusCode: Int): Response<String> {
+    val metricsInterceptor = metricsInterceptorFactory.create(TestAction::call.asAction())!!
+    val chain = testAction.asChain(
+        TestAction::call, listOf(desiredStatusCode),
+        metricsInterceptor
+    )
 
-        @Suppress("UNCHECKED_CAST")
-        return chain.proceed(chain.args) as Response<String>
-    }
+    @Suppress("UNCHECKED_CAST")
+    return chain.proceed(chain.args) as Response<String>
+  }
 }
 
 internal class TestAction : WebAction {
-    @Get("/call/{result}")
-    fun call(desiredStatusCode: Int): Response<String> {
-        return Response("foo", statusCode = desiredStatusCode)
-    }
+  @Get("/call/{result}")
+  fun call(desiredStatusCode: Int): Response<String> {
+    return Response("foo", statusCode = desiredStatusCode)
+  }
 }

--- a/misk/src/test/kotlin/misk/web/marshal/JsonRequestTest.kt
+++ b/misk/src/test/kotlin/misk/web/marshal/JsonRequestTest.kt
@@ -27,88 +27,99 @@ import javax.inject.Inject
 
 @MiskTest(startService = true)
 internal class JsonRequestTest {
-    data class Packet(val message: String)
+  data class Packet(val message: String)
 
-    @MiskTestModule
-    val module = Modules.combine(
-            MiskModule(),
-            WebModule(),
-            TestWebModule(),
-            TestModule())
+  @MiskTestModule
+  val module = Modules.combine(
+      MiskModule(),
+      WebModule(),
+      TestWebModule(),
+      TestModule()
+  )
 
-    private @Inject lateinit var moshi: Moshi
-    private @Inject lateinit var jettyService: JettyService
+  private @Inject lateinit var moshi: Moshi
+  private @Inject lateinit var jettyService: JettyService
+  private val packetJsonAdapter get() = moshi.adapter(Packet::class.java)
+
+  @Test
+  fun passAsObject() {
+    assertThat(post("/as-object", Packet("foo")).message).isEqualTo("foo as-object")
+  }
+
+  @Test
+  fun passAsString() {
+    assertThat(post("/as-string", Packet("foo")).message).isEqualTo("foo as-string")
+  }
+
+  @Test
+  fun passAsByteString() {
+    assertThat(post("/as-byte-string", Packet("foo")).message).isEqualTo("foo as-byte-string")
+  }
+
+  class PassAsObject : WebAction {
+    @Post("/as-object")
+    @RequestContentType(MediaTypes.APPLICATION_JSON)
+    @ResponseContentType(MediaTypes.APPLICATION_JSON)
+    fun call(@RequestBody packet: Packet) = Packet("${packet.message} as-object")
+  }
+
+  class PassAsString : WebAction {
+    @Inject lateinit var moshi: Moshi
     private val packetJsonAdapter get() = moshi.adapter(Packet::class.java)
 
-    @Test
-    fun passAsObject() {
-        assertThat(post("/as-object", Packet("foo")).message).isEqualTo("foo as-object")
+    @Post("/as-string")
+    @RequestContentType(MediaTypes.APPLICATION_JSON)
+    @ResponseContentType(MediaTypes.APPLICATION_JSON)
+    fun call(@RequestBody encodedPacket: String): Packet {
+      val incomingPacket = packetJsonAdapter.fromJson(encodedPacket)
+      return Packet("${incomingPacket?.message} as-string")
     }
+  }
 
-    @Test
-    fun passAsString() {
-        assertThat(post("/as-string", Packet("foo")).message).isEqualTo("foo as-string")
+  class PassAsByteString : WebAction {
+    @Inject lateinit var moshi: Moshi
+    private val packetJsonAdapter get() = moshi.adapter(Packet::class.java)
+
+    @Post("/as-byte-string")
+    @RequestContentType(MediaTypes.APPLICATION_JSON)
+    @ResponseContentType(MediaTypes.APPLICATION_JSON)
+    fun call(@RequestBody encodedPacket: ByteString): Packet {
+      val source = Okio.buffer(Okio.source(ByteArrayInputStream(encodedPacket.toByteArray())))
+      val incomingPacket = packetJsonAdapter.fromJson(source)
+      return Packet("${incomingPacket?.message} as-byte-string")
     }
+  }
 
-    @Test
-    fun passAsByteString() {
-        assertThat(post("/as-byte-string", Packet("foo")).message).isEqualTo("foo as-byte-string")
+  class TestModule : KAbstractModule() {
+    override fun configure() {
+      install(WebActionModule.create<PassAsObject>())
+      install(WebActionModule.create<PassAsString>())
+      install(WebActionModule.create<PassAsByteString>())
     }
+  }
 
-    class PassAsObject : WebAction {
-        @Post("/as-object")
-        @RequestContentType(MediaTypes.APPLICATION_JSON)
-        @ResponseContentType(MediaTypes.APPLICATION_JSON)
-        fun call(@RequestBody packet: Packet) = Packet("${packet.message} as-object")
-    }
+  private fun post(
+      path: String,
+      packet: Packet
+  ): Packet = call(
+      Request.Builder()
+          .url(jettyService.serverUrl.newBuilder().encodedPath(path).build())
+          .post(
+              okhttp3.RequestBody.create(
+                  MediaTypes.APPLICATION_JSON_MEDIA_TYPE,
+                  packetJsonAdapter.toJson(packet)
+              )
+          )
+  )
 
-    class PassAsString : WebAction {
-        @Inject lateinit var moshi: Moshi
-        private val packetJsonAdapter get() = moshi.adapter(Packet::class.java)
+  private fun call(request: Request.Builder): Packet {
+    request.header("Accept", MediaTypes.APPLICATION_JSON)
 
-        @Post("/as-string")
-        @RequestContentType(MediaTypes.APPLICATION_JSON)
-        @ResponseContentType(MediaTypes.APPLICATION_JSON)
-        fun call(@RequestBody encodedPacket: String): Packet {
-            val incomingPacket = packetJsonAdapter.fromJson(encodedPacket)
-            return Packet("${incomingPacket?.message} as-string")
-        }
-    }
-
-    class PassAsByteString : WebAction {
-        @Inject lateinit var moshi: Moshi
-        private val packetJsonAdapter get() = moshi.adapter(Packet::class.java)
-
-        @Post("/as-byte-string")
-        @RequestContentType(MediaTypes.APPLICATION_JSON)
-        @ResponseContentType(MediaTypes.APPLICATION_JSON)
-        fun call(@RequestBody encodedPacket: ByteString): Packet {
-            val source = Okio.buffer(Okio.source(ByteArrayInputStream(encodedPacket.toByteArray())))
-            val incomingPacket = packetJsonAdapter.fromJson(source)
-            return Packet("${incomingPacket?.message} as-byte-string")
-        }
-    }
-
-    class TestModule : KAbstractModule() {
-        override fun configure() {
-            install(WebActionModule.create<PassAsObject>())
-            install(WebActionModule.create<PassAsString>())
-            install(WebActionModule.create<PassAsByteString>())
-        }
-    }
-
-    private fun post(path: String, packet: Packet): Packet = call(Request.Builder()
-            .url(jettyService.serverUrl.newBuilder().encodedPath(path).build())
-            .post(okhttp3.RequestBody.create(MediaTypes.APPLICATION_JSON_MEDIA_TYPE,
-                    packetJsonAdapter.toJson(packet))))
-
-    private fun call(request: Request.Builder): Packet {
-        request.header("Accept", MediaTypes.APPLICATION_JSON)
-
-        val httpClient = OkHttpClient()
-        val response = httpClient.newCall(request.build()).execute()
-        assertThat(response.code()).isEqualTo(200)
-        assertThat(response.header("Content-Type")).isEqualTo(MediaTypes.APPLICATION_JSON)
-        return packetJsonAdapter.fromJson(response.body()!!.source())!!
-    }
+    val httpClient = OkHttpClient()
+    val response = httpClient.newCall(request.build())
+        .execute()
+    assertThat(response.code()).isEqualTo(200)
+    assertThat(response.header("Content-Type")).isEqualTo(MediaTypes.APPLICATION_JSON)
+    return packetJsonAdapter.fromJson(response.body()!!.source())!!
+  }
 }

--- a/misk/src/test/kotlin/misk/web/marshal/JsonResponseTest.kt
+++ b/misk/src/test/kotlin/misk/web/marshal/JsonResponseTest.kt
@@ -26,135 +26,139 @@ import javax.inject.Inject
 
 @MiskTest(startService = true)
 internal class JsonResponseTest {
-    data class Packet(val message: String)
+  data class Packet(val message: String)
 
-    @MiskTestModule
-    val module = Modules.combine(
-            MiskModule(),
-            WebModule(),
-            TestWebModule(),
-            TestModule())
+  @MiskTestModule
+  val module = Modules.combine(
+      MiskModule(),
+      WebModule(),
+      TestWebModule(),
+      TestModule()
+  )
 
-    private @Inject lateinit var jettyService: JettyService
-    private @Inject lateinit var moshi: Moshi
-    private val packetJsonAdapter get() = moshi.adapter(Packet::class.java)
+  private @Inject lateinit var jettyService: JettyService
+  private @Inject lateinit var moshi: Moshi
+  private val packetJsonAdapter get() = moshi.adapter(Packet::class.java)
 
-    @Test
-    fun returnAsObject() {
-        assertThat(get("/response/as-object").message).isEqualTo("as-object")
+  @Test
+  fun returnAsObject() {
+    assertThat(get("/response/as-object").message).isEqualTo("as-object")
+  }
+
+  @Test
+  fun returnAsString() {
+    assertThat(get("/response/as-string").message).isEqualTo("as-string")
+  }
+
+  @Test
+  fun returnAsByteString() {
+    assertThat(get("/response/as-byte-string").message).isEqualTo("as-byte-string")
+  }
+
+  @Test
+  fun returnAsResponseBody() {
+    assertThat(get("/response/as-response-body").message).isEqualTo("as-response-body")
+  }
+
+  @Test
+  fun returnAsObjectResponse() {
+    assertThat(get("/response/as-wrapped-object").message).isEqualTo("as-object")
+  }
+
+  @Test
+  fun returnAsStringResponse() {
+    assertThat(get("/response/as-wrapped-string").message).isEqualTo("as-string")
+  }
+
+  @Test
+  fun returnAsByteStringResponse() {
+    assertThat(get("/response/as-wrapped-byte-string").message).isEqualTo("as-byte-string")
+  }
+
+  @Test
+  fun returnAsResponseBodyResponse() {
+    assertThat(get("/response/as-wrapped-response-body").message).isEqualTo("as-response-body")
+  }
+
+  class ReturnAsObject : WebAction {
+    @Get("/response/as-object")
+    @ResponseContentType(MediaTypes.APPLICATION_JSON)
+    fun call() = Packet("as-object")
+  }
+
+  class ReturnAsString : WebAction {
+    @Get("/response/as-string")
+    @ResponseContentType(MediaTypes.APPLICATION_JSON)
+    fun call() = "{\"message\":\"as-string\"}"
+  }
+
+  class ReturnAsByteString : WebAction {
+    @Get("/response/as-byte-string")
+    @ResponseContentType(MediaTypes.APPLICATION_JSON)
+    fun call(): ByteString = ByteString.encodeUtf8("{\"message\":\"as-byte-string\"}")
+  }
+
+  class ReturnAsResponseBody : WebAction {
+    @Get("/response/as-response-body")
+    @ResponseContentType(MediaTypes.APPLICATION_JSON)
+    fun call(): ResponseBody = object : ResponseBody {
+      override fun writeTo(sink: BufferedSink) {
+        sink.writeUtf8("{\"message\":\"as-response-body\"}")
+      }
     }
+  }
 
-    @Test
-    fun returnAsString() {
-        assertThat(get("/response/as-string").message).isEqualTo("as-string")
+  class ReturnAsObjectResponse : WebAction {
+    @Get("/response/as-wrapped-object")
+    @ResponseContentType(MediaTypes.APPLICATION_JSON)
+    fun call() = Response(Packet("as-object"))
+  }
+
+  class ReturnAsStringResponse : WebAction {
+    @Get("/response/as-wrapped-string")
+    @ResponseContentType(MediaTypes.APPLICATION_JSON)
+    fun call() = Response("{\"message\":\"as-string\"}")
+  }
+
+  class ReturnAsByteStringResponse : WebAction {
+    @Get("/response/as-wrapped-byte-string")
+    @ResponseContentType(MediaTypes.APPLICATION_JSON)
+    fun call() = Response(ByteString.encodeUtf8("""{"message":"as-byte-string"}"""))
+  }
+
+  class ReturnAsResponseBodyResponse : WebAction {
+    @Get("/response/as-wrapped-response-body")
+    @ResponseContentType(MediaTypes.APPLICATION_JSON)
+    fun call() = Response(ByteString.encodeUtf8("""{"message":"as-response-body"}"""))
+  }
+
+  class TestModule : KAbstractModule() {
+    override fun configure() {
+      install(WebActionModule.create<ReturnAsObject>())
+      install(WebActionModule.create<ReturnAsString>())
+      install(WebActionModule.create<ReturnAsByteString>())
+      install(WebActionModule.create<ReturnAsResponseBody>())
+      install(WebActionModule.create<ReturnAsObjectResponse>())
+      install(WebActionModule.create<ReturnAsStringResponse>())
+      install(WebActionModule.create<ReturnAsByteStringResponse>())
+      install(WebActionModule.create<ReturnAsResponseBodyResponse>())
     }
+  }
 
-    @Test
-    fun returnAsByteString() {
-        assertThat(get("/response/as-byte-string").message).isEqualTo("as-byte-string")
-    }
+  private fun get(path: String): Packet = call(
+      Request.Builder()
+          .url(jettyService.serverUrl.newBuilder().encodedPath(path).build())
+          .get()
+  )
 
-    @Test
-    fun returnAsResponseBody() {
-        assertThat(get("/response/as-response-body").message).isEqualTo("as-response-body")
-    }
+  private fun call(request: Request.Builder): Packet {
+    request.header("Accept", MediaTypes.APPLICATION_JSON)
 
-    @Test
-    fun returnAsObjectResponse() {
-        assertThat(get("/response/as-wrapped-object").message).isEqualTo("as-object")
-    }
-
-    @Test
-    fun returnAsStringResponse() {
-        assertThat(get("/response/as-wrapped-string").message).isEqualTo("as-string")
-    }
-
-    @Test
-    fun returnAsByteStringResponse() {
-        assertThat(get("/response/as-wrapped-byte-string").message).isEqualTo("as-byte-string")
-    }
-
-    @Test
-    fun returnAsResponseBodyResponse() {
-        assertThat(get("/response/as-wrapped-response-body").message).isEqualTo("as-response-body")
-    }
-
-    class ReturnAsObject : WebAction {
-        @Get("/response/as-object")
-        @ResponseContentType(MediaTypes.APPLICATION_JSON)
-        fun call() = Packet("as-object")
-    }
-
-    class ReturnAsString : WebAction {
-        @Get("/response/as-string")
-        @ResponseContentType(MediaTypes.APPLICATION_JSON)
-        fun call() = "{\"message\":\"as-string\"}"
-    }
-
-    class ReturnAsByteString : WebAction {
-        @Get("/response/as-byte-string")
-        @ResponseContentType(MediaTypes.APPLICATION_JSON)
-        fun call(): ByteString = ByteString.encodeUtf8("{\"message\":\"as-byte-string\"}")
-    }
-
-    class ReturnAsResponseBody : WebAction {
-        @Get("/response/as-response-body")
-        @ResponseContentType(MediaTypes.APPLICATION_JSON)
-        fun call(): ResponseBody = object : ResponseBody {
-            override fun writeTo(sink: BufferedSink) {
-                sink.writeUtf8("{\"message\":\"as-response-body\"}")
-            }
-        }
-    }
-
-    class ReturnAsObjectResponse : WebAction {
-        @Get("/response/as-wrapped-object")
-        @ResponseContentType(MediaTypes.APPLICATION_JSON)
-        fun call() = Response(Packet("as-object"))
-    }
-
-    class ReturnAsStringResponse : WebAction {
-        @Get("/response/as-wrapped-string")
-        @ResponseContentType(MediaTypes.APPLICATION_JSON)
-        fun call() = Response("{\"message\":\"as-string\"}")
-    }
-
-    class ReturnAsByteStringResponse : WebAction {
-        @Get("/response/as-wrapped-byte-string")
-        @ResponseContentType(MediaTypes.APPLICATION_JSON)
-        fun call() = Response(ByteString.encodeUtf8("""{"message":"as-byte-string"}"""))
-    }
-
-    class ReturnAsResponseBodyResponse : WebAction {
-        @Get("/response/as-wrapped-response-body")
-        @ResponseContentType(MediaTypes.APPLICATION_JSON)
-        fun call() = Response(ByteString.encodeUtf8("""{"message":"as-response-body"}"""))
-    }
-
-    class TestModule : KAbstractModule() {
-        override fun configure() {
-            install(WebActionModule.create<ReturnAsObject>())
-            install(WebActionModule.create<ReturnAsString>())
-            install(WebActionModule.create<ReturnAsByteString>())
-            install(WebActionModule.create<ReturnAsResponseBody>())
-            install(WebActionModule.create<ReturnAsObjectResponse>())
-            install(WebActionModule.create<ReturnAsStringResponse>())
-            install(WebActionModule.create<ReturnAsByteStringResponse>())
-            install(WebActionModule.create<ReturnAsResponseBodyResponse>())
-        }
-    }
-
-    private fun get(path: String): Packet = call(Request.Builder()
-            .url(jettyService.serverUrl.newBuilder().encodedPath(path).build())
-            .get())
-
-    private fun call(request: Request.Builder): Packet {
-        request.header("Accept", MediaTypes.APPLICATION_JSON)
-
-        val httpClient = OkHttpClient()
-        val response = httpClient.newCall(request.build()).execute()
-        assertThat(response.code()).isEqualTo(200)
-        assertThat(response.header("Content-Type")).isEqualTo(MediaTypes.APPLICATION_JSON)
-        return packetJsonAdapter.fromJson(response.body()!!.source())!!
-    }
+    val httpClient = OkHttpClient()
+    val response = httpClient.newCall(request.build())
+        .execute()
+    assertThat(response.code()).isEqualTo(200)
+    assertThat(response.header("Content-Type")).isEqualTo(MediaTypes.APPLICATION_JSON)
+    return packetJsonAdapter.fromJson(response.body()!!.source())!!
+  }
 }

--- a/misk/src/test/kotlin/misk/web/marshal/PlainTextResponseTest.kt
+++ b/misk/src/test/kotlin/misk/web/marshal/PlainTextResponseTest.kt
@@ -25,135 +25,139 @@ import javax.inject.Inject
 
 @MiskTest(startService = true)
 internal class PlainTextResponseTest {
-    @MiskTestModule
-    val module = Modules.combine(
-            MiskModule(),
-            WebModule(),
-            TestWebModule(),
-            TestModule())
+  @MiskTestModule
+  val module = Modules.combine(
+      MiskModule(),
+      WebModule(),
+      TestWebModule(),
+      TestModule()
+  )
 
-    private @Inject lateinit var jettyService: JettyService
+  private @Inject lateinit var jettyService: JettyService
 
-    @Test
-    fun returnAsObject() {
-        assertThat(get("/response/as-object")).isEqualTo("as-object")
+  @Test
+  fun returnAsObject() {
+    assertThat(get("/response/as-object")).isEqualTo("as-object")
+  }
+
+  @Test
+  fun returnAsString() {
+    assertThat(get("/response/as-string")).isEqualTo("as-string")
+  }
+
+  @Test
+  fun returnAsByteString() {
+    assertThat(get("/response/as-byte-string")).isEqualTo("as-byte-string")
+  }
+
+  @Test
+  fun returnAsResponseBody() {
+    assertThat(get("/response/as-response-body")).isEqualTo("as-response-body")
+  }
+
+  @Test
+  fun returnAsObjectResponse() {
+    assertThat(get("/response/as-wrapped-object")).isEqualTo("as-object")
+  }
+
+  @Test
+  fun returnAsStringResponse() {
+    assertThat(get("/response/as-wrapped-string")).isEqualTo("as-string")
+  }
+
+  @Test
+  fun returnAsByteStringResponse() {
+    assertThat(get("/response/as-wrapped-byte-string")).isEqualTo("as-byte-string")
+  }
+
+  @Test
+  fun returnAsResponseBodyResponse() {
+    assertThat(get("/response/as-wrapped-response-body")).isEqualTo("as-response-body")
+  }
+
+  class ReturnAsObject : WebAction {
+    @Get("/response/as-object")
+    @ResponseContentType(MediaTypes.TEXT_PLAIN_UTF8)
+    fun call() = MessageWrapper("as-object")
+  }
+
+  class ReturnAsString : WebAction {
+    @Get("/response/as-string")
+    @ResponseContentType(MediaTypes.TEXT_PLAIN_UTF8)
+    fun call() = "as-string"
+  }
+
+  class ReturnAsByteString : WebAction {
+    @Get("/response/as-byte-string")
+    @ResponseContentType(MediaTypes.TEXT_PLAIN_UTF8)
+    fun call(): ByteString = ByteString.encodeUtf8("as-byte-string")
+  }
+
+  class ReturnAsResponseBody : WebAction {
+    @Get("/response/as-response-body")
+    @ResponseContentType(MediaTypes.TEXT_PLAIN_UTF8)
+    fun call(): ResponseBody = object : ResponseBody {
+      override fun writeTo(sink: BufferedSink) {
+        sink.writeUtf8("as-response-body")
+      }
     }
+  }
 
-    @Test
-    fun returnAsString() {
-        assertThat(get("/response/as-string")).isEqualTo("as-string")
+  class ReturnAsObjectResponse : WebAction {
+    @Get("/response/as-wrapped-object")
+    @ResponseContentType(MediaTypes.TEXT_PLAIN_UTF8)
+    fun call(): Response<MessageWrapper> = Response(MessageWrapper("as-object"))
+  }
+
+  class ReturnAsStringResponse : WebAction {
+    @Get("/response/as-wrapped-string")
+    @ResponseContentType(MediaTypes.TEXT_PLAIN_UTF8)
+    fun call() = Response("as-string")
+  }
+
+  class ReturnAsByteStringResponse : WebAction {
+    @Get("/response/as-wrapped-byte-string")
+    @ResponseContentType(MediaTypes.TEXT_PLAIN_UTF8)
+    fun call() = Response(ByteString.encodeUtf8("as-byte-string"))
+  }
+
+  class ReturnAsResponseBodyResponse : WebAction {
+    @Get("/response/as-wrapped-response-body")
+    @ResponseContentType(MediaTypes.TEXT_PLAIN_UTF8)
+    fun call() = Response(ByteString.encodeUtf8("as-response-body"))
+  }
+
+  class TestModule : KAbstractModule() {
+    override fun configure() {
+      install(WebActionModule.create<ReturnAsObject>())
+      install(WebActionModule.create<ReturnAsString>())
+      install(WebActionModule.create<ReturnAsByteString>())
+      install(WebActionModule.create<ReturnAsResponseBody>())
+      install(WebActionModule.create<ReturnAsObjectResponse>())
+      install(WebActionModule.create<ReturnAsStringResponse>())
+      install(WebActionModule.create<ReturnAsByteStringResponse>())
+      install(WebActionModule.create<ReturnAsResponseBodyResponse>())
     }
+  }
 
-    @Test
-    fun returnAsByteString() {
-        assertThat(get("/response/as-byte-string")).isEqualTo("as-byte-string")
-    }
+  fun get(path: String): String = call(
+      Request.Builder()
+          .url(jettyService.serverUrl.newBuilder().encodedPath(path).build())
+          .get()
+  )
 
-    @Test
-    fun returnAsResponseBody() {
-        assertThat(get("/response/as-response-body")).isEqualTo("as-response-body")
-    }
+  class MessageWrapper(private val message: String) {
+    override fun toString() = message
+  }
 
-    @Test
-    fun returnAsObjectResponse() {
-        assertThat(get("/response/as-wrapped-object")).isEqualTo("as-object")
-    }
+  private fun call(request: Request.Builder): String {
+    request.header("Accept", MediaTypes.TEXT_PLAIN_UTF8)
 
-    @Test
-    fun returnAsStringResponse() {
-        assertThat(get("/response/as-wrapped-string")).isEqualTo("as-string")
-    }
-
-    @Test
-    fun returnAsByteStringResponse() {
-        assertThat(get("/response/as-wrapped-byte-string")).isEqualTo("as-byte-string")
-    }
-
-    @Test
-    fun returnAsResponseBodyResponse() {
-        assertThat(get("/response/as-wrapped-response-body")).isEqualTo("as-response-body")
-    }
-
-    class ReturnAsObject : WebAction {
-        @Get("/response/as-object")
-        @ResponseContentType(MediaTypes.TEXT_PLAIN_UTF8)
-        fun call() = MessageWrapper("as-object")
-    }
-
-    class ReturnAsString : WebAction {
-        @Get("/response/as-string")
-        @ResponseContentType(MediaTypes.TEXT_PLAIN_UTF8)
-        fun call() = "as-string"
-    }
-
-    class ReturnAsByteString : WebAction {
-        @Get("/response/as-byte-string")
-        @ResponseContentType(MediaTypes.TEXT_PLAIN_UTF8)
-        fun call(): ByteString = ByteString.encodeUtf8("as-byte-string")
-    }
-
-    class ReturnAsResponseBody : WebAction {
-        @Get("/response/as-response-body")
-        @ResponseContentType(MediaTypes.TEXT_PLAIN_UTF8)
-        fun call(): ResponseBody = object : ResponseBody {
-            override fun writeTo(sink: BufferedSink) {
-                sink.writeUtf8("as-response-body")
-            }
-        }
-    }
-
-    class ReturnAsObjectResponse : WebAction {
-        @Get("/response/as-wrapped-object")
-        @ResponseContentType(MediaTypes.TEXT_PLAIN_UTF8)
-        fun call(): Response<MessageWrapper> = Response(MessageWrapper("as-object"))
-    }
-
-    class ReturnAsStringResponse : WebAction {
-        @Get("/response/as-wrapped-string")
-        @ResponseContentType(MediaTypes.TEXT_PLAIN_UTF8)
-        fun call() = Response("as-string")
-    }
-
-    class ReturnAsByteStringResponse : WebAction {
-        @Get("/response/as-wrapped-byte-string")
-        @ResponseContentType(MediaTypes.TEXT_PLAIN_UTF8)
-        fun call() = Response(ByteString.encodeUtf8("as-byte-string"))
-    }
-
-    class ReturnAsResponseBodyResponse : WebAction {
-        @Get("/response/as-wrapped-response-body")
-        @ResponseContentType(MediaTypes.TEXT_PLAIN_UTF8)
-        fun call() = Response(ByteString.encodeUtf8("as-response-body"))
-    }
-
-    class TestModule : KAbstractModule() {
-        override fun configure() {
-            install(WebActionModule.create<ReturnAsObject>())
-            install(WebActionModule.create<ReturnAsString>())
-            install(WebActionModule.create<ReturnAsByteString>())
-            install(WebActionModule.create<ReturnAsResponseBody>())
-            install(WebActionModule.create<ReturnAsObjectResponse>())
-            install(WebActionModule.create<ReturnAsStringResponse>())
-            install(WebActionModule.create<ReturnAsByteStringResponse>())
-            install(WebActionModule.create<ReturnAsResponseBodyResponse>())
-        }
-    }
-
-    fun get(path: String): String = call(Request.Builder()
-            .url(jettyService.serverUrl.newBuilder().encodedPath(path).build())
-            .get())
-
-    class MessageWrapper(private val message: String) {
-        override fun toString() = message
-    }
-
-    private fun call(request: Request.Builder): String {
-        request.header("Accept", MediaTypes.TEXT_PLAIN_UTF8)
-
-        val httpClient = OkHttpClient()
-        val response = httpClient.newCall(request.build()).execute()
-        assertThat(response.code()).isEqualTo(200)
-        assertThat(response.header("Content-Type")).isEqualTo(MediaTypes.TEXT_PLAIN_UTF8)
-        return response.body()!!.string()
-    }
+    val httpClient = OkHttpClient()
+    val response = httpClient.newCall(request.build())
+        .execute()
+    assertThat(response.code()).isEqualTo(200)
+    assertThat(response.header("Content-Type")).isEqualTo(MediaTypes.TEXT_PLAIN_UTF8)
+    return response.body()!!.string()
+  }
 }

--- a/misk/src/test/kotlin/misk/web/mediatype/MediaRangeTest.kt
+++ b/misk/src/test/kotlin/misk/web/mediatype/MediaRangeTest.kt
@@ -9,235 +9,237 @@ import org.junit.jupiter.api.Test
 import java.util.Collections.shuffle
 
 internal class MediaRangeTest {
-    @Test
-    fun parseAllWildcards() {
-        val mediaRange = MediaRange.parse("*/*")
-        assertThat(mediaRange.type).isEqualTo(MediaRange.WILDCARD)
-        assertThat(mediaRange.subtype).isEqualTo(MediaRange.WILDCARD)
-        assertThat(mediaRange.charset).isNull()
-        assertThat(mediaRange.extensions).isEmpty()
-        assertThat(mediaRange.parameters).isEmpty()
-        assertThat(mediaRange.qualityFactor).isCloseTo(1.0, Offset.offset(0.01))
+  @Test
+  fun parseAllWildcards() {
+    val mediaRange = MediaRange.parse("*/*")
+    assertThat(mediaRange.type).isEqualTo(MediaRange.WILDCARD)
+    assertThat(mediaRange.subtype).isEqualTo(MediaRange.WILDCARD)
+    assertThat(mediaRange.charset).isNull()
+    assertThat(mediaRange.extensions).isEmpty()
+    assertThat(mediaRange.parameters).isEmpty()
+    assertThat(mediaRange.qualityFactor).isCloseTo(1.0, Offset.offset(0.01))
+  }
+
+  @Test
+  fun parseSubtypeWildcard() {
+    val mediaRange = MediaRange.parse("text / *")
+    assertThat(mediaRange.type).isEqualTo("text")
+    assertThat(mediaRange.subtype).isEqualTo(MediaRange.WILDCARD)
+    assertThat(mediaRange.charset).isNull()
+    assertThat(mediaRange.extensions).isEmpty()
+    assertThat(mediaRange.parameters).isEmpty()
+    assertThat(mediaRange.qualityFactor).isCloseTo(1.0, Offset.offset(0.01))
+  }
+
+  @Test
+  fun parseTypeSubtypeOnly() {
+    val mediaRange = MediaRange.parse("application/json")
+    assertThat(mediaRange.type).isEqualTo("application")
+    assertThat(mediaRange.subtype).isEqualTo("json")
+    assertThat(mediaRange.charset).isNull()
+    assertThat(mediaRange.extensions).isEmpty()
+    assertThat(mediaRange.parameters).isEmpty()
+    assertThat(mediaRange.qualityFactor).isCloseTo(1.0, Offset.offset(0.01))
+  }
+
+  @Test
+  fun parseWithParameters() {
+    val mediaRange = MediaRange.parse("text/html;level = 1 ; strict = true")
+    assertThat(mediaRange.type).isEqualTo("text")
+    assertThat(mediaRange.subtype).isEqualTo("html")
+    assertThat(mediaRange.charset).isNull()
+    assertThat(mediaRange.extensions).isEmpty()
+    assertThat(mediaRange.parameters).containsExactly("level" to "1", "strict" to "true")
+    assertThat(mediaRange.qualityFactor).isCloseTo(1.0, Offset.offset(0.01))
+  }
+
+  @Test
+  fun parseWithCharsetParameter() {
+    val mediaRange = MediaRange.parse("text/html;level = 1 ; strict = true;charset=us-ascii")
+    assertThat(mediaRange.type).isEqualTo("text")
+    assertThat(mediaRange.subtype).isEqualTo("html")
+    assertThat(mediaRange.charset).isEqualTo(Charsets.US_ASCII)
+    assertThat(mediaRange.extensions).isEmpty()
+    assertThat(mediaRange.parameters).containsExactly("level" to "1", "strict" to "true")
+    assertThat(mediaRange.qualityFactor).isCloseTo(1.0, Offset.offset(0.01))
+  }
+
+  @Test
+  fun parseWithQualityFactor() {
+    val mediaRange = MediaRange.parse(
+        "text/html;level = 1 ; strict = true;charset=us-ascii; q = 0.45"
+    )
+    assertThat(mediaRange.type).isEqualTo("text")
+    assertThat(mediaRange.subtype).isEqualTo("html")
+    assertThat(mediaRange.charset).isEqualTo(Charsets.US_ASCII)
+    assertThat(mediaRange.extensions).isEmpty()
+    assertThat(mediaRange.parameters).containsExactly("level" to "1", "strict" to "true")
+    assertThat(mediaRange.qualityFactor).isCloseTo(0.45, Offset.offset(0.01))
+  }
+
+  @Test
+  fun parseWithExtensions() {
+    val mediaRange = MediaRange.parse(
+        "text/html;level = 1 ; strict = true;charset=us-ascii; q = 0.45; ext1=79; ext2=blerp"
+    )
+    assertThat(mediaRange.type).isEqualTo("text")
+    assertThat(mediaRange.subtype).isEqualTo("html")
+    assertThat(mediaRange.charset).isEqualTo(Charsets.US_ASCII)
+    assertThat(mediaRange.extensions).containsExactly("ext1" to "79", "ext2" to "blerp")
+    assertThat(mediaRange.parameters).containsExactly("level" to "1", "strict" to "true")
+    assertThat(mediaRange.qualityFactor).isCloseTo(0.45, Offset.offset(0.01))
+  }
+
+  @Test
+  fun wildcardTypeWithSpecificSubType() {
+    assertThrows(IllegalArgumentException::class.java) {
+      MediaRange.parse("*/html")
     }
+  }
 
-    @Test
-    fun parseSubtypeWildcard() {
-        val mediaRange = MediaRange.parse("text / *")
-        assertThat(mediaRange.type).isEqualTo("text")
-        assertThat(mediaRange.subtype).isEqualTo(MediaRange.WILDCARD)
-        assertThat(mediaRange.charset).isNull()
-        assertThat(mediaRange.extensions).isEmpty()
-        assertThat(mediaRange.parameters).isEmpty()
-        assertThat(mediaRange.qualityFactor).isCloseTo(1.0, Offset.offset(0.01))
+  @Test
+  fun blankType() {
+    assertThrows(IllegalArgumentException::class.java) {
+      MediaRange.parse("/html")
     }
+  }
 
-    @Test
-    fun parseTypeSubtypeOnly() {
-        val mediaRange = MediaRange.parse("application/json")
-        assertThat(mediaRange.type).isEqualTo("application")
-        assertThat(mediaRange.subtype).isEqualTo("json")
-        assertThat(mediaRange.charset).isNull()
-        assertThat(mediaRange.extensions).isEmpty()
-        assertThat(mediaRange.parameters).isEmpty()
-        assertThat(mediaRange.qualityFactor).isCloseTo(1.0, Offset.offset(0.01))
+  @Test
+  fun blankSubType() {
+    assertThrows(IllegalArgumentException::class.java) {
+      MediaRange.parse("text/")
     }
+  }
 
-    @Test
-    fun parseWithParameters() {
-        val mediaRange = MediaRange.parse("text/html;level = 1 ; strict = true")
-        assertThat(mediaRange.type).isEqualTo("text")
-        assertThat(mediaRange.subtype).isEqualTo("html")
-        assertThat(mediaRange.charset).isNull()
-        assertThat(mediaRange.extensions).isEmpty()
-        assertThat(mediaRange.parameters).containsExactly("level" to "1", "strict" to "true")
-        assertThat(mediaRange.qualityFactor).isCloseTo(1.0, Offset.offset(0.01))
+  @Test
+  fun noTypeSubType() {
+    assertThrows(IllegalArgumentException::class.java) {
+      MediaRange.parse("*")
     }
+  }
 
-    @Test
-    fun parseWithCharsetParameter() {
-        val mediaRange = MediaRange.parse("text/html;level = 1 ; strict = true;charset=us-ascii")
-        assertThat(mediaRange.type).isEqualTo("text")
-        assertThat(mediaRange.subtype).isEqualTo("html")
-        assertThat(mediaRange.charset).isEqualTo(Charsets.US_ASCII)
-        assertThat(mediaRange.extensions).isEmpty()
-        assertThat(mediaRange.parameters).containsExactly("level" to "1", "strict" to "true")
-        assertThat(mediaRange.qualityFactor).isCloseTo(1.0, Offset.offset(0.01))
+  @Test
+  fun blankNameToken() {
+    assertThrows(IllegalArgumentException::class.java) {
+      MediaRange.parse("text/html;=foo")
     }
+  }
 
-    @Test
-    fun parseWithQualityFactor() {
-        val mediaRange = MediaRange.parse(
-                "text/html;level = 1 ; strict = true;charset=us-ascii; q = 0.45")
-        assertThat(mediaRange.type).isEqualTo("text")
-        assertThat(mediaRange.subtype).isEqualTo("html")
-        assertThat(mediaRange.charset).isEqualTo(Charsets.US_ASCII)
-        assertThat(mediaRange.extensions).isEmpty()
-        assertThat(mediaRange.parameters).containsExactly("level" to "1", "strict" to "true")
-        assertThat(mediaRange.qualityFactor).isCloseTo(0.45, Offset.offset(0.01))
+  @Test
+  fun blankValueToken() {
+    assertThrows(IllegalArgumentException::class.java) {
+      MediaRange.parse("text/html;bar=")
     }
+  }
 
-    @Test
-    fun parseWithExtensions() {
-        val mediaRange = MediaRange.parse(
-                "text/html;level = 1 ; strict = true;charset=us-ascii; q = 0.45; ext1=79; ext2=blerp")
-        assertThat(mediaRange.type).isEqualTo("text")
-        assertThat(mediaRange.subtype).isEqualTo("html")
-        assertThat(mediaRange.charset).isEqualTo(Charsets.US_ASCII)
-        assertThat(mediaRange.extensions).containsExactly("ext1" to "79", "ext2" to "blerp")
-        assertThat(mediaRange.parameters).containsExactly("level" to "1", "strict" to "true")
-        assertThat(mediaRange.qualityFactor).isCloseTo(0.45, Offset.offset(0.01))
+  @Test
+  fun multipleQualityFactors() {
+    assertThrows(IllegalArgumentException::class.java) {
+      MediaRange.parse("text/html;q=0.4;q=0.56")
     }
+  }
 
-    @Test
-    fun wildcardTypeWithSpecificSubType() {
-        assertThrows(IllegalArgumentException::class.java) {
-            MediaRange.parse("*/html")
-        }
+  @Test
+  fun charsetInExtensions() {
+    assertThrows(IllegalArgumentException::class.java) {
+      MediaRange.parse("text/html;q=0.4;charset=utf-8")
     }
+  }
 
-    @Test
-    fun blankType() {
-        assertThrows(IllegalArgumentException::class.java) {
-            MediaRange.parse("/html")
-        }
-    }
+  @Test
+  fun matchTypeWildcard() {
+    val mediaRange = MediaRange.parse("*/*")
+    assertThat(mediaRange.matcher(MediaType.parse("text/html")!!)).isNotNull()
+    assertThat(mediaRange.matcher(MediaType.parse("text/plain")!!)).isNotNull()
+    assertThat(mediaRange.matcher(MediaType.parse("application/json")!!)).isNotNull()
+  }
 
-    @Test
-    fun blankSubType() {
-        assertThrows(IllegalArgumentException::class.java) {
-            MediaRange.parse("text/")
-        }
-    }
+  @Test
+  fun matchSubtypeWildcard() {
+    val mediaRange = MediaRange.parse("text/*")
+    assertThat(mediaRange.matcher(MediaType.parse("text/html")!!)).isNotNull()
+    assertThat(mediaRange.matcher(MediaType.parse("text/plain")!!)).isNotNull()
+    assertThat(mediaRange.matcher(MediaType.parse("application/json")!!)).isNull()
+  }
 
-    @Test
-    fun noTypeSubType() {
-        assertThrows(IllegalArgumentException::class.java) {
-            MediaRange.parse("*")
-        }
-    }
+  @Test
+  fun matchExactTypeSubtype() {
+    val mediaRange = MediaRange.parse("text/html")
+    assertThat(mediaRange.matcher(MediaType.parse("text/html")!!)).isNotNull()
+    assertThat(mediaRange.matcher(MediaType.parse("text/plain")!!)).isNull()
+    assertThat(mediaRange.matcher(MediaType.parse("application/json")!!)).isNull()
+  }
 
-    @Test
-    fun blankNameToken() {
-        assertThrows(IllegalArgumentException::class.java) {
-            MediaRange.parse("text/html;=foo")
-        }
-    }
+  @Test
+  fun matchNoCharsetInMediaType() {
+    val mediaRange = MediaRange.parse("text/html;charset=utf-8")
+    val mediaType = MediaType.parse("text/html")!!
+    val matcher = mediaRange.matcher(mediaType)
 
-    @Test
-    fun blankValueToken() {
-        assertThrows(IllegalArgumentException::class.java) {
-            MediaRange.parse("text/html;bar=")
-        }
-    }
+    assertThat(matcher).isNotNull()
+    assertThat(matcher!!.matchesCharset).isFalse()
+  }
 
-    @Test
-    fun multipleQualityFactors() {
-        assertThrows(IllegalArgumentException::class.java) {
-            MediaRange.parse("text/html;q=0.4;q=0.56")
-        }
-    }
+  @Test
+  fun matchNoCharsetInMediaRange() {
+    val mediaRange = MediaRange.parse("text/html")
+    val mediaType = MediaType.parse("text/html;charset=utf-8")!!
+    val matcher = mediaRange.matcher(mediaType)
 
-    @Test
-    fun charsetInExtensions() {
-        assertThrows(IllegalArgumentException::class.java) {
-            MediaRange.parse("text/html;q=0.4;charset=utf-8")
-        }
-    }
+    assertThat(matcher).isNotNull()
+    assertThat(matcher!!.matchesCharset).isFalse()
+  }
 
-    @Test
-    fun matchTypeWildcard() {
-        val mediaRange = MediaRange.parse("*/*")
-        assertThat(mediaRange.matcher(MediaType.parse("text/html")!!)).isNotNull()
-        assertThat(mediaRange.matcher(MediaType.parse("text/plain")!!)).isNotNull()
-        assertThat(mediaRange.matcher(MediaType.parse("application/json")!!)).isNotNull()
-    }
+  @Test
+  fun charsetsDoNotMatch() {
+    val mediaRange = MediaRange.parse("text/html;charset=us-ascii")
+    val mediaType = MediaType.parse("text/html;charset=utf-8")!!
+    val matcher = mediaRange.matcher(mediaType)
 
-    @Test
-    fun matchSubtypeWildcard() {
-        val mediaRange = MediaRange.parse("text/*")
-        assertThat(mediaRange.matcher(MediaType.parse("text/html")!!)).isNotNull()
-        assertThat(mediaRange.matcher(MediaType.parse("text/plain")!!)).isNotNull()
-        assertThat(mediaRange.matcher(MediaType.parse("application/json")!!)).isNull()
-    }
+    assertThat(matcher).isNull()
+  }
 
-    @Test
-    fun matchExactTypeSubtype() {
-        val mediaRange = MediaRange.parse("text/html")
-        assertThat(mediaRange.matcher(MediaType.parse("text/html")!!)).isNotNull()
-        assertThat(mediaRange.matcher(MediaType.parse("text/plain")!!)).isNull()
-        assertThat(mediaRange.matcher(MediaType.parse("application/json")!!)).isNull()
-    }
+  @Test
+  fun charsetsMatch() {
+    val mediaRange = MediaRange.parse("text/html;charset=us-ascii")
+    val mediaType = MediaType.parse("text/html;charset=us-ascii")!!
+    val matcher = mediaRange.matcher(mediaType)
 
-    @Test
-    fun matchNoCharsetInMediaType() {
-        val mediaRange = MediaRange.parse("text/html;charset=utf-8")
-        val mediaType = MediaType.parse("text/html")!!
-        val matcher = mediaRange.matcher(mediaType)
+    assertThat(matcher).isNotNull()
+    assertThat(matcher!!.matchesCharset).isTrue()
+  }
 
-        assertThat(matcher).isNotNull()
-        assertThat(matcher!!.matchesCharset).isFalse()
-    }
+  @Test
+  fun compareTo() {
+    val r1 = MediaRange.parse("*/*")
+    val r2 = MediaRange.parse("text/*")
+    val r3 = MediaRange.parse("text/html")
+    val r4 = MediaRange.parse("text/html;charset=utf-8;level=1")
+    val r5 = MediaRange.parse("text/html;charset=utf-8;level=1;q=0.5;ext1=one")
+    val r6 = MediaRange.parse("text/html;charset=utf-8;level=1;f=zed")
 
-    @Test
-    fun matchNoCharsetInMediaRange() {
-        val mediaRange = MediaRange.parse("text/html")
-        val mediaType = MediaType.parse("text/html;charset=utf-8")!!
-        val matcher = mediaRange.matcher(mediaType)
+    val unsorted = mutableListOf(r1, r2, r3, r4, r5, r6)
+    shuffle(unsorted)
 
-        assertThat(matcher).isNotNull()
-        assertThat(matcher!!.matchesCharset).isFalse()
-    }
+    val sorted = unsorted.sorted()
+    assertThat(sorted).containsExactly(r6, r5, r4, r3, r2, r1)
+  }
 
-    @Test
-    fun charsetsDoNotMatch() {
-        val mediaRange = MediaRange.parse("text/html;charset=us-ascii")
-        val mediaType = MediaType.parse("text/html;charset=utf-8")!!
-        val matcher = mediaRange.matcher(mediaType)
+  // From https://developer.mozilla.org/en-US/docs/Web/HTTP/Content_negotiation/List_of_default_Accept_values
+  @Test
+  fun parsesDefaultBrowserValues() {
+    MediaRange.parseRanges("text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8")
 
-        assertThat(matcher).isNull()
-    }
-
-    @Test
-    fun charsetsMatch() {
-        val mediaRange = MediaRange.parse("text/html;charset=us-ascii")
-        val mediaType = MediaType.parse("text/html;charset=us-ascii")!!
-        val matcher = mediaRange.matcher(mediaType)
-
-        assertThat(matcher).isNotNull()
-        assertThat(matcher!!.matchesCharset).isTrue()
-    }
-
-    @Test
-    fun compareTo() {
-        val r1 = MediaRange.parse("*/*")
-        val r2 = MediaRange.parse("text/*")
-        val r3 = MediaRange.parse("text/html")
-        val r4 = MediaRange.parse("text/html;charset=utf-8;level=1")
-        val r5 = MediaRange.parse("text/html;charset=utf-8;level=1;q=0.5;ext1=one")
-        val r6 = MediaRange.parse("text/html;charset=utf-8;level=1;f=zed")
-
-        val unsorted = mutableListOf(r1, r2, r3, r4, r5, r6)
-        shuffle(unsorted)
-
-        val sorted = unsorted.sorted()
-        assertThat(sorted).containsExactly(r6, r5, r4, r3, r2, r1)
-    }
-
-    // From https://developer.mozilla.org/en-US/docs/Web/HTTP/Content_negotiation/List_of_default_Accept_values
-    @Test
-    fun parsesDefaultBrowserValues() {
-        MediaRange.parseRanges("text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8")
-
-        MediaRange.parseRanges(
-                "application/xml,application/xhtml+xml,text/html;q=0.9, text/plain;q=0.8,image/png,*/*;q=0.5"
-        )
-        MediaRange.parseRanges("text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8")
-        MediaRange.parseRanges(
-                "image/jpeg, application/x-ms-application, image/gif, application/xaml+xml, image/pjpeg, application/x-ms-xbap, application/x-shockwave-flash, application/msword, */*"
-        )
-        MediaRange.parseRanges("text/html, application/xhtml+xml, image/jxr, */*")
-        MediaRange.parseRanges(
-                "text/html, application/xml;q=0.9, application/xhtml+xml, image/png, image/webp, image/jpeg, image/gif, image/x-xbitmap, */*;q=0.1"
-        )
-    }
+    MediaRange.parseRanges(
+        "application/xml,application/xhtml+xml,text/html;q=0.9, text/plain;q=0.8,image/png,*/*;q=0.5"
+    )
+    MediaRange.parseRanges("text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8")
+    MediaRange.parseRanges(
+        "image/jpeg, application/x-ms-application, image/gif, application/xaml+xml, image/pjpeg, application/x-ms-xbap, application/x-shockwave-flash, application/msword, */*"
+    )
+    MediaRange.parseRanges("text/html, application/xhtml+xml, image/jxr, */*")
+    MediaRange.parseRanges(
+        "text/html, application/xml;q=0.9, application/xhtml+xml, image/png, image/webp, image/jpeg, image/gif, image/x-xbitmap, */*;q=0.1"
+    )
+  }
 }

--- a/misk/testing/src/main/kotlin/misk/cloud/fake/environment/FakeInstanceMetadataModule.kt
+++ b/misk/testing/src/main/kotlin/misk/cloud/fake/environment/FakeInstanceMetadataModule.kt
@@ -1,11 +1,11 @@
 package misk.cloud.fake.environment
 
-import misk.inject.KAbstractModule
 import misk.environment.InstanceMetadata
+import misk.inject.KAbstractModule
 
 /** Provides a hard-coded set of instance metadata */
 class FakeInstanceMetadataModule(val metadata: InstanceMetadata) : KAbstractModule() {
-    override fun configure() {
-        bind<InstanceMetadata>().toInstance(metadata)
-    }
+  override fun configure() {
+    bind<InstanceMetadata>().toInstance(metadata)
+  }
 }

--- a/misk/testing/src/main/kotlin/misk/cloud/fake/security/keys/FakeKeyManagementModule.kt
+++ b/misk/testing/src/main/kotlin/misk/cloud/fake/security/keys/FakeKeyManagementModule.kt
@@ -5,7 +5,8 @@ import misk.inject.asSingleton
 import misk.security.keys.KeyService
 
 class FakeKeyManagementModule : KAbstractModule() {
-    override fun configure() {
-        bind<KeyService>().to<FakeKeyService>().asSingleton()
-    }
+  override fun configure() {
+    bind<KeyService>().to<FakeKeyService>()
+        .asSingleton()
+  }
 }

--- a/misk/testing/src/main/kotlin/misk/cloud/fake/security/keys/FakeKeyService.kt
+++ b/misk/testing/src/main/kotlin/misk/cloud/fake/security/keys/FakeKeyService.kt
@@ -8,26 +8,32 @@ import javax.crypto.Cipher
 import javax.crypto.spec.SecretKeySpec
 
 class FakeKeyService : KeyService {
-    override fun encrypt(keyAlias: String, plainText: ByteString): ByteString {
-        val key = newSymmetricKey(keyAlias)
-        val cipher = Cipher.getInstance("AES")
-        cipher.init(Cipher.ENCRYPT_MODE, key)
-        return ByteString.of(ByteBuffer.wrap(cipher.doFinal(plainText.toByteArray())))
-    }
+  override fun encrypt(
+      keyAlias: String,
+      plainText: ByteString
+  ): ByteString {
+    val key = newSymmetricKey(keyAlias)
+    val cipher = Cipher.getInstance("AES")
+    cipher.init(Cipher.ENCRYPT_MODE, key)
+    return ByteString.of(ByteBuffer.wrap(cipher.doFinal(plainText.toByteArray())))
+  }
 
-    override fun decrypt(keyAlias: String, cipherText: ByteString): ByteString {
-        val key = newSymmetricKey(keyAlias)
-        val cipher = Cipher.getInstance("AES")
-        cipher.init(Cipher.DECRYPT_MODE, key)
-        return ByteString.of(ByteBuffer.wrap(cipher.doFinal(cipherText.toByteArray())))
-    }
+  override fun decrypt(
+      keyAlias: String,
+      cipherText: ByteString
+  ): ByteString {
+    val key = newSymmetricKey(keyAlias)
+    val cipher = Cipher.getInstance("AES")
+    cipher.init(Cipher.DECRYPT_MODE, key)
+    return ByteString.of(ByteBuffer.wrap(cipher.doFinal(cipherText.toByteArray())))
+  }
 
-    private fun newSymmetricKey(keyText: String): Key {
-        val keyInput = when (keyText.length) {
-            in 1..31 -> keyText + " ".repeat(32 - keyText.length)
-            32 -> keyText
-            else -> keyText.take(32)
-        }
-        return SecretKeySpec(keyInput.toByteArray(Charsets.US_ASCII), "AES");
+  private fun newSymmetricKey(keyText: String): Key {
+    val keyInput = when (keyText.length) {
+      in 1..31 -> keyText + " ".repeat(32 - keyText.length)
+      32 -> keyText
+      else -> keyText.take(32)
     }
+    return SecretKeySpec(keyInput.toByteArray(Charsets.US_ASCII), "AES");
+  }
 }

--- a/misk/testing/src/main/kotlin/misk/cloud/gcp/FakeGoogleCloudModule.kt
+++ b/misk/testing/src/main/kotlin/misk/cloud/gcp/FakeGoogleCloudModule.kt
@@ -6,8 +6,8 @@ import misk.inject.KAbstractModule
 
 /** Installs testing support for running against google cloud emulators */
 internal class FakeGoogleCloudModule : KAbstractModule() {
-    override fun configure() {
-        install(FakeDatastoreModule())
-        install(FakeStorageModule())
-    }
+  override fun configure() {
+    install(FakeDatastoreModule())
+    install(FakeStorageModule())
+  }
 }

--- a/misk/testing/src/main/kotlin/misk/cloud/gcp/datastore/FakeDatastoreModule.kt
+++ b/misk/testing/src/main/kotlin/misk/cloud/gcp/datastore/FakeDatastoreModule.kt
@@ -13,40 +13,41 @@ import javax.inject.Inject
 
 /** Installs a version of the [Datastore] that works off an in-memory local store */
 class FakeDatastoreModule : KAbstractModule() {
-    override fun configure() {
-        binder().addMultibinderBinding<Service>().to<FakeDatastoreService>()
+  override fun configure() {
+    binder().addMultibinderBinding<Service>()
+        .to<FakeDatastoreService>()
+  }
+
+  @Provides
+  @Singleton
+  fun provideDatastoreHelper(): LocalDatastoreHelper = datastoreHelper.value
+
+  @Provides
+  @Singleton
+  fun provideDatastore(datastoreHelper: LocalDatastoreHelper): Datastore =
+      datastoreHelper.options.service
+
+  @Singleton
+  class FakeDatastoreService @Inject constructor(
+      private val datastoreHelper: LocalDatastoreHelper
+  ) : AbstractIdleService() {
+
+    override fun startUp() {
+      // Reset on every restart / test run
+      datastoreHelper.reset()
     }
 
-    @Provides
-    @Singleton
-    fun provideDatastoreHelper(): LocalDatastoreHelper = datastoreHelper.value
+    override fun shutDown() {}
+  }
 
-    @Provides
-    @Singleton
-    fun provideDatastore(datastoreHelper: LocalDatastoreHelper): Datastore =
-            datastoreHelper.options.service
-
-    @Singleton
-    class FakeDatastoreService @Inject constructor(
-            private val datastoreHelper: LocalDatastoreHelper
-    ) : AbstractIdleService() {
-
-        override fun startUp() {
-            // Reset on every restart / test run
-            datastoreHelper.reset()
-        }
-
-        override fun shutDown() {}
+  // NB(mmihic): We use a VM-wide singleton for the datastore because starting the datastore
+  // service is expensive, and we don't want to do it for every test.
+  companion object {
+    private val datastoreHelper = lazy {
+      // Start as soon as we create it
+      val helper = LocalDatastoreHelper.create(1.0)
+      helper.start()
+      helper
     }
-
-    // NB(mmihic): We use a VM-wide singleton for the datastore because starting the datastore
-    // service is expensive, and we don't want to do it for every test.
-    companion object {
-        private val datastoreHelper = lazy {
-            // Start as soon as we create it
-            val helper = LocalDatastoreHelper.create(1.0)
-            helper.start()
-            helper
-        }
-    }
+  }
 }

--- a/misk/testing/src/main/kotlin/misk/cloud/gcp/storage/CustomStorageRpcTestCases.kt
+++ b/misk/testing/src/main/kotlin/misk/cloud/gcp/storage/CustomStorageRpcTestCases.kt
@@ -18,368 +18,430 @@ import java.nio.ByteBuffer
 
 /** Test cases covering custom storage RPC implementations, used for testing local and in-memory storage */
 internal abstract class CustomStorageRpcTestCases<T : StorageRpc> {
-    lateinit var rpc: T
-    lateinit var storage: Storage
+  lateinit var rpc: T
+  lateinit var storage: Storage
 
-    @BeforeEach
-    fun buildStorage() {
-        rpc = newStorageRpc()
-        storage = StorageOptions.newBuilder()
-                .setCredentials(NoCredentials.getInstance())
-                .setServiceRpcFactory { _ -> rpc }
-                .build()
-                .service
+  @BeforeEach
+  fun buildStorage() {
+    rpc = newStorageRpc()
+    storage = StorageOptions.newBuilder()
+        .setCredentials(NoCredentials.getInstance())
+        .setServiceRpcFactory { _ -> rpc }
+        .build()
+        .service
+  }
+
+  @Test
+  fun createEmpty() {
+    val blobId = BlobId.of("my_bucket", "my_entry")
+    val result = storage.create(
+        BlobInfo.newBuilder(blobId)
+            .setContentType("text/plain")
+            .build()
+    )
+
+    assertThat(result.blobId).isEqualTo(BlobId.of(blobId.bucket, blobId.name, 1))
+    assertThat(result.generation).isEqualTo(1)
+    assertThat(result.metageneration).isEqualTo(1)
+    assertThat(result.contentType).isEqualTo("text/plain")
+    assertThat(result.getContent()).isEmpty()
+  }
+
+  @Test
+  fun createWithContent() {
+    val contents = "This is my text"
+    val blobId = BlobId.of("my_bucket", "my_entry")
+    val result = storage.create(
+        BlobInfo.newBuilder(blobId)
+            .setContentType("text/plain")
+            .build(), contents.toByteArray()
+    )
+
+    assertThat(result.blobId).isEqualTo(BlobId.of(blobId.bucket, blobId.name, 1))
+    assertThat(result.generation).isEqualTo(1)
+    assertThat(result.metageneration).isEqualTo(1)
+    assertThat(result.contentType).isEqualTo("text/plain")
+    assertThat(String(result.getContent())).isEqualTo("This is my text")
+  }
+
+  @Test
+  fun createIfNotExists() {
+    val contents = "This is my text"
+    val blobId = BlobId.of("my_bucket", "my_entry")
+    val result = storage.create(
+        BlobInfo.newBuilder(blobId)
+            .setContentType("text/plain")
+            .build(), contents.toByteArray(), Storage.BlobTargetOption.doesNotExist()
+    )
+
+    assertThat(result.blobId).isEqualTo(BlobId.of(blobId.bucket, blobId.name, 1))
+    assertThat(result.generation).isEqualTo(1)
+    assertThat(result.metageneration).isEqualTo(1)
+    assertThat(result.contentType).isEqualTo("text/plain")
+    assertThat(String(result.getContent())).isEqualTo("This is my text")
+
+    assertThrows(StorageException::class.java) {
+      val contents2 = "This is my text"
+      storage.create(
+          BlobInfo.newBuilder(blobId)
+              .setContentType("text/plain")
+              .build(), contents2.toByteArray(), Storage.BlobTargetOption.doesNotExist()
+      )
     }
+  }
 
-    @Test
-    fun createEmpty() {
-        val blobId = BlobId.of("my_bucket", "my_entry")
-        val result = storage.create(BlobInfo.newBuilder(blobId)
-                .setContentType("text/plain")
-                .build())
+  @Test
+  fun createIfGenerationMatches() {
+    val contents = "This is my text"
+    val blobId = BlobId.of("my_bucket", "my_entry")
+    val result = storage.create(
+        BlobInfo.newBuilder(blobId)
+            .setContentType("text/plain")
+            .build(), contents.toByteArray()
+    )
 
-        assertThat(result.blobId).isEqualTo(BlobId.of(blobId.bucket, blobId.name, 1))
-        assertThat(result.generation).isEqualTo(1)
-        assertThat(result.metageneration).isEqualTo(1)
-        assertThat(result.contentType).isEqualTo("text/plain")
-        assertThat(result.getContent()).isEmpty()
+    assertThat(result.blobId).isEqualTo(BlobId.of(blobId.bucket, blobId.name, 1))
+    assertThat(result.generation).isEqualTo(1)
+    assertThat(result.metageneration).isEqualTo(1)
+    assertThat(result.contentType).isEqualTo("text/plain")
+    assertThat(String(result.getContent())).isEqualTo("This is my text")
+
+    val contents2 = "This is another text"
+    val blobId2 = BlobId.of(blobId.bucket, blobId.name, result.generation)
+    val result2 = storage.create(
+        BlobInfo.newBuilder(blobId2)
+            .setContentType("text/plain")
+            .build(), contents2.toByteArray(), Storage.BlobTargetOption.generationMatch()
+    )
+
+    assertThat(result2.blobId).isEqualTo(BlobId.of(blobId.bucket, blobId.name, 2))
+    assertThat(result2.generation).isEqualTo(2)
+    assertThat(result2.metageneration).isEqualTo(1)
+    assertThat(result2.contentType).isEqualTo("text/plain")
+    assertThat(String(result.getContent())).isEqualTo("This is another text")
+
+    assertThrows(StorageException::class.java) {
+      val contents3 = "This is the third text"
+      storage.create(
+          BlobInfo.newBuilder(blobId2) // Old generation
+              .setContentType("text/plain")
+              .build(), contents3.toByteArray(), Storage.BlobTargetOption.generationMatch()
+      )
     }
+  }
 
-    @Test
-    fun createWithContent() {
-        val contents = "This is my text"
-        val blobId = BlobId.of("my_bucket", "my_entry")
-        val result = storage.create(BlobInfo.newBuilder(blobId)
-                .setContentType("text/plain")
-                .build(), contents.toByteArray())
+  @Test
+  fun createUpdatesMetagenerationIfMetadataChanged() {
+    val contents = "This is my text"
+    val blobId = BlobId.of("my_bucket", "my_entry")
+    val result = storage.create(
+        BlobInfo.newBuilder(blobId)
+            .setContentType("text/plain")
+            .setMetadata(mapOf("foo" to "bar"))
+            .build(), contents.toByteArray()
+    )
 
-        assertThat(result.blobId).isEqualTo(BlobId.of(blobId.bucket, blobId.name, 1))
-        assertThat(result.generation).isEqualTo(1)
-        assertThat(result.metageneration).isEqualTo(1)
-        assertThat(result.contentType).isEqualTo("text/plain")
-        assertThat(String(result.getContent())).isEqualTo("This is my text")
-    }
+    assertThat(result.generation).isEqualTo(1)
+    assertThat(result.metageneration).isEqualTo(1)
+    assertThat(result.contentType).isEqualTo("text/plain")
+    assertThat(result.metadata).isEqualTo(mapOf("foo" to "bar"))
 
-    @Test
-    fun createIfNotExists() {
-        val contents = "This is my text"
-        val blobId = BlobId.of("my_bucket", "my_entry")
-        val result = storage.create(BlobInfo.newBuilder(blobId)
-                .setContentType("text/plain")
-                .build(), contents.toByteArray(), Storage.BlobTargetOption.doesNotExist())
+    val contents2 = "This is another text"
+    val result2 = storage.create(
+        BlobInfo.newBuilder(blobId)
+            .setContentType("text/plain")
+            .setMetadata(mapOf("foo" to "zed"))
+            .build(), contents2.toByteArray()
+    )
 
-        assertThat(result.blobId).isEqualTo(BlobId.of(blobId.bucket, blobId.name, 1))
-        assertThat(result.generation).isEqualTo(1)
-        assertThat(result.metageneration).isEqualTo(1)
-        assertThat(result.contentType).isEqualTo("text/plain")
-        assertThat(String(result.getContent())).isEqualTo("This is my text")
+    assertThat(result2.generation).isEqualTo(2)
+    assertThat(result2.metageneration).isEqualTo(2)
+    assertThat(result2.contentType).isEqualTo("text/plain")
+    assertThat(result2.metadata).isEqualTo(mapOf("foo" to "zed"))
+  }
 
-        assertThrows(StorageException::class.java) {
-            val contents2 = "This is my text"
-            storage.create(BlobInfo.newBuilder(blobId)
-                    .setContentType("text/plain")
-                    .build(), contents2.toByteArray(), Storage.BlobTargetOption.doesNotExist())
-        }
-    }
+  @Test
+  fun progressiveUpload() {
+    val blobId = BlobId.of("my_bucket", "my_entry")
+    val blob = storage.create(
+        BlobInfo.newBuilder(blobId)
+            .setContentType("text/plain")
+            .build()
+    )
 
-    @Test
-    fun createIfGenerationMatches() {
-        val contents = "This is my text"
-        val blobId = BlobId.of("my_bucket", "my_entry")
-        val result = storage.create(BlobInfo.newBuilder(blobId)
-                .setContentType("text/plain")
-                .build(), contents.toByteArray())
-
-        assertThat(result.blobId).isEqualTo(BlobId.of(blobId.bucket, blobId.name, 1))
-        assertThat(result.generation).isEqualTo(1)
-        assertThat(result.metageneration).isEqualTo(1)
-        assertThat(result.contentType).isEqualTo("text/plain")
-        assertThat(String(result.getContent())).isEqualTo("This is my text")
-
-        val contents2 = "This is another text"
-        val blobId2 = BlobId.of(blobId.bucket, blobId.name, result.generation)
-        val result2 = storage.create(BlobInfo.newBuilder(blobId2)
-                .setContentType("text/plain")
-                .build(), contents2.toByteArray(), Storage.BlobTargetOption.generationMatch())
-
-        assertThat(result2.blobId).isEqualTo(BlobId.of(blobId.bucket, blobId.name, 2))
-        assertThat(result2.generation).isEqualTo(2)
-        assertThat(result2.metageneration).isEqualTo(1)
-        assertThat(result2.contentType).isEqualTo("text/plain")
-        assertThat(String(result.getContent())).isEqualTo("This is another text")
-
-        assertThrows(StorageException::class.java) {
-            val contents3 = "This is the third text"
-            storage.create(BlobInfo.newBuilder(blobId2) // Old generation
-                    .setContentType("text/plain")
-                    .build(), contents3.toByteArray(), Storage.BlobTargetOption.generationMatch())
-        }
-    }
-
-    @Test
-    fun createUpdatesMetagenerationIfMetadataChanged() {
-        val contents = "This is my text"
-        val blobId = BlobId.of("my_bucket", "my_entry")
-        val result = storage.create(BlobInfo.newBuilder(blobId)
-                .setContentType("text/plain")
-                .setMetadata(mapOf("foo" to "bar"))
-                .build(), contents.toByteArray())
-
-        assertThat(result.generation).isEqualTo(1)
-        assertThat(result.metageneration).isEqualTo(1)
-        assertThat(result.contentType).isEqualTo("text/plain")
-        assertThat(result.metadata).isEqualTo(mapOf("foo" to "bar"))
-
-        val contents2 = "This is another text"
-        val result2 = storage.create(BlobInfo.newBuilder(blobId)
-                .setContentType("text/plain")
-                .setMetadata(mapOf("foo" to "zed"))
-                .build(), contents2.toByteArray())
-
-        assertThat(result2.generation).isEqualTo(2)
-        assertThat(result2.metageneration).isEqualTo(2)
-        assertThat(result2.contentType).isEqualTo("text/plain")
-        assertThat(result2.metadata).isEqualTo(mapOf("foo" to "zed"))
-    }
-
-    @Test
-    fun progressiveUpload() {
-        val blobId = BlobId.of("my_bucket", "my_entry")
-        val blob = storage.create(BlobInfo.newBuilder(blobId)
-                .setContentType("text/plain")
-                .build())
-
-        val upload = "This is my text".repeat(1024 * 256)
-        blob.writer().use {
-                    // Use the minimum chunk size, which is smaller than the buffer size, to
-                    // ensure that we are sending multiple chunks
-                    it.setChunkSize(256 * 1024)
-                    it.write(ByteBuffer.wrap(upload.toByteArray()))
-                }
-
-        val download = blob.getContent()
-        assertThat(String(download)).isEqualTo(upload)
-    }
-
-    @Test
-    fun get() {
-        val contents = "This is my text"
-        val blobId = BlobId.of("my_bucket", "my_entry")
-        storage.create(BlobInfo.newBuilder(blobId)
-                .setContentType("text/plain")
-                .build(), contents.toByteArray())
-
-        val blob = storage.get(blobId)
-        assertThat(blob).isNotNull()
-        assertThat(blob.generation).isEqualTo(1)
-        assertThat(blob.metageneration).isEqualTo(1)
-        assertThat(blob.size).isEqualTo("This is my text".length.toLong())
-        assertThat(blob.exists()).isTrue()
-        assertThat(String(blob.getContent())).isEqualTo("This is my text")
-    }
-
-    @Test
-    fun getIfGenerationMatches() {
-        // Create the blob
-        val contents1 = "This is my text"
-        val blobId = BlobId.of("my_bucket", "my_entry")
-        storage.create(BlobInfo.newBuilder(blobId)
-                .setContentType("text/plain")
-                .build(), contents1.toByteArray())
-
-        val blob1 = storage.get(blobId)
-
-        // Update the blob
-        val contents2 = "This is another text"
-        storage.create(BlobInfo.newBuilder(BlobId.of(blobId.bucket, blobId.name, 1))
-                .setContentType("text/plain")
-                .build(), contents2.toByteArray())
-
-        // The prior returned blob should reflect the old state, and should not be accessible
-        // if generation matching is requested (since it has the old generation)
-        assertThat(blob1).isNotNull()
-        assertThat(blob1.generation).isEqualTo(1)
-        assertThat(blob1.metageneration).isEqualTo(1)
-        assertThat(blob1.size).isEqualTo(contents1.length.toLong())
-        assertThat(blob1.exists()).isTrue()
-        assertThat(String(blob1.getContent())).isEqualTo(contents2)
-        assertThrows(StorageException::class.java) {
-            blob1.getContent(BlobSourceOption.generationMatch())
+    val upload = "This is my text".repeat(1024 * 256)
+    blob.writer()
+        .use {
+          // Use the minimum chunk size, which is smaller than the buffer size, to
+          // ensure that we are sending multiple chunks
+          it.setChunkSize(256 * 1024)
+          it.write(ByteBuffer.wrap(upload.toByteArray()))
         }
 
-        // The newly returned blob should reflect the new state, and should be accessible even
-        // if generation match is requested (since it has the current generation)
-        val blob2 = storage.get(blobId)
-        assertThat(blob2).isNotNull()
-        assertThat(blob2.generation).isEqualTo(2)
-        assertThat(blob2.metageneration).isEqualTo(1)
-        assertThat(blob2.size).isEqualTo(contents2.length.toLong())
-        assertThat(blob2.exists()).isTrue()
-        assertThat(String(blob2.getContent(BlobSourceOption.generationMatch())))
-                .isEqualTo(contents2)
+    val download = blob.getContent()
+    assertThat(String(download)).isEqualTo(upload)
+  }
+
+  @Test
+  fun get() {
+    val contents = "This is my text"
+    val blobId = BlobId.of("my_bucket", "my_entry")
+    storage.create(
+        BlobInfo.newBuilder(blobId)
+            .setContentType("text/plain")
+            .build(), contents.toByteArray()
+    )
+
+    val blob = storage.get(blobId)
+    assertThat(blob).isNotNull()
+    assertThat(blob.generation).isEqualTo(1)
+    assertThat(blob.metageneration).isEqualTo(1)
+    assertThat(blob.size).isEqualTo("This is my text".length.toLong())
+    assertThat(blob.exists()).isTrue()
+    assertThat(String(blob.getContent())).isEqualTo("This is my text")
+  }
+
+  @Test
+  fun getIfGenerationMatches() {
+    // Create the blob
+    val contents1 = "This is my text"
+    val blobId = BlobId.of("my_bucket", "my_entry")
+    storage.create(
+        BlobInfo.newBuilder(blobId)
+            .setContentType("text/plain")
+            .build(), contents1.toByteArray()
+    )
+
+    val blob1 = storage.get(blobId)
+
+    // Update the blob
+    val contents2 = "This is another text"
+    storage.create(
+        BlobInfo.newBuilder(BlobId.of(blobId.bucket, blobId.name, 1))
+            .setContentType("text/plain")
+            .build(), contents2.toByteArray()
+    )
+
+    // The prior returned blob should reflect the old state, and should not be accessible
+    // if generation matching is requested (since it has the old generation)
+    assertThat(blob1).isNotNull()
+    assertThat(blob1.generation).isEqualTo(1)
+    assertThat(blob1.metageneration).isEqualTo(1)
+    assertThat(blob1.size).isEqualTo(contents1.length.toLong())
+    assertThat(blob1.exists()).isTrue()
+    assertThat(String(blob1.getContent())).isEqualTo(contents2)
+    assertThrows(StorageException::class.java) {
+      blob1.getContent(BlobSourceOption.generationMatch())
     }
 
-    @Test
-    fun getWhenNotExists() {
-        assertThat(storage.get(BlobId.of("my_bucket", "my_entry"))).isNull()
-    }
+    // The newly returned blob should reflect the new state, and should be accessible even
+    // if generation match is requested (since it has the current generation)
+    val blob2 = storage.get(blobId)
+    assertThat(blob2).isNotNull()
+    assertThat(blob2.generation).isEqualTo(2)
+    assertThat(blob2.metageneration).isEqualTo(1)
+    assertThat(blob2.size).isEqualTo(contents2.length.toLong())
+    assertThat(blob2.exists()).isTrue()
+    assertThat(String(blob2.getContent(BlobSourceOption.generationMatch())))
+        .isEqualTo(contents2)
+  }
 
-    @Test
-    fun delete() {
-        val contents = "This is my text"
-        val blobId = BlobId.of("my_bucket", "my_entry")
-        val result = storage.create(BlobInfo.newBuilder(blobId)
-                .setContentType("text/plain")
-                .build(), contents.toByteArray())
+  @Test
+  fun getWhenNotExists() {
+    assertThat(storage.get(BlobId.of("my_bucket", "my_entry"))).isNull()
+  }
 
-        val deleted = result.delete()
+  @Test
+  fun delete() {
+    val contents = "This is my text"
+    val blobId = BlobId.of("my_bucket", "my_entry")
+    val result = storage.create(
+        BlobInfo.newBuilder(blobId)
+            .setContentType("text/plain")
+            .build(), contents.toByteArray()
+    )
 
-        assertThat(deleted).isTrue()
-        assertThat(storage[result.blobId]).isNull()
-    }
+    val deleted = result.delete()
 
-    @Test
-    fun deleteIfGenerationMatch() {
-        // Create the blob
-        val contents1 = "This is my text"
-        val blobId = BlobId.of("my_bucket", "my_entry")
-        val blob1 = storage.create(BlobInfo.newBuilder(blobId)
-                .setContentType("text/plain")
-                .build(), contents1.toByteArray())
+    assertThat(deleted).isTrue()
+    assertThat(storage[result.blobId]).isNull()
+  }
 
-        // Update the blob
-        val contents2 = "This is another text"
-        val blob2 = storage.create(BlobInfo.newBuilder(blob1.blobId)
-                .setContentType("text/plain")
-                .build(), contents2.toByteArray())
+  @Test
+  fun deleteIfGenerationMatch() {
+    // Create the blob
+    val contents1 = "This is my text"
+    val blobId = BlobId.of("my_bucket", "my_entry")
+    val blob1 = storage.create(
+        BlobInfo.newBuilder(blobId)
+            .setContentType("text/plain")
+            .build(), contents1.toByteArray()
+    )
 
-        // Try to delete at the old generation - this should fail
-        val deleteOldVersion = blob1.delete(BlobSourceOption.generationMatch())
-        assertThat(deleteOldVersion).isFalse()
+    // Update the blob
+    val contents2 = "This is another text"
+    val blob2 = storage.create(
+        BlobInfo.newBuilder(blob1.blobId)
+            .setContentType("text/plain")
+            .build(), contents2.toByteArray()
+    )
 
-        // Delete at the new generation - this should succeed
-        val deleteNewVersion = blob2.delete(BlobSourceOption.generationMatch())
-        assertThat(deleteNewVersion).isTrue()
+    // Try to delete at the old generation - this should fail
+    val deleteOldVersion = blob1.delete(BlobSourceOption.generationMatch())
+    assertThat(deleteOldVersion).isFalse()
 
-        assertThat(storage[blob2.blobId]).isNull()
-    }
+    // Delete at the new generation - this should succeed
+    val deleteNewVersion = blob2.delete(BlobSourceOption.generationMatch())
+    assertThat(deleteNewVersion).isTrue()
 
-    @Test
-    fun deleteWhenNotExists() {
-        val deleted = storage.delete(BlobId.of("my_bucket", "my_entry"))
-        assertThat(deleted).isFalse()
-    }
+    assertThat(storage[blob2.blobId]).isNull()
+  }
 
-    @Test
-    fun progressiveDownload() {
-        val upload = "This is my text".repeat(1024 * 256)
-        val blobId = BlobId.of("my_bucket", "my_entry")
-        val blob = storage.create(BlobInfo.newBuilder(blobId)
-                .setContentType("text/plain")
-                .build(), upload.toByteArray())
+  @Test
+  fun deleteWhenNotExists() {
+    val deleted = storage.delete(BlobId.of("my_bucket", "my_entry"))
+    assertThat(deleted).isFalse()
+  }
 
-        val download = ByteBuffer.allocate(upload.length)
+  @Test
+  fun progressiveDownload() {
+    val upload = "This is my text".repeat(1024 * 256)
+    val blobId = BlobId.of("my_bucket", "my_entry")
+    val blob = storage.create(
+        BlobInfo.newBuilder(blobId)
+            .setContentType("text/plain")
+            .build(), upload.toByteArray()
+    )
 
-        // Read in smaller chunks
-        blob.reader().use {
-                    // Use the minimum chunk size, which is smaller than the buffer size, to
-                    // ensure that we are retrieving multiple chunks
-                    it.forEachChunk(256 * 1024) { buffer, _ -> download.put(buffer) }
-                }
+    val download = ByteBuffer.allocate(upload.length)
 
-        download.position(0)
-        assertThat(String(download.array())).isEqualTo(upload)
-    }
+    // Read in smaller chunks
+    blob.reader()
+        .use {
+          // Use the minimum chunk size, which is smaller than the buffer size, to
+          // ensure that we are retrieving multiple chunks
+          it.forEachChunk(256 * 1024) { buffer, _ -> download.put(buffer) }
+        }
 
-    @Test
-    fun copy() {
-        val data = "This is my text".repeat(1024 * 256)
-        val sourceBlobId = BlobId.of("my_bucket", "my_entry")
-        val sourceBlob = storage.create(BlobInfo.newBuilder(sourceBlobId)
-                .setContentType("text/plain")
-                .build(), data.toByteArray())
+    download.position(0)
+    assertThat(String(download.array())).isEqualTo(upload)
+  }
 
-        val targetBlobId = BlobId.of("my_bucket", "new_entry")
+  @Test
+  fun copy() {
+    val data = "This is my text".repeat(1024 * 256)
+    val sourceBlobId = BlobId.of("my_bucket", "my_entry")
+    val sourceBlob = storage.create(
+        BlobInfo.newBuilder(sourceBlobId)
+            .setContentType("text/plain")
+            .build(), data.toByteArray()
+    )
 
-        sourceBlob.copyTo(targetBlobId)
+    val targetBlobId = BlobId.of("my_bucket", "new_entry")
 
-        val targetBlob = storage.get(targetBlobId)
-        assertThat(String(targetBlob.getContent())).isEqualTo(data)
-    }
+    sourceBlob.copyTo(targetBlobId)
 
-    @Test
-    fun listFolders() {
-        storage.create(BlobInfo.newBuilder("my_bucket", "notes/storage/merp.txt")
-                .setContentType("text/plain")
-                .build(), "This is a merp".toByteArray())
-        storage.create(BlobInfo.newBuilder("my_bucket", "notes/storage/traif.txt")
-                .setContentType("text/plain")
-                .build(), "This is traif".toByteArray())
-        storage.create(BlobInfo.newBuilder("my_bucket", "notes/misc/blah.txt")
-                .setContentType("text/plain")
-                .build(), "This is a blah".toByteArray())
-        storage.create(BlobInfo.newBuilder("my_bucket", "notes/misc/boop.txt")
-                .setContentType("text/plain")
-                .build(), "This is a boop".toByteArray())
-        storage.create(BlobInfo.newBuilder("my_bucket", "notes/top.txt")
-                .setContentType("text/plain")
-                .build(), "This is at the top level of notes".toByteArray())
-        storage.create(BlobInfo.newBuilder("my_bucket", "notes/top2.txt")
-                .setContentType("text/plain")
-                .build(), "This is also at the top level of notes".toByteArray())
-        storage.create(BlobInfo.newBuilder("my_bucket", "images/storage.txt")
-                .setContentType("text/plain")
-                .build(), "This is about storage".toByteArray())
-        storage.create(BlobInfo.newBuilder("my_bucket", "images.txt")
-                .setContentType("text/plain")
-                .build(), "This documents images".toByteArray())
-        storage.create(BlobInfo.newBuilder("other_bucket", "protos.txt")
-                .setContentType("text/plain")
-                .build(), "These are protos in another bucket".toByteArray())
+    val targetBlob = storage.get(targetBlobId)
+    assertThat(String(targetBlob.getContent())).isEqualTo(data)
+  }
 
-        val all = storage.list("my_bucket")
-        assertThat(all.blobIds).containsExactlyInAnyOrder(
-                BlobId.of("my_bucket", "notes/storage/merp.txt", 1),
-                BlobId.of("my_bucket", "notes/storage/traif.txt", 1),
-                BlobId.of("my_bucket", "notes/misc/blah.txt", 1),
-                BlobId.of("my_bucket", "notes/misc/boop.txt", 1),
-                BlobId.of("my_bucket", "notes/top.txt", 1),
-                BlobId.of("my_bucket", "notes/top2.txt", 1),
-                BlobId.of("my_bucket", "images/storage.txt", 1),
-                BlobId.of("my_bucket", "images.txt", 1))
+  @Test
+  fun listFolders() {
+    storage.create(
+        BlobInfo.newBuilder("my_bucket", "notes/storage/merp.txt")
+            .setContentType("text/plain")
+            .build(), "This is a merp".toByteArray()
+    )
+    storage.create(
+        BlobInfo.newBuilder("my_bucket", "notes/storage/traif.txt")
+            .setContentType("text/plain")
+            .build(), "This is traif".toByteArray()
+    )
+    storage.create(
+        BlobInfo.newBuilder("my_bucket", "notes/misc/blah.txt")
+            .setContentType("text/plain")
+            .build(), "This is a blah".toByteArray()
+    )
+    storage.create(
+        BlobInfo.newBuilder("my_bucket", "notes/misc/boop.txt")
+            .setContentType("text/plain")
+            .build(), "This is a boop".toByteArray()
+    )
+    storage.create(
+        BlobInfo.newBuilder("my_bucket", "notes/top.txt")
+            .setContentType("text/plain")
+            .build(), "This is at the top level of notes".toByteArray()
+    )
+    storage.create(
+        BlobInfo.newBuilder("my_bucket", "notes/top2.txt")
+            .setContentType("text/plain")
+            .build(), "This is also at the top level of notes".toByteArray()
+    )
+    storage.create(
+        BlobInfo.newBuilder("my_bucket", "images/storage.txt")
+            .setContentType("text/plain")
+            .build(), "This is about storage".toByteArray()
+    )
+    storage.create(
+        BlobInfo.newBuilder("my_bucket", "images.txt")
+            .setContentType("text/plain")
+            .build(), "This documents images".toByteArray()
+    )
+    storage.create(
+        BlobInfo.newBuilder("other_bucket", "protos.txt")
+            .setContentType("text/plain")
+            .build(), "These are protos in another bucket".toByteArray()
+    )
 
-        val roots = storage.list("my_bucket", currentDirectory())
-        assertThat(roots.blobIds).containsExactlyInAnyOrder(
-                BlobId.of("my_bucket", "notes"),
-                BlobId.of("my_bucket", "images"),
-                BlobId.of("my_bucket", "images.txt", 1))
+    val all = storage.list("my_bucket")
+    assertThat(all.blobIds).containsExactlyInAnyOrder(
+        BlobId.of("my_bucket", "notes/storage/merp.txt", 1),
+        BlobId.of("my_bucket", "notes/storage/traif.txt", 1),
+        BlobId.of("my_bucket", "notes/misc/blah.txt", 1),
+        BlobId.of("my_bucket", "notes/misc/boop.txt", 1),
+        BlobId.of("my_bucket", "notes/top.txt", 1),
+        BlobId.of("my_bucket", "notes/top2.txt", 1),
+        BlobId.of("my_bucket", "images/storage.txt", 1),
+        BlobId.of("my_bucket", "images.txt", 1)
+    )
 
-        val subDir = storage.list("my_bucket", prefix("notes/"), currentDirectory())
-        assertThat(subDir.blobIds).containsExactlyInAnyOrder(
-                BlobId.of("my_bucket", "notes/misc"),
-                BlobId.of("my_bucket", "notes/storage"),
-                BlobId.of("my_bucket", "notes/top.txt", 1),
-                BlobId.of("my_bucket", "notes/top2.txt", 1))
+    val roots = storage.list("my_bucket", currentDirectory())
+    assertThat(roots.blobIds).containsExactlyInAnyOrder(
+        BlobId.of("my_bucket", "notes"),
+        BlobId.of("my_bucket", "images"),
+        BlobId.of("my_bucket", "images.txt", 1)
+    )
 
-        val subDirRecursive = storage.list("my_bucket", prefix("notes/"))
-        assertThat(subDirRecursive.blobIds).containsExactlyInAnyOrder(
-                BlobId.of("my_bucket", "notes/storage/merp.txt", 1),
-                BlobId.of("my_bucket", "notes/storage/traif.txt", 1),
-                BlobId.of("my_bucket", "notes/misc/blah.txt", 1),
-                BlobId.of("my_bucket", "notes/misc/boop.txt", 1),
-                BlobId.of("my_bucket", "notes/top.txt", 1),
-                BlobId.of("my_bucket", "notes/top2.txt", 1))
+    val subDir = storage.list("my_bucket", prefix("notes/"), currentDirectory())
+    assertThat(subDir.blobIds).containsExactlyInAnyOrder(
+        BlobId.of("my_bucket", "notes/misc"),
+        BlobId.of("my_bucket", "notes/storage"),
+        BlobId.of("my_bucket", "notes/top.txt", 1),
+        BlobId.of("my_bucket", "notes/top2.txt", 1)
+    )
 
-        val partialNameMatch =
-                storage.list("my_bucket", prefix("notes/s"), currentDirectory())
-        assertThat(partialNameMatch.blobIds).containsExactlyInAnyOrder(
-                BlobId.of("my_bucket", "notes/storage"))
+    val subDirRecursive = storage.list("my_bucket", prefix("notes/"))
+    assertThat(subDirRecursive.blobIds).containsExactlyInAnyOrder(
+        BlobId.of("my_bucket", "notes/storage/merp.txt", 1),
+        BlobId.of("my_bucket", "notes/storage/traif.txt", 1),
+        BlobId.of("my_bucket", "notes/misc/blah.txt", 1),
+        BlobId.of("my_bucket", "notes/misc/boop.txt", 1),
+        BlobId.of("my_bucket", "notes/top.txt", 1),
+        BlobId.of("my_bucket", "notes/top2.txt", 1)
+    )
 
-        val recursivePartialNameMatch = storage.list("my_bucket", prefix("notes/s"))
-        assertThat(recursivePartialNameMatch.blobIds).containsExactlyInAnyOrder(
-                BlobId.of("my_bucket", "notes/storage/merp.txt", 1),
-                BlobId.of("my_bucket", "notes/storage/traif.txt", 1))
-    }
+    val partialNameMatch =
+        storage.list("my_bucket", prefix("notes/s"), currentDirectory())
+    assertThat(partialNameMatch.blobIds).containsExactlyInAnyOrder(
+        BlobId.of("my_bucket", "notes/storage")
+    )
 
-    abstract fun newStorageRpc(): T
+    val recursivePartialNameMatch = storage.list("my_bucket", prefix("notes/s"))
+    assertThat(recursivePartialNameMatch.blobIds).containsExactlyInAnyOrder(
+        BlobId.of("my_bucket", "notes/storage/merp.txt", 1),
+        BlobId.of("my_bucket", "notes/storage/traif.txt", 1)
+    )
+  }
+
+  abstract fun newStorageRpc(): T
 }

--- a/misk/testing/src/main/kotlin/misk/cloud/gcp/storage/FakeStorageModule.kt
+++ b/misk/testing/src/main/kotlin/misk/cloud/gcp/storage/FakeStorageModule.kt
@@ -9,13 +9,13 @@ import misk.inject.KAbstractModule
 
 /** Installs an embeddable version of [Storage] that works in-memory */
 class FakeStorageModule : KAbstractModule() {
-    override fun configure() {}
+  override fun configure() {}
 
-    @Provides
-    @Singleton
-    fun provideStorage(): Storage = StorageOptions.newBuilder()
-            .setCredentials(NoCredentials.getInstance())
-            .setServiceRpcFactory({ _ -> InMemoryStorageRpc() })
-            .build()
-            .service
+  @Provides
+  @Singleton
+  fun provideStorage(): Storage = StorageOptions.newBuilder()
+      .setCredentials(NoCredentials.getInstance())
+      .setServiceRpcFactory({ _ -> InMemoryStorageRpc() })
+      .build()
+      .service
 }

--- a/misk/testing/src/main/kotlin/misk/cloud/gcp/storage/InMemoryStorageRpc.kt
+++ b/misk/testing/src/main/kotlin/misk/cloud/gcp/storage/InMemoryStorageRpc.kt
@@ -17,218 +17,238 @@ import kotlin.concurrent.write
  * for tests. This implementation is fully thread safe.
  */
 class InMemoryStorageRpc : BaseCustomStorageRpc() {
-    private val content = mutableMapOf<String, ByteArray>()
-    private val metadata = mutableMapOf<String, StorageObject>()
-    private val pendingContent = mutableMapOf<String, ByteArray>()
-    private val lock = ReentrantReadWriteLock()
+  private val content = mutableMapOf<String, ByteArray>()
+  private val metadata = mutableMapOf<String, StorageObject>()
+  private val pendingContent = mutableMapOf<String, ByteArray>()
+  private val lock = ReentrantReadWriteLock()
 
-    override fun create(
-            obj: StorageObject,
-            content: InputStream,
-            options: Map<StorageRpc.Option, *>
-    ): StorageObject? = lock.write {
-        val existing = options.check(metadata[obj.path])
-        val newGeneration = (existing?.generation ?: 0) + 1
-        val existingMetadata = existing?.metadata
-        val newMetaGeneration = when {
-            existingMetadata == null -> 1
-            existingMetadata != obj.metadata -> existing.metageneration + 1
-            else -> existing.metageneration
+  override fun create(
+      obj: StorageObject,
+      content: InputStream,
+      options: Map<StorageRpc.Option, *>
+  ): StorageObject? = lock.write {
+    val existing = options.check(metadata[obj.path])
+    val newGeneration = (existing?.generation ?: 0) + 1
+    val existingMetadata = existing?.metadata
+    val newMetaGeneration = when {
+      existingMetadata == null -> 1
+      existingMetadata != obj.metadata -> existing.metageneration + 1
+      else -> existing.metageneration
+    }
+
+    val contentBytes = toByteArray(content)
+    this.content[obj.path] = contentBytes
+
+    val newStorageObject = obj.clone()
+    newStorageObject.generation = newGeneration
+    newStorageObject.metageneration = newMetaGeneration
+    newStorageObject.setSize(BigInteger.valueOf(contentBytes.size.toLong()))
+    metadata[obj.path] = newStorageObject
+    newStorageObject
+  }
+
+  override fun list(
+      bucket: String,
+      options: Map<StorageRpc.Option, *>
+  ): Tuple<String, Iterable<StorageObject>> = lock.read {
+    val prefix = options[StorageRpc.Option.PREFIX]?.toString()?.trimStart('/') ?: ""
+
+    val matchingObjects = metadata.values.filter {
+      it.bucket == bucket && it.name.startsWith(prefix)
+    }
+
+    val delimiter = options[StorageRpc.Option.DELIMITER]?.toString()
+    val results = matchingObjects.map { obj ->
+      delimiter?.let {
+        // If the storage object has a folder delimiter after the prefix, we want to take
+        // just the initial folder name rather than the object iself
+        val subFolderEnd = obj.name.indexOf(delimiter, prefix.length)
+        if (subFolderEnd != -1) {
+          StorageObject()
+              .setName(obj.name.substring(0, subFolderEnd))
+              .setBucket(obj.bucket)
+              .setOwner(obj.owner)
+        } else obj
+      } ?: obj
+    }
+        .distinctBy { it.name }
+    return Tuple.of(null, results)
+  }
+
+  override fun get(
+      obj: StorageObject,
+      options: Map<StorageRpc.Option, *>
+  ): StorageObject? =
+      lock.read {
+        val existing = options.check(metadata[obj.path]) ?: return null
+        val toReturn = existing.clone()
+        toReturn.id = obj.path
+        toReturn.setSize(BigInteger.valueOf(content[obj.path]?.size?.toLong() ?: 0L))
+      }
+
+  override fun delete(
+      obj: StorageObject,
+      options: Map<StorageRpc.Option, *>
+  ): Boolean =
+      lock.write {
+        try {
+          options.check(metadata[obj.path])
+          content.remove(obj.path)
+          metadata.remove(obj.path) != null
+        } catch (e: StorageException) {
+          false
+        }
+      }
+
+  override fun load(
+      obj: StorageObject,
+      options: Map<StorageRpc.Option, *>
+  ): ByteArray =
+      lock.read {
+        options.check(metadata[obj.path])
+        return content[obj.path]
+            ?: throw StorageException(404, "file not found ${obj.path}")
+      }
+
+  override fun read(
+      from: StorageObject,
+      options: Map<StorageRpc.Option, *>,
+      zposition: Long,
+      zbytes: Int
+  ): Tuple<String, ByteArray> = lock.read {
+    options.check(metadata[from.path])
+    val bytes = content[from.path]
+        ?: throw StorageException(404, "fild not found ${from.path}")
+
+    val position = if (zposition >= 0) zposition.toInt() else 0
+    val amtRead = if (position + zbytes > bytes.size) bytes.size - position else zbytes
+    if (amtRead <= 0) return Tuple.of("etag-goes-here", ByteArray(0))
+    val result = bytes.copyOfRange(position, position + amtRead)
+    return Tuple.of("etag-goes-here", result)
+  }
+
+  override fun open(
+      obj: StorageObject,
+      options: Map<StorageRpc.Option, *>
+  ): String = lock.write {
+    val existing = options.check(metadata[obj.path])
+
+    val newObject = obj.clone()
+    newObject.generation = existing?.generation ?: 0L
+    newObject.metageneration = existing?.generation ?: 0L
+    metadata[obj.path] = newObject
+    return obj.path
+  }
+
+  override fun write(
+      uploadId: String,
+      toWrite: ByteArray,
+      toWriteOffset: Int,
+      destOffset: Long,
+      length: Int,
+      last: Boolean
+  ) {
+    lock.write {
+      val destBytes = pendingContent[uploadId]?.let { currentBytes ->
+        if (currentBytes.size < length + destOffset) {
+          // TODO(mmihic): WTF no bulk copy?
+          val newBytes = ByteArray(length + destOffset.toInt())
+          for (i in (0 until currentBytes.size)) newBytes[i] = currentBytes[i]
+          newBytes
+        } else currentBytes
+      } ?: ByteArray(length + destOffset.toInt())
+
+      for (i in (0 until length)) destBytes[i + destOffset.toInt()] = toWrite[i + toWriteOffset]
+      if (last) {
+        content[uploadId] = destBytes
+        pendingContent.remove(uploadId)
+
+        metadata[uploadId]?.let {
+          val newObject = it.clone()
+          newObject.generation++
+          metadata[uploadId] = newObject
+        }
+      } else {
+        pendingContent.put(uploadId, destBytes)
+      }
+    }
+  }
+
+  override fun openRewrite(request: StorageRpc.RewriteRequest): StorageRpc.RewriteResponse =
+      lock.write {
+        request.sourceOptions.check(metadata[request.source.path])
+            ?: throw StorageException(404, "file not found ${request.source.path}")
+
+        val existingTarget = request.targetOptions.check(metadata[request.target.path])
+        val newTarget = request.target.clone()
+        newTarget.generation = (existingTarget?.generation ?: 0) + 1
+        newTarget.metageneration = when {
+          existingTarget == null -> 1
+          existingTarget.metadata == newTarget.metadata -> existingTarget.metageneration
+          else -> existingTarget.metageneration + 1
         }
 
-        val contentBytes = toByteArray(content)
-        this.content[obj.path] = contentBytes
+        val sourceData = content[request.source.path]
+            ?: throw StorageException(404, "file not found ${request.source.path}")
 
-        val newStorageObject = obj.clone()
-        newStorageObject.generation = newGeneration
-        newStorageObject.metageneration = newMetaGeneration
-        newStorageObject.setSize(BigInteger.valueOf(contentBytes.size.toLong()))
-        metadata[obj.path] = newStorageObject
-        newStorageObject
-    }
-
-    override fun list(
-            bucket: String,
-            options: Map<StorageRpc.Option, *>
-    ): Tuple<String, Iterable<StorageObject>> = lock.read {
-        val prefix = options[StorageRpc.Option.PREFIX]?.toString()?.trimStart('/') ?: ""
-
-        val matchingObjects = metadata.values.filter {
-            it.bucket == bucket && it.name.startsWith(prefix)
-        }
-
-        val delimiter = options[StorageRpc.Option.DELIMITER]?.toString()
-        val results = matchingObjects.map { obj ->
-            delimiter?.let {
-                // If the storage object has a folder delimiter after the prefix, we want to take
-                // just the initial folder name rather than the object iself
-                val subFolderEnd = obj.name.indexOf(delimiter, prefix.length)
-                if (subFolderEnd != -1) {
-                    StorageObject()
-                            .setName(obj.name.substring(0, subFolderEnd))
-                            .setBucket(obj.bucket)
-                            .setOwner(obj.owner)
-                } else obj
-            } ?: obj
-        }.distinctBy { it.name }
-        return Tuple.of(null, results)
-    }
-
-    override fun get(obj: StorageObject, options: Map<StorageRpc.Option, *>): StorageObject? =
-            lock.read {
-                val existing = options.check(metadata[obj.path]) ?: return null
-                val toReturn = existing.clone()
-                toReturn.id = obj.path
-                toReturn.setSize(BigInteger.valueOf(content[obj.path]?.size?.toLong() ?: 0L))
-            }
-
-    override fun delete(obj: StorageObject, options: Map<StorageRpc.Option, *>): Boolean =
-            lock.write {
-                try {
-                    options.check(metadata[obj.path])
-                    content.remove(obj.path)
-                    metadata.remove(obj.path) != null
-                } catch (e: StorageException) {
-                    false
-                }
-            }
-
-    override fun load(obj: StorageObject, options: Map<StorageRpc.Option, *>): ByteArray =
-            lock.read {
-                options.check(metadata[obj.path])
-                return content[obj.path]
-                        ?: throw StorageException(404, "file not found ${obj.path}")
-            }
-
-    override fun read(
-            from: StorageObject,
-            options: Map<StorageRpc.Option, *>,
-            zposition: Long,
-            zbytes: Int
-    ): Tuple<String, ByteArray> = lock.read {
-        options.check(metadata[from.path])
-        val bytes = content[from.path]
-                ?: throw StorageException(404, "fild not found ${from.path}")
-
-        val position = if (zposition >= 0) zposition.toInt() else 0
-        val amtRead = if (position + zbytes > bytes.size) bytes.size - position else zbytes
-        if (amtRead <= 0) return Tuple.of("etag-goes-here", ByteArray(0))
-        val result = bytes.copyOfRange(position, position + amtRead)
-        return Tuple.of("etag-goes-here", result)
-    }
-
-    override fun open(obj: StorageObject, options: Map<StorageRpc.Option, *>): String = lock.write {
-        val existing = options.check(metadata[obj.path])
-
-        val newObject = obj.clone()
-        newObject.generation = existing?.generation ?: 0L
-        newObject.metageneration = existing?.generation ?: 0L
-        metadata[obj.path] = newObject
-        return obj.path
-    }
-
-    override fun write(
-            uploadId: String,
-            toWrite: ByteArray,
-            toWriteOffset: Int,
-            destOffset: Long,
-            length: Int,
-            last: Boolean
-    ) {
-        lock.write {
-            val destBytes = pendingContent[uploadId]?.let { currentBytes ->
-                if (currentBytes.size < length + destOffset) {
-                    // TODO(mmihic): WTF no bulk copy?
-                    val newBytes = ByteArray(length + destOffset.toInt())
-                    for (i in (0 until currentBytes.size)) newBytes[i] = currentBytes[i]
-                    newBytes
-                } else currentBytes
-            } ?: ByteArray(length + destOffset.toInt())
-
-            for (i in (0 until length)) destBytes[i + destOffset.toInt()] = toWrite[i + toWriteOffset]
-            if (last) {
-                content[uploadId] = destBytes
-                pendingContent.remove(uploadId)
-
-                metadata[uploadId]?.let {
-                    val newObject = it.clone()
-                    newObject.generation++
-                    metadata[uploadId] = newObject
-                }
-            } else {
-                pendingContent.put(uploadId, destBytes)
-            }
-        }
-    }
-
-    override fun openRewrite(request: StorageRpc.RewriteRequest): StorageRpc.RewriteResponse =
-            lock.write {
-                request.sourceOptions.check(metadata[request.source.path])
-                        ?: throw StorageException(404, "file not found ${request.source.path}")
-
-                val existingTarget = request.targetOptions.check(metadata[request.target.path])
-                val newTarget = request.target.clone()
-                newTarget.generation = (existingTarget?.generation ?: 0) + 1
-                newTarget.metageneration = when {
-                    existingTarget == null -> 1
-                    existingTarget.metadata == newTarget.metadata -> existingTarget.metageneration
-                    else -> existingTarget.metageneration + 1
-                }
-
-                val sourceData = content[request.source.path]
-                        ?: throw StorageException(404, "file not found ${request.source.path}")
-
-                metadata[request.target.path] = newTarget
-                content[request.target.path] = sourceData.copyOf()
-                return StorageRpc.RewriteResponse(
-                        request,
-                        request.target,
-                        sourceData.size.toLong(),
-                        true,
-                        "token",
-                        sourceData.size.toLong())
-            }
+        metadata[request.target.path] = newTarget
+        content[request.target.path] = sourceData.copyOf()
+        return StorageRpc.RewriteResponse(
+            request,
+            request.target,
+            sourceData.size.toLong(),
+            true,
+            "token",
+            sourceData.size.toLong()
+        )
+      }
 }
 
 fun Map<StorageRpc.Option, *>.check(obj: StorageObject?): StorageObject? {
-    forEach {
-        when (it.key) {
-            StorageRpc.Option.IF_GENERATION_MATCH ->
-                checkMatch(it.value, obj?.generation)
-            StorageRpc.Option.IF_GENERATION_NOT_MATCH ->
-                checkDoesNotMatch(it.value, obj?.generation)
-            StorageRpc.Option.IF_METAGENERATION_MATCH ->
-                checkMatch(it.value, obj?.metageneration)
-            StorageRpc.Option.IF_METAGENERATION_NOT_MATCH ->
-                checkDoesNotMatch(it.value, obj?.metageneration)
-            else -> {
-            }
-        }
+  forEach {
+    when (it.key) {
+      StorageRpc.Option.IF_GENERATION_MATCH ->
+        checkMatch(it.value, obj?.generation)
+      StorageRpc.Option.IF_GENERATION_NOT_MATCH ->
+        checkDoesNotMatch(it.value, obj?.generation)
+      StorageRpc.Option.IF_METAGENERATION_MATCH ->
+        checkMatch(it.value, obj?.metageneration)
+      StorageRpc.Option.IF_METAGENERATION_NOT_MATCH ->
+        checkDoesNotMatch(it.value, obj?.metageneration)
+      else -> {
+      }
     }
+  }
 
-    return obj
+  return obj
 }
 
-private fun checkMatch(value: Any?, objValue: Long?) {
-    val longValue = (value as? Number)?.toLong() ?: 0L
-    if (objValue == null) {
-        if (longValue != 0L) {
-            throw StorageException(FileAlreadyExistsException("already exists"))
-        }
-    } else if (longValue != objValue) {
-        throw StorageException(401, "generation mismatch; $longValue != $objValue")
+private fun checkMatch(
+    value: Any?,
+    objValue: Long?
+) {
+  val longValue = (value as? Number)?.toLong() ?: 0L
+  if (objValue == null) {
+    if (longValue != 0L) {
+      throw StorageException(FileAlreadyExistsException("already exists"))
     }
+  } else if (longValue != objValue) {
+    throw StorageException(401, "generation mismatch; $longValue != $objValue")
+  }
 }
 
-private fun checkDoesNotMatch(value: Any?, objValue: Long?) {
-    val longValue = (value as? Number)?.toLong() ?: 0L
-    if (objValue == null) {
-        if (longValue == 0L) {
-            throw StorageException(404, "file not found")
-        }
-    } else if (longValue == objValue) {
-        throw StorageException(401, "generation mismatch; $longValue == $objValue")
+private fun checkDoesNotMatch(
+    value: Any?,
+    objValue: Long?
+) {
+  val longValue = (value as? Number)?.toLong() ?: 0L
+  if (objValue == null) {
+    if (longValue == 0L) {
+      throw StorageException(404, "file not found")
     }
+  } else if (longValue == objValue) {
+    throw StorageException(401, "generation mismatch; $longValue == $objValue")
+  }
 }
 
 private val StorageObject.path get() = "$bucket/$name"

--- a/misk/testing/src/main/kotlin/misk/cloud/gcp/storage/InMemoryStorageRpcTest.kt
+++ b/misk/testing/src/main/kotlin/misk/cloud/gcp/storage/InMemoryStorageRpcTest.kt
@@ -1,5 +1,5 @@
 package misk.cloud.gcp.storage
 
 internal class InMemoryStorageRpcTest : CustomStorageRpcTestCases<InMemoryStorageRpc>() {
-    override fun newStorageRpc() = InMemoryStorageRpc()
+  override fun newStorageRpc() = InMemoryStorageRpc()
 }

--- a/misk/testing/src/main/kotlin/misk/cloud/gcp/storage/LocalStorageRpcTest.kt
+++ b/misk/testing/src/main/kotlin/misk/cloud/gcp/storage/LocalStorageRpcTest.kt
@@ -9,11 +9,11 @@ import javax.inject.Inject
 
 @MiskTest(startService = false)
 internal class LocalStorageRpcTest : CustomStorageRpcTestCases<LocalStorageRpc>() {
-    @MiskTestModule
-    val module = TemporaryFolderModule()
+  @MiskTestModule
+  val module = TemporaryFolderModule()
 
-    @Inject
-    private lateinit var tempFolder: TemporaryFolder
+  @Inject
+  private lateinit var tempFolder: TemporaryFolder
 
-    override fun newStorageRpc() = LocalStorageRpc(tempFolder.newFolder(), Moshi.Builder().build())
+  override fun newStorageRpc() = LocalStorageRpc(tempFolder.newFolder(), Moshi.Builder().build())
 }

--- a/misk/testing/src/main/kotlin/misk/testing/AfterEachExtensionModule.kt
+++ b/misk/testing/src/main/kotlin/misk/testing/AfterEachExtensionModule.kt
@@ -4,20 +4,20 @@ import com.google.inject.Module
 import misk.inject.KAbstractModule
 import misk.inject.addMultibinderBinding
 import org.junit.jupiter.api.extension.AfterEachCallback
-import org.junit.jupiter.api.extension.BeforeEachCallback
 import kotlin.reflect.KClass
 
 /** Module registering a callback that fires after each test */
 class AfterEachExtensionModule<T : AfterEachCallback> constructor(
-        private val kclass: KClass<T>
+    private val kclass: KClass<T>
 ) : KAbstractModule() {
 
-    override fun configure() {
-        binder().addMultibinderBinding<AfterEachCallback>().to(kclass.java)
-    }
+  override fun configure() {
+    binder().addMultibinderBinding<AfterEachCallback>()
+        .to(kclass.java)
+  }
 
-    companion object{
-        inline fun <reified T: AfterEachCallback> create() : Module =
-                AfterEachExtensionModule(T::class)
-    }
+  companion object {
+    inline fun <reified T : AfterEachCallback> create(): Module =
+        AfterEachExtensionModule(T::class)
+  }
 }

--- a/misk/testing/src/main/kotlin/misk/testing/BeforeEachExtensionModule.kt
+++ b/misk/testing/src/main/kotlin/misk/testing/BeforeEachExtensionModule.kt
@@ -8,15 +8,16 @@ import kotlin.reflect.KClass
 
 /** Module registering a callback that fires before each test */
 class BeforeEachExtensionModule<T : BeforeEachCallback> constructor(
-        private val kclass: KClass<T>
+    private val kclass: KClass<T>
 ) : KAbstractModule() {
 
-    override fun configure() {
-        binder().addMultibinderBinding<BeforeEachCallback>().to(kclass.java)
-    }
+  override fun configure() {
+    binder().addMultibinderBinding<BeforeEachCallback>()
+        .to(kclass.java)
+  }
 
-    companion object{
-        inline fun <reified T: BeforeEachCallback> create() : Module =
-                BeforeEachExtensionModule(T::class)
-    }
+  companion object {
+    inline fun <reified T : BeforeEachCallback> create(): Module =
+        BeforeEachExtensionModule(T::class)
+  }
 }

--- a/misk/testing/src/main/kotlin/misk/testing/ExtensionContextExtensions.kt
+++ b/misk/testing/src/main/kotlin/misk/testing/ExtensionContextExtensions.kt
@@ -3,14 +3,17 @@ package misk.testing
 import org.junit.jupiter.api.extension.ExtensionContext
 
 /** Stores an object scoped to the test class on the context */
-fun <T> ExtensionContext.store(name: String, value: T) {
-    val namespace = ExtensionContext.Namespace.create(requiredTestClass)
-    getStore(namespace).put(name, value)
+fun <T> ExtensionContext.store(
+    name: String,
+    value: T
+) {
+  val namespace = ExtensionContext.Namespace.create(requiredTestClass)
+  getStore(namespace).put(name, value)
 }
 
 /** @return A previously stored object scoped to the test class */
 inline fun <reified T> ExtensionContext.retrieve(name: String): T {
-    val namespace = ExtensionContext.Namespace.create(requiredTestClass)
-    return getStore(namespace)[name, T::class.java]
+  val namespace = ExtensionContext.Namespace.create(requiredTestClass)
+  return getStore(namespace)[name, T::class.java]
 }
 

--- a/misk/testing/src/main/kotlin/misk/testing/MiskTestExtension.kt
+++ b/misk/testing/src/main/kotlin/misk/testing/MiskTestExtension.kt
@@ -7,8 +7,6 @@ import com.google.inject.Module
 import com.google.inject.util.Modules
 import misk.inject.getInstance
 import misk.inject.uninject
-import misk.testing.store
-import misk.testing.retrieve
 import org.junit.jupiter.api.extension.AfterEachCallback
 import org.junit.jupiter.api.extension.BeforeEachCallback
 import org.junit.jupiter.api.extension.ExtensionContext
@@ -16,94 +14,101 @@ import java.util.concurrent.TimeUnit
 import javax.inject.Inject
 
 internal class MiskTestExtension : BeforeEachCallback, AfterEachCallback {
+  override fun beforeEach(context: ExtensionContext) {
+    val testModules = context.getActionTestModules()
+        .asSequence()
+        .toList()
+        .toTypedArray()
+    val callbackModules = if (context.startService()) serviceManagementModules else arrayOf()
+    val modules = Modules.combine(MiskTestingModule(), *callbackModules, *testModules)
+
+    val injector = Guice.createInjector(modules)
+    injector.injectMembers(context.requiredTestInstance)
+    context.store("injector", injector)
+
+    injector.getInstance<Callbacks>()
+        .beforeEach(context)
+  }
+
+  override fun afterEach(context: ExtensionContext) {
+    val injector = context.retrieve<Injector>("injector")
+
+    injector.getInstance<Callbacks>()
+        .afterEach(context)
+    uninject(context.requiredTestInstance)
+  }
+
+  class StartServicesBeforeEach : BeforeEachCallback {
+    @Inject
+    lateinit var serviceManager: ServiceManager
+
     override fun beforeEach(context: ExtensionContext) {
-        val testModules = context.getActionTestModules().asSequence().toList().toTypedArray()
-        val callbackModules = if (context.startService()) serviceManagementModules else arrayOf()
-        val modules = Modules.combine(MiskTestingModule(), *callbackModules, *testModules)
-
-        val injector = Guice.createInjector(modules)
-        injector.injectMembers(context.requiredTestInstance)
-        context.store("injector", injector)
-
-        injector.getInstance<Callbacks>().beforeEach(context)
+      if (context.startService()) {
+        serviceManager.startAsync()
+        serviceManager.awaitHealthy(5, TimeUnit.SECONDS)
+      }
     }
+  }
+
+  class StopServicesAfterEach : AfterEachCallback {
+    @Inject
+    lateinit var serviceManager: ServiceManager
 
     override fun afterEach(context: ExtensionContext) {
-        val injector = context.retrieve<Injector>("injector")
+      if (context.startService()) {
+        serviceManager.stopAsync()
+      }
+    }
+  }
 
-        injector.getInstance<Callbacks>().afterEach(context)
-        uninject(context.requiredTestInstance)
+  private val serviceManagementModules = arrayOf(
+      BeforeEachExtensionModule.create<StartServicesBeforeEach>(),
+      AfterEachExtensionModule.create<StopServicesAfterEach>()
+  )
+
+  class Callbacks : BeforeEachCallback, AfterEachCallback {
+    @Inject
+    @JvmSuppressWildcards
+    lateinit var beforeEachCallbacks: Set<BeforeEachCallback>
+
+    @Inject
+    @JvmSuppressWildcards
+    lateinit var afterEachCallbacks: Set<AfterEachCallback>
+
+    override fun afterEach(context: ExtensionContext) {
+      afterEachCallbacks.forEach { it.afterEach(context) }
     }
 
-    class StartServicesBeforeEach : BeforeEachCallback {
-        @Inject
-        lateinit var serviceManager: ServiceManager
-
-        override fun beforeEach(context: ExtensionContext) {
-            if (context.startService()) {
-                serviceManager.startAsync()
-                serviceManager.awaitHealthy(5, TimeUnit.SECONDS)
-            }
-        }
+    override fun beforeEach(context: ExtensionContext) {
+      beforeEachCallbacks.forEach { it.beforeEach(context) }
     }
-
-    class StopServicesAfterEach : AfterEachCallback {
-        @Inject
-        lateinit var serviceManager: ServiceManager
-
-        override fun afterEach(context: ExtensionContext) {
-            if (context.startService()) {
-                serviceManager.stopAsync()
-            }
-        }
-    }
-
-    private val serviceManagementModules = arrayOf(
-            BeforeEachExtensionModule.create<StartServicesBeforeEach>(),
-            AfterEachExtensionModule.create<StopServicesAfterEach>()
-    )
-
-    class Callbacks : BeforeEachCallback, AfterEachCallback {
-        @Inject
-        @JvmSuppressWildcards
-        lateinit var beforeEachCallbacks: Set<BeforeEachCallback>
-
-        @Inject
-        @JvmSuppressWildcards
-        lateinit var afterEachCallbacks : Set<AfterEachCallback>
-
-        override fun afterEach(context: ExtensionContext) {
-            afterEachCallbacks.forEach { it.afterEach(context) }
-        }
-
-        override fun beforeEach(context: ExtensionContext) {
-            beforeEachCallbacks.forEach { it.beforeEach(context) }
-        }
-    }
+  }
 }
 
 private fun ExtensionContext.startService(): Boolean {
-    val namespace = ExtensionContext.Namespace.create(requiredTestClass)
-    // First check the context cache
-    return getStore(namespace).getOrComputeIfAbsent("startService",
-            { requiredTestClass.getAnnotationsByType(MiskTest::class.java)[0].startService },
-            Boolean::class.java)
+  val namespace = ExtensionContext.Namespace.create(requiredTestClass)
+  // First check the context cache
+  return getStore(namespace).getOrComputeIfAbsent(
+      "startService",
+      { requiredTestClass.getAnnotationsByType(MiskTest::class.java)[0].startService },
+      Boolean::class.java
+  )
 }
 
 private fun ExtensionContext.getActionTestModules(): Iterable<Module> {
-    val namespace = ExtensionContext.Namespace.create(requiredTestClass)
-    // First check the context cache
-    @Suppress("UNCHECKED_CAST")
-    return getStore(namespace).getOrComputeIfAbsent("module",
-            { modulesViaReflection() }) as Iterable<Module>
+  val namespace = ExtensionContext.Namespace.create(requiredTestClass)
+  // First check the context cache
+  @Suppress("UNCHECKED_CAST")
+  return getStore(namespace).getOrComputeIfAbsent("module",
+      { modulesViaReflection() }) as Iterable<Module>
 }
 
 private fun ExtensionContext.modulesViaReflection(): Iterable<Module> {
-    return requiredTestClass.declaredFields
-            .filter { it.isAnnotationPresent(MiskTestModule::class.java) }
-            .map {
-                it.isAccessible = true
-                it.get(requiredTestInstance) as Module
-            }
+  return requiredTestClass.declaredFields
+      .filter { it.isAnnotationPresent(MiskTestModule::class.java) }
+      .map {
+        it.isAccessible = true
+        it.get(requiredTestInstance) as Module
+      }
 }
 

--- a/misk/testing/src/main/kotlin/misk/testing/MiskTestingModule.kt
+++ b/misk/testing/src/main/kotlin/misk/testing/MiskTestingModule.kt
@@ -7,8 +7,8 @@ import org.junit.jupiter.api.extension.BeforeEachCallback
 
 /** Ensures there is always a binding for extension callbacks, even if none are registered */
 internal class MiskTestingModule : KAbstractModule() {
-    override fun configure() {
-        binder().newMultibinder<BeforeEachCallback>()
-        binder().newMultibinder<AfterEachCallback>()
-    }
+  override fun configure() {
+    binder().newMultibinder<BeforeEachCallback>()
+    binder().newMultibinder<AfterEachCallback>()
+  }
 }

--- a/misk/testing/src/main/kotlin/misk/testing/TemporaryFolder.kt
+++ b/misk/testing/src/main/kotlin/misk/testing/TemporaryFolder.kt
@@ -3,58 +3,54 @@ package misk.testing
 import com.google.inject.Provides
 import misk.inject.KAbstractModule
 import org.junit.jupiter.api.extension.AfterEachCallback
-import org.junit.jupiter.api.extension.BeforeEachCallback
-import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.api.extension.ExtensionContext
 import java.nio.file.Files
 import java.nio.file.Path
 import javax.inject.Inject
 import javax.inject.Singleton
-import kotlin.reflect.KMutableProperty
-import kotlin.reflect.full.createType
-import kotlin.reflect.full.isSubtypeOf
-import kotlin.reflect.full.memberProperties
 
 /** A temporary folder for use by a given test */
 class TemporaryFolder(val root: Path) {
-    /** Deletes all files and folders under the temporary folder */
-    fun delete() {
-        root.toFile().deleteRecursively()
-    }
+  /** Deletes all files and folders under the temporary folder */
+  fun delete() {
+    root.toFile()
+        .deleteRecursively()
+  }
 
-    /** @return a new folder with a randomly generated name */
-    fun newFolder(): Path = Files.createTempDirectory(root, "")
+  /** @return a new folder with a randomly generated name */
+  fun newFolder(): Path = Files.createTempDirectory(root, "")
 
-    /** @return a new folder with the given name */
-    fun newFolder(name: String): Path = Files.createDirectories(root.resolve(name))
+  /** @return a new folder with the given name */
+  fun newFolder(name: String): Path = Files.createDirectories(root.resolve(name))
 
-    /** @return a new file with a randomly generated name */
-    fun newFile(): Path = Files.createTempFile(root, "", "")
+  /** @return a new file with a randomly generated name */
+  fun newFile(): Path = Files.createTempFile(root, "", "")
 
-    /** @return a new file with the given name */
-    fun newFile(name: String): Path = Files.createFile(root.resolve(name))
+  /** @return a new file with the given name */
+  fun newFile(name: String): Path = Files.createFile(root.resolve(name))
 }
 
 class TemporaryFolderModule : KAbstractModule() {
-    override fun configure() {
-        install(AfterEachExtensionModule.create<DeleteTempFolder>())
+  override fun configure() {
+    install(AfterEachExtensionModule.create<DeleteTempFolder>())
+  }
+
+  @Provides
+  @Singleton
+  fun provideTemporaryFolder(): TemporaryFolder {
+    val tempDir = Files.createTempDirectory("test-")
+    tempDir.toFile()
+        .deleteOnExit()
+
+    return TemporaryFolder(tempDir)
+  }
+
+  class DeleteTempFolder : AfterEachCallback {
+    @Inject
+    lateinit var tempDir: TemporaryFolder
+
+    override fun afterEach(context: ExtensionContext) {
+      tempDir.delete()
     }
-
-    @Provides
-    @Singleton
-    fun provideTemporaryFolder() : TemporaryFolder {
-        val tempDir = Files.createTempDirectory("test-")
-        tempDir.toFile().deleteOnExit()
-
-        return TemporaryFolder(tempDir)
-    }
-
-    class DeleteTempFolder : AfterEachCallback {
-        @Inject
-        lateinit var tempDir: TemporaryFolder
-
-        override fun afterEach(context: ExtensionContext) {
-            tempDir.delete()
-        }
-    }
+  }
 }

--- a/misk/testing/src/main/kotlin/misk/testing/TestWebModule.kt
+++ b/misk/testing/src/main/kotlin/misk/testing/TestWebModule.kt
@@ -6,9 +6,9 @@ import misk.web.WebConfig
 import javax.inject.Singleton
 
 class TestWebModule : KAbstractModule() {
-    override fun configure() {}
+  override fun configure() {}
 
-    @Provides
-    @Singleton
-    fun provideWebConfig() = WebConfig(0, 500000)
+  @Provides
+  @Singleton
+  fun provideWebConfig() = WebConfig(0, 500000)
 }

--- a/misk/testing/src/main/kotlin/misk/time/FakeClock.kt
+++ b/misk/testing/src/main/kotlin/misk/time/FakeClock.kt
@@ -7,17 +7,23 @@ import java.time.ZoneId
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicLong
 
-class FakeClock(epochMillis: Long = 0, private val zone: ZoneId = ZoneId.of("UTC")) : Clock() {
+class FakeClock(
+    epochMillis: Long = 0,
+    private val zone: ZoneId = ZoneId.of("UTC")
+) : Clock() {
 
-    private val millis: AtomicLong = AtomicLong(epochMillis)
+  private val millis: AtomicLong = AtomicLong(epochMillis)
 
-    override fun getZone(): ZoneId = zone
+  override fun getZone(): ZoneId = zone
 
-    override fun withZone(zone: ZoneId): Clock = FakeClock(millis.get(), zone)
+  override fun withZone(zone: ZoneId): Clock = FakeClock(millis.get(), zone)
 
-    override fun instant(): Instant = Instant.ofEpochMilli(millis.get()).atZone(zone).toInstant()
+  override fun instant(): Instant = Instant.ofEpochMilli(millis.get()).atZone(zone).toInstant()
 
-    fun add(d: Duration) = millis.addAndGet(d.toMillis())
+  fun add(d: Duration) = millis.addAndGet(d.toMillis())
 
-    fun add(n: Long, unit: TimeUnit) = millis.addAndGet(TimeUnit.MILLISECONDS.convert(n, unit))
+  fun add(
+      n: Long,
+      unit: TimeUnit
+  ) = millis.addAndGet(TimeUnit.MILLISECONDS.convert(n, unit))
 }

--- a/misk/testing/src/main/kotlin/misk/time/FakeClockModule.kt
+++ b/misk/testing/src/main/kotlin/misk/time/FakeClockModule.kt
@@ -4,8 +4,8 @@ import misk.inject.KAbstractModule
 import java.time.Clock
 
 class FakeClockModule : KAbstractModule() {
-    override fun configure() {
-        bind<Clock>().to<FakeClock>()
-        bind<FakeClock>().asEagerSingleton()
-    }
+  override fun configure() {
+    bind<Clock>().to<FakeClock>()
+    bind<FakeClock>().asEagerSingleton()
+  }
 }


### PR DESCRIPTION
Most of the noise is coming from the change to indent spaces 2 instead
of the Kotlin standard of 4.

https://github.com/square/java-code-styles/pull/51

This is causing a lot of local diff noise when developing, so figured
one giant change was better.