### PR TITLE
Fix NotFoundAction handling

### DIFF
--- a/misk/src/main/kotlin/misk/web/WebActionModule.kt
+++ b/misk/src/main/kotlin/misk/web/WebActionModule.kt
@@ -20,24 +20,65 @@ import kotlin.reflect.KFunction
 import kotlin.reflect.full.findAnnotation
 
 class WebActionModule<A : WebAction> private constructor(
-        val webActionClass: KClass<A>,
-        val member: KFunction<*>,
-        val pathPattern: String,
-        val httpMethod: HttpMethod,
-        val acceptedContentTypes: List<MediaRange>,
-        val responseContentType: MediaType?
+        private val webActionClass: KClass<A>
 ) : AbstractModule() {
     override fun configure() {
-        val provider = getProvider(webActionClass.java)
         @Suppress("UNCHECKED_CAST")
         val binder: Multibinder<BoundAction<A, *>> = Multibinder.newSetBinder(
                 binder(),
                 parameterizedType<BoundAction<*, *>>(subtypeOf<WebAction>(),
                         subtypeOf<Any>()).typeLiteral()
         ) as Multibinder<BoundAction<A, *>>
-        binder.addBinding().toProvider(
-                        BoundActionProvider(provider, member, pathPattern, httpMethod,
-                                acceptedContentTypes, responseContentType))
+
+        // Find the function with Get or Post annotations. Only one such function is
+        // allow, but may have both Get and Post annotations if the action can handle
+        // both forms of HTTP method
+        val actionFunctions = webActionClass.members.mapNotNull {
+            if (it.findAnnotation<Get>() != null || it.findAnnotation<Post>() != null) {
+                it as? KFunction<*>
+                        ?: throw IllegalArgumentException("expected $it to be a function")
+            } else null
+        }
+
+        require(actionFunctions.isNotEmpty()) {
+            "no Get or Post annotations on ${webActionClass.simpleName}"
+        }
+
+        require(actionFunctions.size == 1) {
+            val actionFunctionNames = actionFunctions.joinToString(", ") { it.name }
+            "multiple annotated methods on ${webActionClass.simpleName}: $actionFunctionNames"
+        }
+
+        // Bind providers for each supported HTTP method
+        val actionFunction = actionFunctions.first()
+        val get = actionFunction.findAnnotation<Get>()
+        if (get != null) {
+            val getProvider = buildProvider(actionFunction, HttpMethod.GET, get.pathPattern)
+            binder.addBinding().toProvider(getProvider)
+        }
+
+        val post = actionFunction.findAnnotation<Post>()
+        if (post != null) {
+            val postProvider = buildProvider(actionFunction, HttpMethod.POST, post.pathPattern)
+            binder.addBinding().toProvider(postProvider)
+        }
+    }
+
+    private fun buildProvider(function: KFunction<*>, httpMethod: HttpMethod, pathPattern: String):
+            BoundActionProvider<A, *> {
+        // NB(mmihic): The response media type may be ommitted; in this case only
+        // generic return types (String, ByteString, ResponseBody, etc) are supported
+        val responseContentType = function.responseContentType
+        val acceptedContentTypes = function.acceptedContentTypes
+        val provider = getProvider(webActionClass.java)
+        return BoundActionProvider(
+                provider,
+                function,
+                pathPattern,
+                httpMethod,
+                acceptedContentTypes,
+                responseContentType
+        )
     }
 
     companion object {
@@ -49,34 +90,7 @@ class WebActionModule<A : WebAction> private constructor(
         }
 
         fun <A : WebAction> create(webActionClass: KClass<A>): WebActionModule<A> {
-            var result: WebActionModule<A>? = null
-
-            for (member in webActionClass.members) {
-                for (annotation in member.annotations) {
-                    if (annotation !is Get && annotation !is Post) continue
-                    if (member !is KFunction<*>) throw IllegalArgumentException(
-                            "expected $member to be a function")
-                    if (result != null) throw IllegalArgumentException(
-                            "multiple annotated methods in $webActionClass")
-
-                    // NB(mmihic): The response media type may be ommitted; in this case only
-                    // generic return types (String, ByteString, ResponseBody, etc) are supported
-                    val responseContentType = member.responseContentType
-                    val acceptedContentTypes = member.acceptedContentTypes
-
-                    result = when (annotation) {
-                        is Get -> WebActionModule(webActionClass, member, annotation.pathPattern,
-                                HttpMethod.GET, acceptedContentTypes, responseContentType)
-                        is Post -> WebActionModule(webActionClass, member, annotation.pathPattern,
-                                HttpMethod.POST, acceptedContentTypes, responseContentType)
-                        else -> throw AssertionError()
-                    }
-                }
-            }
-            if (result == null) {
-                throw IllegalArgumentException("no annotated methods in $webActionClass")
-            }
-            return result
+            return WebActionModule(webActionClass)
         }
     }
 }
@@ -94,20 +108,22 @@ private val KFunction<*>.responseContentType: MediaType?
 internal class BoundActionProvider<A : WebAction, R>(
         val provider: Provider<A>,
         val function: KFunction<R>,
-        val pathPattern: String,
-        val httpMethod: HttpMethod,
-        val acceptedContentTypes: List<MediaRange>,
-        val responseContentType: MediaType?
+        private val pathPattern: String,
+        private val httpMethod: HttpMethod,
+        private val acceptedContentTypes: List<MediaRange>,
+        private val responseContentType: MediaType?
 ) : Provider<BoundAction<A, *>> {
 
     @Inject
-    lateinit var userProvidedInterceptorFactories: List<Interceptor.Factory>
+    private lateinit var userProvidedInterceptorFactories: List<Interceptor.Factory>
+
     @Inject
     @JvmSuppressWildcards
     @MiskDefault
-    lateinit var miskInterceptorFactories: Set<Interceptor.Factory>
+    private lateinit var miskInterceptorFactories: Set<Interceptor.Factory>
+
     @Inject
-    lateinit var parameterExtractorFactories: List<ParameterExtractor.Factory>
+    private lateinit var parameterExtractorFactories: List<ParameterExtractor.Factory>
 
     override fun get(): BoundAction<A, *> {
         val action = function.asAction()

--- a/misk/src/main/kotlin/misk/web/actions/NotFoundAction.kt
+++ b/misk/src/main/kotlin/misk/web/actions/NotFoundAction.kt
@@ -2,18 +2,24 @@ package misk.web.actions
 
 import misk.web.Get
 import misk.web.PathParam
+import misk.web.Post
+import misk.web.RequestContentType
 import misk.web.Response
 import misk.web.ResponseContentType
 import misk.web.mediatype.MediaTypes
+import okhttp3.Headers
 import javax.inject.Singleton
 
 @Singleton
 class NotFoundAction : WebAction {
     @Get("/{path:.*}")
-    @ResponseContentType(MediaTypes.TEXT_PLAIN_UTF8)
+    @Post("/{path:.*}")
+    @RequestContentType(MediaTypes.ALL)
+    @ResponseContentType(MediaTypes.ALL)
     fun notFound(@PathParam path: String): Response<String> {
         return Response(
                 body = "Nothing found at /$path",
+                headers = Headers.of("Content-Type", MediaTypes.TEXT_PLAIN_UTF8),
                 statusCode = 404
         )
     }

--- a/misk/src/main/kotlin/misk/web/jetty/WebActionsServlet.kt
+++ b/misk/src/main/kotlin/misk/web/jetty/WebActionsServlet.kt
@@ -1,10 +1,12 @@
 package misk.web.jetty
 
+import misk.exceptions.StatusCode
 import misk.inject.keyOf
 import misk.scope.ActionScope
 import misk.web.BoundAction
 import misk.web.Request
 import misk.web.actions.WebAction
+import misk.web.mediatype.MediaTypes
 import okhttp3.Headers
 import okhttp3.HttpUrl
 import okio.Okio
@@ -40,7 +42,15 @@ internal class WebActionsServlet @Inject constructor(
                 it.match(request, asRequest.url)
             }.sorted()
 
-            candidateActions.firstOrNull()?.handle(asRequest, response)
+            val bestAction = candidateActions.firstOrNull()
+            if (bestAction != null) {
+                bestAction.handle(asRequest, response)
+            } else {
+                response.status = StatusCode.NOT_FOUND.code
+                response.addHeader("Content-Type", MediaTypes.TEXT_PLAIN_UTF8)
+                response.writer.print("Nothing found at /${asRequest.url.encodedPath()}")
+                response.writer.close()
+            }
         }
     }
 }

--- a/misk/src/test/kotlin/misk/web/actions/NotFoundActionTest.kt
+++ b/misk/src/test/kotlin/misk/web/actions/NotFoundActionTest.kt
@@ -1,17 +1,126 @@
 package misk.web.actions
 
-import org.assertj.core.api.Assertions.assertThat
+import com.google.inject.util.Modules
+import com.squareup.moshi.Moshi
+import misk.MiskModule
 import misk.testing.MiskTest
-import misk.web.Response
+import misk.testing.MiskTestModule
+import misk.testing.TestWebModule
+import misk.web.WebActionModule
+import misk.web.WebModule
+import misk.web.jetty.JettyService
+import misk.web.mediatype.MediaTypes
+import misk.web.mediatype.asMediaType
+import okhttp3.MediaType
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import javax.inject.Inject
 
-@MiskTest
+@MiskTest(startService = true)
 class NotFoundActionTest {
-    @Inject lateinit var notFoundAction: NotFoundAction
+    @MiskTestModule
+    val module = Modules.combine(
+            MiskModule(),
+            WebModule(),
+            TestWebModule(),
+            WebActionModule.create<NotFoundAction>())
+
+    val httpClient = OkHttpClient()
+
+    data class Packet(val message: String)
+
+    private val jsonMediaType = MediaTypes.APPLICATION_JSON.asMediaType()
+    private val plainTextMediaType = MediaTypes.TEXT_PLAIN_UTF8.asMediaType()
+    private val weirdMediaType = "application/weird".asMediaType()
+
+    private @Inject
+    lateinit var moshi: Moshi
+
+    private @Inject
+    lateinit var jettyService: JettyService
+
+    private val packetJsonAdapter get() = moshi.adapter(Packet::class.java)
 
     @Test
-    fun test() {
-        assertThat(notFoundAction.notFound("notfound")).isEqualTo(Response("Nothing found at /notfound", statusCode = 404))
+    fun postJsonExpectJsonPathNotFound() {
+        val requestContent = packetJsonAdapter.toJson(Packet("my friend"))
+        val request = post("/unknown", jsonMediaType, requestContent, jsonMediaType)
+        val response = httpClient.newCall(request).execute()
+        assertThat(response.code()).isEqualTo(404)
     }
+
+    @Test
+    fun postTextExpectTextPathNotFound() {
+        val request = post("/unknown", plainTextMediaType, "my friend", plainTextMediaType)
+        val response = httpClient.newCall(request).execute()
+        assertThat(response.code()).isEqualTo(404)
+    }
+
+    @Test
+    fun postArbitraryExpectArbitraryPathNotFound() {
+        val request = post("/unknown", weirdMediaType, "my friend", weirdMediaType)
+        val response = httpClient.newCall(request).execute()
+        assertThat(response.code()).isEqualTo(404)
+    }
+
+    @Test
+    fun getJsonPathNotFound() {
+        val request = get("/unknown", jsonMediaType)
+        val response = httpClient.newCall(request).execute()
+        assertThat(response.code()).isEqualTo(404)
+    }
+
+    @Test
+    fun getTextPathNotFound() {
+        val request = get("/unknown", plainTextMediaType)
+        val response = httpClient.newCall(request).execute()
+        assertThat(response.code()).isEqualTo(404)
+    }
+
+    @Test
+    fun getArbitraryPathNotFound() {
+        val request = get("/unknown", weirdMediaType)
+        val response = httpClient.newCall(request).execute()
+        assertThat(response.code()).isEqualTo(404)
+    }
+
+    @Test
+    fun headPathNotFound() {
+        val request = head("/unknown", weirdMediaType)
+        val response = httpClient.newCall(request).execute()
+        assertThat(response.code()).isEqualTo(404)
+    }
+
+    private fun head(path: String, acceptedMediaType: MediaType? = null): Request {
+        return Request.Builder()
+                .head()
+                .url(jettyService.serverUrl.newBuilder().encodedPath(path).build())
+                .header("Accept", acceptedMediaType.toString())
+                .build()
+    }
+
+    private fun get(path: String, acceptedMediaType: MediaType? = null): Request {
+        return Request.Builder()
+                .get()
+                .url(jettyService.serverUrl.newBuilder().encodedPath(path).build())
+                .header("Accept", acceptedMediaType.toString())
+                .build()
+    }
+
+    private fun post(
+            path: String,
+            contentType: MediaType,
+            content: String,
+            acceptedMediaType: MediaType? = null
+    ): Request {
+        return Request.Builder()
+                .post(RequestBody.create(contentType, content))
+                .url(jettyService.serverUrl.newBuilder().encodedPath(path).build())
+                .header("Accept", acceptedMediaType.toString())
+                .build()
+    }
+
 }


### PR DESCRIPTION
Previously POSTing to an unknown path would result in a 200 with an
empty response body, instead of the expected 404. Multiple problems:

1. The NotFoundAction was only bound for GET requests
2. The NotFoundAction only supported requests with Accept: text/plain

The NotFoundAction is now bound for both GET and POSTs, and supports
requests for any type of content (but always returns text/plain). Also
added a backstop in the WebActionsServlet to return a 404 if no suitable
action could be found; this handles cases where applications do not
install the NotFoundAction, or when a request arrives with an
unsupported HTTP method.