### PR TITLE
Allow binding an ExceptionMapper by an Exception type

### DIFF
--- a/misk/src/main/kotlin/misk/web/WebModule.kt
+++ b/misk/src/main/kotlin/misk/web/WebModule.kt
@@ -2,6 +2,7 @@ package misk.web
 
 import misk.Interceptor
 import misk.MiskDefault
+import misk.exceptions.ActionException
 import misk.inject.KAbstractModule
 import misk.inject.addMultibinderBinding
 import misk.inject.addMultibinderBindingWithAnnotation
@@ -70,7 +71,7 @@ class WebModule : KAbstractModule() {
         binder().addMultibinderBindingWithAnnotation<Interceptor.Factory, MiskDefault>().to<BoxResponseInterceptorFactory>()
 
         // Register build-in exception mappers
-        install(ExceptionMapperModule.create<ActionExceptionMapper>())
+        install(ExceptionMapperModule.create<ActionException, ActionExceptionMapper>())
 
         // Register built-in parameter extractors
         binder().addMultibinderBinding<ParameterExtractor.Factory>()

--- a/misk/src/main/kotlin/misk/web/exceptions/ExceptionHandlingInterceptor.kt
+++ b/misk/src/main/kotlin/misk/web/exceptions/ExceptionHandlingInterceptor.kt
@@ -11,6 +11,7 @@ import misk.web.Response
 import misk.web.marshal.StringResponseBody
 import misk.web.mediatype.MediaTypes
 import okhttp3.Headers
+import org.slf4j.event.Level
 import java.lang.reflect.InvocationTargetException
 import java.util.concurrent.ExecutionException
 import javax.inject.Inject
@@ -24,7 +25,7 @@ import javax.inject.Inject
  */
 class ExceptionHandlingInterceptor(
         private val actionName: String,
-        private val mappers: Set<ExceptionMapper<*>>
+        private val mapperResolver: ExceptionMapperResolver
 ) : Interceptor {
 
     override fun intercept(chain: Chain): Any? = try {
@@ -37,16 +38,11 @@ class ExceptionHandlingInterceptor(
         is ExecutionException -> toResponse(th.cause!!)
         is InvocationTargetException -> toResponse(th.targetException)
         is UncheckedExecutionException -> toResponse(th.cause!!)
-        else -> mapperFor(th)?.let {
+        else -> mapperResolver.mapperFor(th)?.let {
             log.log(it.loggingLevel(th), th) { "exception dispatching to $actionName" }
             it.toResponse(th)
         } ?: toInternalServerError(th)
     }
-
-    @Suppress("UNCHECKED_CAST")
-    private fun mapperFor(th: Throwable): ExceptionMapper<Throwable>? = mappers.firstOrNull {
-        it.canHandle(th)
-    } as ExceptionMapper<Throwable>?
 
     private fun toInternalServerError(th: Throwable): Response<*> {
         log.error(th) { "unexpected error dispatching to $actionName" }
@@ -54,9 +50,9 @@ class ExceptionHandlingInterceptor(
     }
 
     class Factory @Inject internal constructor(
-            private val mappers: MutableSet<ExceptionMapper<*>>
+        private val mapperResolver: ExceptionMapperResolver
     ) : Interceptor.Factory {
-        override fun create(action: Action) = ExceptionHandlingInterceptor(action.name, mappers)
+        override fun create(action: Action) = ExceptionHandlingInterceptor(action.name, mapperResolver)
     }
 
     private companion object {

--- a/misk/src/main/kotlin/misk/web/exceptions/ExceptionMapperModule.kt
+++ b/misk/src/main/kotlin/misk/web/exceptions/ExceptionMapperModule.kt
@@ -1,20 +1,46 @@
 package misk.web.exceptions
 
 import com.google.inject.TypeLiteral
-import com.google.inject.multibindings.Multibinder
+import com.google.inject.multibindings.MapBinder
 import misk.inject.KAbstractModule
 import kotlin.reflect.KClass
 
-class ExceptionMapperModule<T : ExceptionMapper<*>>(
-        private val kclass: KClass<T>
+/**
+ * Binds a [Throwable] to an [ExceptionMapper].
+ *
+ * When an Exception occurs dispatching an Action, the bound ExceptionMapper is called to handle
+ * the Exception. If there is not an explicit binding for the thrown Exception, the mapper for the
+ * closest superclass is used.
+ *
+ * Given the example code
+ *
+ * ```
+ * install(ExceptionMapperModule.create<ActionException, ActionExceptionMapper>())
+ * install(ExceptionMapperModule.create<MyActionException, MyActionExceptionMapper>())
+ *
+ * class MyActionException : ActionException {}
+ * class MyOtherActionException : ActionException {}
+ * ```
+ *
+ * MyActionException maps to the specific MyActionExceptionMapper and MyOtherActionException
+ * maps to the ActionExceptionMapper since uses the binding of the closest bound superclass.
+ */
+class ExceptionMapperModule<M : ExceptionMapper<T>, in T : Throwable>(
+    private val exceptionClass: KClass<T>,
+    private val mapperClass: KClass<M>
 ) : KAbstractModule() {
     override fun configure() {
-        Multibinder.newSetBinder(binder(), exceptionMapperTypeLiteral).addBinding().to(kclass.java)
+      MapBinder.newMapBinder(binder(), exceptionTypeLiteral, exceptionMapperTypeLiteral)
+          .addBinding(exceptionClass)
+          .to(mapperClass.java)
     }
 
     companion object {
-        inline fun <reified T : ExceptionMapper<*>> create() = ExceptionMapperModule(T::class)
+      inline fun <reified T : Throwable, reified M : ExceptionMapper<T>> create() = ExceptionMapperModule(
+          T::class, M::class
+      )
 
-        private val exceptionMapperTypeLiteral = object : TypeLiteral<ExceptionMapper<*>>() {}
+      private val exceptionMapperTypeLiteral = object : TypeLiteral<ExceptionMapper<*>>() {}
+      private val exceptionTypeLiteral = object : TypeLiteral<KClass<*>>() {}
     }
 }

--- a/misk/src/main/kotlin/misk/web/exceptions/ExceptionMapperResolver.kt
+++ b/misk/src/main/kotlin/misk/web/exceptions/ExceptionMapperResolver.kt
@@ -1,0 +1,43 @@
+package misk.web.exceptions
+
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.ConcurrentMap
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlin.reflect.KClass
+import kotlin.reflect.full.isSubclassOf
+import kotlin.reflect.full.superclasses
+
+@Singleton
+class ExceptionMapperResolver @Inject internal constructor(
+    private val mappers: @JvmSuppressWildcards Map<KClass<*>, ExceptionMapper<*>>
+) {
+
+  private val cache: ConcurrentMap<KClass<*>, ExceptionMapper<Throwable>> = ConcurrentHashMap()
+
+  @Suppress("UNCHECKED_CAST")
+  fun mapperFor(th: Throwable): ExceptionMapper<Throwable>? {
+    // The resolved Mapper is always the same, so cache it
+    return cache.getOrPut(th::class, {
+      val mappedException = getSuperclasses(th::class).firstOrNull { mappers.containsKey(it) }
+      return mappers[mappedException] as ExceptionMapper<Throwable>?
+    })
+  }
+
+  private fun getSuperclasses(kClass: KClass<*>): List<KClass<*>> {
+    val dfs = DFS()
+    dfs.doDFS(kClass)
+    return dfs.result
+  }
+
+  private class DFS {
+    val result: MutableList<KClass<*>> = mutableListOf()
+
+    fun doDFS(node: KClass<*>) {
+      result.add(node)
+      node.superclasses
+          .filter { it.isSubclassOf(Throwable::class) }
+          .forEach({ doDFS(it) })
+    }
+  }
+}

--- a/misk/src/test/kotlin/misk/web/exceptions/ExceptionMapperResolverTest.kt
+++ b/misk/src/test/kotlin/misk/web/exceptions/ExceptionMapperResolverTest.kt
@@ -1,0 +1,60 @@
+package misk.web.exceptions
+
+import misk.exceptions.ActionException
+import misk.exceptions.NotFoundException
+import misk.web.Response
+import misk.web.ResponseBody
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import kotlin.reflect.KClass
+
+internal class ExceptionMapperResolverTest {
+
+  val mappers = mutableMapOf<KClass<*>, ExceptionMapper<*>>()
+  val resolver = ExceptionMapperResolver(mappers)
+
+  @Test
+  fun resolvesToSpecificMapper() {
+    mappers[NotFoundException::class] = NotFoundExceptionMapper()
+    mappers[ActionException::class] = ActionExceptionMapper()
+
+    assertThat(resolver.mapperFor(NotFoundException()))
+        .isInstanceOf(NotFoundExceptionMapper::class.java)
+  }
+
+  @Test
+  fun resolvesToSuperClassMapper() {
+    mappers[ActionException::class] = ActionExceptionMapper()
+
+    assertThat(resolver.mapperFor(NotFoundException()))
+        .isInstanceOf(ActionExceptionMapper::class.java)
+  }
+
+  @Test
+  fun noMapperFound() {
+    assertThat(resolver.mapperFor(NotFoundException()))
+        .isNull()
+  }
+
+  @Test
+  fun nonActionException() {
+    mappers[ArithmeticException::class] = ArithmeticExceptionMapper()
+
+    assertThat(resolver.mapperFor(ArithmeticException()))
+        .isInstanceOf(ArithmeticExceptionMapper::class.java)
+  }
+
+  class NotFoundExceptionMapper : BaseExceptionMapper<NotFoundException>()
+  class ActionExceptionMapper : BaseExceptionMapper<ActionException>()
+  class ArithmeticExceptionMapper : BaseExceptionMapper<ArithmeticException>()
+
+  open class BaseExceptionMapper<in T : Throwable> : ExceptionMapper<T> {
+    override fun toResponse(th: T): Response<ResponseBody> {
+      TODO("")
+    }
+
+    override fun canHandle(th: Throwable): Boolean {
+      TODO("")
+    }
+  }
+}


### PR DESCRIPTION
This adds deterministic ExceptionMapper resolution, instead of relying
on the binding order of ExceptionMappers.

If an Exception is thrown without an explicit bound ExceptionMapper, the
superclasses of the Exception are explored for possible bound
ExceptionMappers. The closest bound superclass wins.

e.g If an application adds an explicit binding for NotFoundException,
that explicit Mapper is preferred over the base ActionExceptionMapper.
However, if no binding for BadRequestException exists, the base
ActionExceptionMapper is used instead.

Since an Exception always resolves to the same ExceptionMapper for the
life of a VM, it is safe to cache the resolution result.