### PR TITLE
Fix wildcard based content routing

### DIFF
--- a/misk/build-wire.sh
+++ b/misk/build-wire.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+# TODO(mmihic): Totally temporary script to build wire files. To be replaces with
+# proper gradle support
+# Build protos captured in test resources
+java -jar ~/Downloads/wire-compiler-2.3.0-RC1-jar-with-dependencies.jar \
+	--proto_path=src/test/proto     \
+	--java_out=src/test/java     \
+	parsing/parsing.proto 
+
+

--- a/misk/src/main/kotlin/misk/web/BoundAction.kt
+++ b/misk/src/main/kotlin/misk/web/BoundAction.kt
@@ -5,8 +5,9 @@ import misk.web.actions.WebAction
 import misk.web.actions.WebSocketListener
 import misk.web.actions.asChain
 import misk.web.extractors.ParameterExtractor
-import misk.web.jetty.RealWebSocket
 import misk.web.mediatype.MediaRange
+import misk.web.mediatype.MediaTypes
+import misk.web.mediatype.compareTo
 import okhttp3.HttpUrl
 import okhttp3.MediaType
 import org.eclipse.jetty.http.HttpMethod
@@ -58,7 +59,7 @@ internal class BoundAction<A : WebAction, out R>(
     requestContentType: MediaType?,
     requestAcceptedTypes: List<MediaRange>,
     url: HttpUrl
-  ): RequestMatch? {
+  ): BoundActionMatch? {
     // Confirm the path and method matches
     val pathMatcher = pathMatcher(url) ?: return null
     if (requestMethod != httpMethod.name) return null
@@ -75,10 +76,22 @@ internal class BoundAction<A : WebAction, out R>(
         responseContentType?.closestMediaRangeMatch(requestAcceptedTypes)
     if (responseContentType != null && responseContentTypeMatch == null) return null
 
-    return RequestMatch(this, pathMatcher, responseContentTypeMatch)
+    val acceptedMediaRange = requestContentTypeMatch?.mediaRange ?: MediaRange.ALL_MEDIA
+    val requestCharsetMatch = requestContentTypeMatch?.matchesCharset ?: false
+
+    return BoundActionMatch(
+        this,
+        pathMatcher,
+        acceptedMediaRange,
+        requestCharsetMatch,
+        responseContentType ?: MediaTypes.ALL_MEDIA_TYPE
+    )
   }
 
-  internal fun handle(request: Request, pathMather: Matcher): Response<ResponseBody> {
+  internal fun handle(
+    request: Request,
+    pathMather: Matcher
+  ): Response<ResponseBody> {
     // Find values for all the parameters.
     val webAction = webActionProvider.get()
     val parameters = parameterExtractors.map {
@@ -112,30 +125,52 @@ internal class BoundAction<A : WebAction, out R>(
 
   /** Returns a Matcher if requestUrl can be matched, else null */
   private fun pathMatcher(requestUrl: HttpUrl): Matcher? {
-    val matcher = pathPattern.pattern.matcher(requestUrl.encodedPath())
+    val matcher = pathPattern.regex.matcher(requestUrl.encodedPath())
     return if (matcher.matches()) matcher else null
   }
 }
 
-/** Matches a request to an action. Can be sorted to pick the most specific match amongst a set of candidates */
-internal class RequestMatch(
-  val action: BoundAction<*, *>,
-  private val pathMatcher: Matcher,
-  private val responseContentTypeMatch: MediaRange.Matcher?
+/** Matches a request . Can be sorted to pick the most specific match amongst a set of candidates */
+internal open class RequestMatch(
+  private val pathPattern: PathPattern,
+  private val acceptedMediaRange: MediaRange,
+  private val requestCharsetMatch: Boolean,
+  private val responseContentType: MediaType
 ) : Comparable<RequestMatch> {
+
   override fun compareTo(other: RequestMatch): Int {
-    val patternDiff = action.pathPattern.compareTo(other.action.pathPattern)
+    val patternDiff = pathPattern.compareTo(other.pathPattern)
     if (patternDiff != 0) return patternDiff
 
-    if (responseContentTypeMatch != null && other.responseContentTypeMatch == null) return -1
-    if (responseContentTypeMatch == null && other.responseContentTypeMatch != null) return 1
-    if (responseContentTypeMatch != null && other.responseContentTypeMatch != null) {
-      return responseContentTypeMatch.compareTo(other.responseContentTypeMatch)
-    }
+    val requestContentTypeDiff = acceptedMediaRange.compareTo(other.acceptedMediaRange)
+    if (requestContentTypeDiff != 0) return requestContentTypeDiff
+
+    val responseContentTypeDiff = responseContentType.compareTo(other.responseContentType)
+    if (responseContentTypeDiff != 0) return responseContentTypeDiff
+
+    // Only after we have compared both the accepted and emitted content types should we
+    // bother clarifying with the charset; we'd rather match a (text/*, text/plain)
+    // with no charset over a (text/*, text/*) with charset
+    if (requestCharsetMatch && !other.requestCharsetMatch) return -1
+    if (!requestCharsetMatch && other.requestCharsetMatch) return 1
 
     return 0
   }
 
+  override fun toString(): String =
+      "path: $pathPattern, accepts: $acceptedMediaRange, emits: $responseContentType"
+}
+
+/** A [RequestMatch] associated with the action that matched */
+internal class BoundActionMatch(
+  val action: BoundAction<*, *>,
+  private val pathMatcher: Matcher,
+  acceptedMediaRange: MediaRange,
+  requestCharsetMatch: Boolean,
+  responseContentType: MediaType
+) : RequestMatch(action.pathPattern, acceptedMediaRange, requestCharsetMatch, responseContentType) {
+
+  /** Handles the request by handing it off to the action */
   fun handle(request: Request, jettyResponse: HttpServletResponse) {
     val result = action.handle(request, pathMatcher)
     result.writeToJettyResponse(jettyResponse)
@@ -148,3 +183,4 @@ internal class RequestMatch(
 
 private fun MediaType.closestMediaRangeMatch(ranges: List<MediaRange>) =
     ranges.mapNotNull { it.matcher(this) }.sorted().firstOrNull()
+

--- a/misk/src/main/kotlin/misk/web/jetty/WebActionsServlet.kt
+++ b/misk/src/main/kotlin/misk/web/jetty/WebActionsServlet.kt
@@ -1,7 +1,6 @@
 package misk.web.jetty
 
 import misk.inject.keyOf
-import misk.logging.getLogger
 import misk.scope.ActionScope
 import misk.web.BoundAction
 import misk.web.Request
@@ -20,8 +19,6 @@ import javax.inject.Inject
 import javax.inject.Singleton
 import javax.servlet.http.HttpServletRequest
 import javax.servlet.http.HttpServletResponse
-
-private val logger = getLogger<WebActionsServlet>()
 
 @Singleton
 internal class WebActionsServlet @Inject constructor(
@@ -43,18 +40,17 @@ internal class WebActionsServlet @Inject constructor(
         keyOf<Request>() to asRequest)
 
     scope.enter(seedData).use {
-      val candidateActions = boundActions.mapNotNull {
-        it.match(
-            request.method,
-            request.contentType?.let { MediaType.parse(it) },
-            request.accepts(),
-            asRequest.url
-        )
-      }
-      val bestAction = candidateActions.sorted().firstOrNull()
-      bestAction?.handle(asRequest, response)
-      logger.debug { "Request handled by WebActionServlet" }
-    }
+          val candidateActions = boundActions.mapNotNull {
+            it.match(
+                request.method,
+                request.contentType?.let { MediaType.parse(it) },
+                request.accepts(),
+                asRequest.url
+            )
+          }
+          val bestAction = candidateActions.sorted().firstOrNull()
+          bestAction?.handle(asRequest, response)
+        }
   }
 
   override fun configure(factory: WebSocketServletFactory) {
@@ -104,7 +100,7 @@ private fun HttpServletRequest.urlString(): HttpUrl? {
     HttpUrl.parse(requestURL.toString() + "?" + queryString)
 }
 
-internal fun HttpServletRequest.asRequest(): Request {
+private fun HttpServletRequest.asRequest(): Request {
   return Request(
       urlString()!!,
       HttpMethod.valueOf(method),

--- a/misk/src/main/kotlin/misk/web/mediatype/MediaTypes.kt
+++ b/misk/src/main/kotlin/misk/web/mediatype/MediaTypes.kt
@@ -6,10 +6,10 @@ object MediaTypes {
   const val APPLICATION_JSON = "application/json;charset=utf-8"
   val APPLICATION_JSON_MEDIA_TYPE = APPLICATION_JSON.asMediaType()
 
-  const val APPLICATION_FORM_URLENCODED = "application/x-www-form-urlencoded;charset=utf-8"
-
   const val TEXT_PLAIN_UTF8 = "text/plain;charset=utf-8"
   val TEXT_PLAIN_UTF8_MEDIA_TYPE = TEXT_PLAIN_UTF8.asMediaType()
+
+  const val APPLICATION_FORM_URLENCODED = "application/x-www-form-urlencoded;charset=utf-8"
 
   const val ALL = "*/*"
   val ALL_MEDIA_TYPE = ALL.asMediaType()
@@ -17,3 +17,12 @@ object MediaTypes {
 
 fun String.asMediaType() = MediaType.parse(this)!!
 fun String.asMediaRange() = MediaRange.parse(this)
+
+internal val MediaType.wildcardCount
+  get() = when {
+    type() == "*" -> 2
+    subtype() == "*" -> 1
+    else -> 0
+  }
+
+fun MediaType.compareTo(other: MediaType) = wildcardCount - other.wildcardCount

--- a/misk/src/test/kotlin/misk/web/ContentBasedDispatchTest.kt
+++ b/misk/src/test/kotlin/misk/web/ContentBasedDispatchTest.kt
@@ -26,58 +26,91 @@ internal class ContentBasedDispatchTest {
       MiskModule(),
       WebModule(),
       TestWebModule(),
-      TestModule())
+      TestModule()
+  )
+
+  val httpClient = OkHttpClient()
 
   data class Packet(val message: String)
 
   private val jsonMediaType = MediaTypes.APPLICATION_JSON.asMediaType()
   private val plainTextMediaType = MediaTypes.TEXT_PLAIN_UTF8.asMediaType()
   private val weirdTextMediaType = "text/weird".asMediaType()
+  private val weirdMediaType = "weird/weird".asMediaType()
 
-  @Inject lateinit var moshi: Moshi
-  @Inject lateinit var jettyService: JettyService
+  private @Inject
+  lateinit var moshi: Moshi
+
+  private @Inject
+  lateinit var jettyService: JettyService
+
   private val packetJsonAdapter get() = moshi.adapter(Packet::class.java)
 
   @Test
   fun postJsonExpectJson() {
     val requestContent = packetJsonAdapter.toJson(Packet("my friend"))
-    val responseContent = post(jsonMediaType, requestContent, jsonMediaType).source()
+    val responseContent = postHello(jsonMediaType, requestContent, jsonMediaType).source()
     assertThat(packetJsonAdapter.fromJson(responseContent)!!.message)
         .isEqualTo("json->json my friend")
   }
 
   @Test
-  fun postJsonExpectText() {
+  fun postJsonExpectPlainText() {
     val requestContent = packetJsonAdapter.toJson(Packet("my friend"))
-    val responseContent = post(jsonMediaType, requestContent, plainTextMediaType).source()
+    val responseContent = postHello(jsonMediaType, requestContent, plainTextMediaType).source()
     assertThat(responseContent.readUtf8()).isEqualTo("json->text my friend")
   }
 
   @Test
-  fun postTextExpectJson() {
-    val responseContent = post(plainTextMediaType, "my friend", jsonMediaType).source()
+  fun postPlainTextExpectJson() {
+    val responseContent = postHello(plainTextMediaType, "my friend", jsonMediaType).source()
     assertThat(packetJsonAdapter.fromJson(responseContent)!!.message)
         .isEqualTo("text->json my friend")
   }
 
   @Test
+  fun postPlainTextExpectPlainText() {
+    val responseContent = postHello(plainTextMediaType, "my friend", plainTextMediaType).source()
+    assertThat(responseContent.readUtf8()).isEqualTo("text->text my friend")
+  }
+
+  @Test
+  fun postWeirdTextExpectPlainText() {
+    val responseContent = postHello(weirdTextMediaType, "my friend", plainTextMediaType).source()
+    assertThat(responseContent.readUtf8()).isEqualTo("text*->text my friend")
+  }
+
+  @Test
+  fun postPlainTextExpectWeirdText() {
+    val responseContent = postHello(plainTextMediaType, "my friend", weirdTextMediaType).source()
+    assertThat(responseContent.readUtf8()).isEqualTo("text->text* my friend")
+  }
+
+  @Test
   fun postArbitraryExpectJson() {
-    val responseContent = post(weirdTextMediaType, "my friend", jsonMediaType).source()
+    val responseContent = postHello(weirdMediaType, "my friend", jsonMediaType).source()
     assertThat(packetJsonAdapter.fromJson(responseContent)!!.message)
         .isEqualTo("*->json my friend")
   }
 
   @Test
   fun postArbitraryExpectArbitrary() {
-    val responseContent = post(weirdTextMediaType, "my friend", weirdTextMediaType).source()
+    val responseContent = postHello(
+        weirdMediaType,
+        "my friend",
+        weirdMediaType
+    ).source()
     assertThat(responseContent.readUtf8()).isEqualTo("*->* my friend")
   }
 
   class TestModule : KAbstractModule() {
     override fun configure() {
+      install(WebActionModule.create<PostPlainTextReturnAnyText>())
+      install(WebActionModule.create<PostAnyTextReturnPlainText>())
+      install(WebActionModule.create<PostPlainTextReturnPlainText>())
       install(WebActionModule.create<PostJsonReturnJson>())
-      install(WebActionModule.create<PostTextReturnJson>())
-      install(WebActionModule.create<PostJsonReturnText>())
+      install(WebActionModule.create<PostPlainTextReturnJson>())
+      install(WebActionModule.create<PostJsonReturnPlainText>())
       install(WebActionModule.create<PostAnythingReturnJson>())
       install(WebActionModule.create<PostAnythingReturnAnything>())
     }
@@ -90,14 +123,35 @@ internal class ContentBasedDispatchTest {
     fun hello(@misk.web.RequestBody request: Packet) = Packet("json->json ${request.message}")
   }
 
-  class PostTextReturnJson : WebAction {
+  class PostPlainTextReturnJson : WebAction {
     @Post("/hello")
     @RequestContentType("text/plain")
     @ResponseContentType("application/json")
     fun hello(@misk.web.RequestBody message: String) = Packet("text->json $message")
   }
 
-  class PostJsonReturnText : WebAction {
+  class PostPlainTextReturnPlainText : WebAction {
+    @Post("/hello")
+    @RequestContentType("text/plain")
+    @ResponseContentType("text/plain")
+    fun hello(@misk.web.RequestBody message: String) = "text->text $message"
+  }
+
+  class PostAnyTextReturnPlainText : WebAction {
+    @Post("/hello")
+    @RequestContentType("text/*")
+    @ResponseContentType("text/plain")
+    fun hello(@misk.web.RequestBody message: String) = "text*->text $message"
+  }
+
+  class PostPlainTextReturnAnyText : WebAction {
+    @Post("/hello")
+    @RequestContentType("text/plain")
+    @ResponseContentType("text/*")
+    fun hello(@misk.web.RequestBody message: String) = "text->text* $message"
+  }
+
+  class PostJsonReturnPlainText : WebAction {
     @Post("/hello")
     @RequestContentType("application/json")
     @ResponseContentType("text/plain")
@@ -115,21 +169,32 @@ internal class ContentBasedDispatchTest {
     fun hello(@misk.web.RequestBody message: String) = "*->* $message"
   }
 
-  private fun post(
-    contentType: MediaType, content: String,
-    acceptedMediaType: MediaType? = null
+  private fun postHello(
+      contentType: MediaType,
+      content: String,
+      acceptedMediaType: MediaType? = null
   ): okhttp3.ResponseBody {
-    val httpClient = OkHttpClient()
+    val request = newRequest("/hello", contentType, content, acceptedMediaType)
+    val response = httpClient.newCall(request)
+        .execute()
+    assertThat(response.code()).isEqualTo(200)
+    return response.body()!!
+  }
+
+  private fun newRequest(
+      path: String,
+      contentType: MediaType,
+      content: String,
+      acceptedMediaType: MediaType? = null
+  ): Request {
     val request = Request.Builder()
         .post(RequestBody.create(contentType, content))
-        .url(jettyService.httpServerUrl.newBuilder().encodedPath("/hello").build())
+        .url(jettyService.httpServerUrl.newBuilder().encodedPath(path).build())
 
     if (acceptedMediaType != null) {
       request.header("Accept", acceptedMediaType.toString())
     }
 
-    val response = httpClient.newCall(request.build()).execute()
-    assertThat(response.code()).isEqualTo(200)
-    return response.body()!!
+    return request.build()
   }
 }

--- a/misk/src/test/kotlin/misk/web/PathPatternTest.kt
+++ b/misk/src/test/kotlin/misk/web/PathPatternTest.kt
@@ -8,7 +8,7 @@ internal class PathPatternTest {
   @Test
   fun withOnlyConstants() {
     val p = PathPattern.parse("/a/b/c/d/e/f/g")
-    assertThat(p.pattern.toString()).isEqualTo("\\Q/a/b/c/d/e/f/g\\E")
+    assertThat(p.regex.toString()).isEqualTo("\\Q/a/b/c/d/e/f/g\\E")
     assertThat(p.numSegments).isEqualTo(7)
     assertThat(p.numRegexVariables).isEqualTo(0)
     assertThat(p.matchesWildcardPath).isFalse()
@@ -18,80 +18,80 @@ internal class PathPatternTest {
   @Test
   fun withSimpleVariableMatches() {
     val p = PathPattern.parse("/abc/{jeff}/def/{jesse}")
-    assertThat(p.pattern.toString()).isEqualTo("\\Q/abc/\\E([^/]*)\\Q/def/\\E([^/]*)")
+    assertThat(p.regex.toString()).isEqualTo("\\Q/abc/\\E([^/]*)\\Q/def/\\E([^/]*)")
     assertThat(p.numSegments).isEqualTo(4)
     assertThat(p.numRegexVariables).isEqualTo(0)
     assertThat(p.matchesWildcardPath).isFalse()
     assertThat(p.variableNames).containsExactly("jeff", "jesse")
 
-    val m1 = p.pattern.matcher("/abc/moo/def/bark")
+    val m1 = p.regex.matcher("/abc/moo/def/bark")
     assertThat(m1.matches()).isTrue()
     assertThat(m1.group(1)).isEqualTo("moo")
     assertThat(m1.group(2)).isEqualTo("bark")
 
-    assertThat(p.pattern.matcher("/abc/moo/def").matches()).isFalse()
-    assertThat(p.pattern.matcher("/abc/moo/def/bark/more").matches()).isFalse()
+    assertThat(p.regex.matcher("/abc/moo/def").matches()).isFalse()
+    assertThat(p.regex.matcher("/abc/moo/def/bark/more").matches()).isFalse()
   }
 
   @Test
   fun withRegexMatches() {
     val p = PathPattern.parse("/org/admin/{folder:[a-z]+}/{object:[a-z0-9]+}")
-    assertThat(p.pattern.toString()).isEqualTo("\\Q/org/admin/\\E([a-z]+)\\Q/\\E([a-z0-9]+)")
+    assertThat(p.regex.toString()).isEqualTo("\\Q/org/admin/\\E([a-z]+)\\Q/\\E([a-z0-9]+)")
     assertThat(p.numSegments).isEqualTo(4)
     assertThat(p.numRegexVariables).isEqualTo(2)
     assertThat(p.matchesWildcardPath).isFalse()
     assertThat(p.variableNames).containsExactly("folder", "object")
 
-    val m1 = p.pattern.matcher("/org/admin/oranges/foo")
+    val m1 = p.regex.matcher("/org/admin/oranges/foo")
     assertThat(m1.matches()).isTrue()
     assertThat(m1.group(1)).isEqualTo("oranges")
     assertThat(m1.group(2)).isEqualTo("foo")
 
-    val m2 = p.pattern.matcher("/org/admin/apples/bar75")
+    val m2 = p.regex.matcher("/org/admin/apples/bar75")
     assertThat(m2.matches()).isTrue()
     assertThat(m2.group(1)).isEqualTo("apples")
     assertThat(m2.group(2)).isEqualTo("bar75")
 
-    assertThat(p.pattern.matcher("/org/admin/239034/bar75").matches()).isFalse()
-    assertThat(p.pattern.matcher("/org/admin/apples/_admin").matches()).isFalse()
-    assertThat(p.pattern.matcher("/org/admin/apples/_admin").matches()).isFalse()
-    assertThat(p.pattern.matcher("/org/admin/apples/bar75/zod").matches()).isFalse()
+    assertThat(p.regex.matcher("/org/admin/239034/bar75").matches()).isFalse()
+    assertThat(p.regex.matcher("/org/admin/apples/_admin").matches()).isFalse()
+    assertThat(p.regex.matcher("/org/admin/apples/_admin").matches()).isFalse()
+    assertThat(p.regex.matcher("/org/admin/apples/bar75/zod").matches()).isFalse()
   }
 
   @Test
   fun withFullPathCapture() {
     val p = PathPattern.parse("/org/admin/{object_type:o.*}/{path:.*}")
-    assertThat(p.pattern.toString()).isEqualTo("\\Q/org/admin/\\E(o[^/]*)\\Q/\\E(.*)")
+    assertThat(p.regex.toString()).isEqualTo("\\Q/org/admin/\\E(o[^/]*)\\Q/\\E(.*)")
     assertThat(p.numSegments).isEqualTo(4)
     assertThat(p.numRegexVariables).isEqualTo(2)
     assertThat(p.matchesWildcardPath).isTrue()
     assertThat(p.variableNames).containsExactly("object_type", "path")
 
-    val m1 = p.pattern.matcher("/org/admin/oranges/foo")
+    val m1 = p.regex.matcher("/org/admin/oranges/foo")
     assertThat(m1.matches()).isTrue()
     assertThat(m1.group(1)).isEqualTo("oranges")
     assertThat(m1.group(2)).isEqualTo("foo")
 
-    val m2 = p.pattern.matcher("/org/admin/oranges/foo/bar")
+    val m2 = p.regex.matcher("/org/admin/oranges/foo/bar")
     assertThat(m2.matches()).isTrue()
     assertThat(m2.group(1)).isEqualTo("oranges")
     assertThat(m2.group(2)).isEqualTo("foo/bar")
 
-    assertThat(p.pattern.matcher("/org/admin/users/foo").matches()).isFalse()
+    assertThat(p.regex.matcher("/org/admin/users/foo").matches()).isFalse()
   }
 
   @Test
   fun withWildcardCaptureInMiddle() {
     val p = PathPattern.parse("/org/admin/{object_type:.*}/get")
-    assertThat(p.pattern.toString()).isEqualTo("\\Q/org/admin/\\E([^/]*)\\Q/get\\E")
+    assertThat(p.regex.toString()).isEqualTo("\\Q/org/admin/\\E([^/]*)\\Q/get\\E")
     assertThat(p.numSegments).isEqualTo(4)
     assertThat(p.numRegexVariables).isEqualTo(1)
     assertThat(p.matchesWildcardPath).isFalse()
     assertThat(p.variableNames).containsExactly("object_type")
 
-    assertThat(p.pattern.matcher("/org/admin/users/get").matches()).isTrue()
-    assertThat(p.pattern.matcher("/org/admin/get").matches()).isFalse()
-    assertThat(p.pattern.matcher("/org/admin/users/floozers").matches()).isFalse()
+    assertThat(p.regex.matcher("/org/admin/users/get").matches()).isTrue()
+    assertThat(p.regex.matcher("/org/admin/get").matches()).isFalse()
+    assertThat(p.regex.matcher("/org/admin/users/floozers").matches()).isFalse()
   }
 
   @Test

--- a/misk/src/test/kotlin/misk/web/RequestMatchTest.kt
+++ b/misk/src/test/kotlin/misk/web/RequestMatchTest.kt
@@ -1,0 +1,51 @@
+package misk.web
+
+import misk.web.mediatype.asMediaRange
+import okhttp3.MediaType
+import org.assertj.core.api.assertOrdering
+import org.junit.jupiter.api.Test
+
+internal class RequestMatchTest {
+  @Test
+  fun preferMostSpecificPath() {
+    assertOrdering(
+        match(PathPattern.parse("/org/admin/users"), "text/*", "text/*"),
+        match(PathPattern.parse("/org/{folder}/{type}"), "text/plain", "text/plain"),
+        match(PathPattern.parse("{path:.*}"), "text/plain", "text/plain")
+    )
+  }
+
+  @Test
+  fun preferMostSpecificContentTypes() {
+    assertOrdering(
+        match("text/plain", "text/plain"),
+        match("text/plain", "text/*"),
+        match("text/plain", "*/*"),
+        match("text/*", "text/plain"),
+        match("text/*", "text/*"),
+        match("text/*", "*/*"),
+        match("*/*", "text/plain"),
+        match("*/*", "text/*"),
+        match("*/*", "*/*")
+    )
+  }
+
+  private fun match(
+    requestRange: String,
+    responseType: String
+  ) =
+    match(PathPattern.parse("/a"), requestRange, responseType)
+
+  private fun match(
+    path: PathPattern,
+    requestRange: String,
+    responseType: String
+  ) =
+    RequestMatch(
+        path,
+        requestRange.asMediaRange(),
+        false,
+        MediaType.parse(responseType)!!
+    )
+
+}

--- a/misk/src/test/kotlin/misk/web/mediatype/MediaRangeTest.kt
+++ b/misk/src/test/kotlin/misk/web/mediatype/MediaRangeTest.kt
@@ -169,6 +169,15 @@ internal class MediaRangeTest {
   }
 
   @Test
+  fun matchWildcardsOnMediaType() {
+    val mediaRange = MediaRange.parse("text/html")
+    assertThat(mediaRange.matcher(MediaType.parse("*/*")!!)).isNotNull()
+    assertThat(mediaRange.matcher(MediaType.parse("text/*")!!)).isNotNull()
+    assertThat(mediaRange.matcher(MediaType.parse("application/*")!!)).isNull()
+    assertThat(mediaRange.matcher(MediaType.parse("application/json")!!)).isNull()
+  }
+
+  @Test
   fun matchNoCharsetInMediaType() {
     val mediaRange = MediaRange.parse("text/html;charset=utf-8")
     val mediaType = MediaType.parse("text/html")!!

--- a/misk/src/test/kotlin/org/assertj/core/api/AssertExtensions.kt
+++ b/misk/src/test/kotlin/org/assertj/core/api/AssertExtensions.kt
@@ -1,5 +1,6 @@
 package org.assertj.core.api
 
+import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.data.MapEntry
 
 fun <KEY, VALUE> MapAssert<KEY, VALUE>.containsExactly(
@@ -13,10 +14,34 @@ fun <ACTUAL : CharSequence> AbstractCharSequenceAssert<*, ACTUAL>.isEqualToAsJso
 ): AbstractCharSequenceAssert<*, ACTUAL> {
   // Normalize whitespace outside of field names and string values
   val regex = Regex("[^\\s\"']+|\"[^\"]*\"|'[^']*'")
-  val normalizedActual = regex.findAll(actual).map { it.groupValues[0] }.joinToString(" ")
-  val normalizedExpected = regex.findAll(expected).map { it.groupValues[0] }.joinToString(" ")
+  val normalizedActual = regex.findAll(actual)
+      .map { it.groupValues[0] }
+      .joinToString(" ")
+  val normalizedExpected = regex.findAll(expected)
+      .map { it.groupValues[0] }
+      .joinToString(" ")
   objects.assertEqual(getWritableAssertionInfo(), normalizedActual, normalizedExpected)
   return this
 }
 
+// NB(mmihic): Explicitly tests ordering by comparing the ordering of element against
+// each other. assertThat().isSorted() checks the entire ordering, but that can be difficult
+// to debug vs comparing each element against each other
+fun <A : Comparable<A>> assertOrdering(vararg values: A) {
+  values.forEachIndexed { index, value ->
+    assertThat(value).isEqualByComparingTo(value)
+
+    val before = if (index == 0) listOf() else values.take(index - 1)
+    before.forEach {
+      assertThat(value).isGreaterThan(it)
+      assertThat(it).isLessThan(value)
+    }
+
+    val after = if (index == values.size - 1) listOf() else values.drop(index + 1)
+    after.forEach {
+      assertThat(value).isLessThan(it)
+      assertThat(it).isGreaterThan(value)
+    }
+  }
+}
 


### PR DESCRIPTION
Fixed content based routing when the requests or actions have wildcards
in their accepted or emitted media ranges. The previous logic had
several issues:

1. We weren't considering the action's content type when ordering, so if
there were an action accepting text/* and another accepting text/plain,
and a request arrived with content-type text/plain, we'd randomly select
between those two actions. We now deterministically prefer the action
with the most specific matching content type (thus a request with text/plain
would match the action accepting text/plain, and a request text/yaml
would match the action accepting text/*)

2. We were ordering actions based on the Accepts header supplied by the
client rather than the media type defined on the action, so if there
were an action that could emit text/plain and another that could emit
*/* and a request arrived with Accepts: text/*, we'd randonly select
between those two actions. We now deteministically prefer the action
with the most specific matching response content type (thus a request
accepting text/* would prefer the action emitteing text/plain over the
action emitting */*).

As part of this, also cleaned up toString() methods on the various
matchers to make debugging easier.