### PR TITLE
Run IntelliJ's formatter on all of Misk.

### DIFF
--- a/misk/src/main/kotlin/misk/Action.kt
+++ b/misk/src/main/kotlin/misk/Action.kt
@@ -4,8 +4,8 @@ import kotlin.reflect.KFunction
 import kotlin.reflect.KType
 
 data class Action(
-  val name: String,
-  val function: KFunction<*>,
-  val parameterTypes: List<KType>,
-  val returnType: KType
+    val name: String,
+    val function: KFunction<*>,
+    val parameterTypes: List<KType>,
+    val returnType: KType
 )

--- a/misk/src/main/kotlin/misk/MiskApplication.kt
+++ b/misk/src/main/kotlin/misk/MiskApplication.kt
@@ -80,11 +80,11 @@ class MiskApplication(private val modules: List<Module>, commands: List<MiskComm
     val injector = Guice.createInjector(modules)
     val serviceManager = injector.getInstance<ServiceManager>()
     Runtime.getRuntime().addShutdownHook(object : Thread() {
-          override fun run() {
-            serviceManager.stopAsync()
-            serviceManager.awaitStopped()
-          }
-        })
+      override fun run() {
+        serviceManager.stopAsync()
+        serviceManager.awaitStopped()
+      }
+    })
 
     serviceManager.startAsync()
     serviceManager.awaitHealthy()

--- a/misk/src/main/kotlin/misk/MiskCommand.kt
+++ b/misk/src/main/kotlin/misk/MiskCommand.kt
@@ -12,7 +12,10 @@ import javax.inject.Inject
  * pick the appropriate command based on the name, create an injector based on that
  * command's modules, use the injector to initialize the command, and then run the command.
  */
-abstract class MiskCommand(internal val name: String, internal val modules: List<Module>) : Runnable {
+abstract class MiskCommand(
+    internal val name: String,
+    internal val modules: List<Module>
+) : Runnable {
   constructor(name: String, vararg modules: Module) : this(name, modules.toList())
 
   @Inject

--- a/misk/src/main/kotlin/misk/cloud/gcp/GoogleCloudModule.kt
+++ b/misk/src/main/kotlin/misk/cloud/gcp/GoogleCloudModule.kt
@@ -41,10 +41,11 @@ class GoogleCloudModule : KAbstractModule() {
       DatastoreOptions.newBuilder()
           .setCredentials(credentials)
           .setHost(config.transport.host)
-          .setTransportOptions(HttpTransportOptions.newBuilder()
-              .setConnectTimeout(config.transport.connect_timeout_ms)
-              .setReadTimeout(config.transport.read_timeout_ms)
-              .build())
+          .setTransportOptions(
+              HttpTransportOptions.newBuilder()
+                  .setConnectTimeout(config.transport.connect_timeout_ms)
+                  .setReadTimeout(config.transport.read_timeout_ms)
+                  .build())
           .build()
           .service
 
@@ -72,10 +73,11 @@ class GoogleCloudModule : KAbstractModule() {
       return StorageOptions.newBuilder()
           .setCredentials(credentials)
           .setHost(config.transport.host)
-          .setTransportOptions(HttpTransportOptions.newBuilder()
-              .setConnectTimeout(config.transport.connect_timeout_ms)
-              .setReadTimeout(config.transport.read_timeout_ms)
-              .build())
+          .setTransportOptions(
+              HttpTransportOptions.newBuilder()
+                  .setConnectTimeout(config.transport.connect_timeout_ms)
+                  .setReadTimeout(config.transport.read_timeout_ms)
+                  .build())
           .build()
           .service
     }

--- a/misk/src/main/kotlin/misk/cloud/gcp/datastore/DatastoreExtensions.kt
+++ b/misk/src/main/kotlin/misk/cloud/gcp/datastore/DatastoreExtensions.kt
@@ -15,7 +15,7 @@ fun Entity.getByteString(name: String) = getBlob(name).toByteString()
 fun <T> Entity.getProto(name: String, protoAdapter: ProtoAdapter<T>): T =
     protoAdapter.decode(getByteString(name))
 
-fun Entity.Builder.set(name: String, bytes: ByteString) : Entity.Builder =
+fun Entity.Builder.set(name: String, bytes: ByteString): Entity.Builder =
     set(name, Blob.copyFrom(bytes.asByteBuffer()))
 
 fun <T> QueryResults<T>.asList(): List<T> = asSequence().toList()

--- a/misk/src/main/kotlin/misk/cloud/gcp/storage/BaseCustomStorageRpc.kt
+++ b/misk/src/main/kotlin/misk/cloud/gcp/storage/BaseCustomStorageRpc.kt
@@ -109,8 +109,10 @@ abstract class BaseCustomStorageRpc : StorageRpc {
     throw UnsupportedOperationException()
   }
 
-  override fun listAcls(bucket: String?,
-      options: Map<StorageRpc.Option, *>?): List<BucketAccessControl> {
+  override fun listAcls(
+      bucket: String?,
+      options: Map<StorageRpc.Option, *>?
+  ): List<BucketAccessControl> {
     throw UnsupportedOperationException()
   }
 
@@ -126,23 +128,31 @@ abstract class BaseCustomStorageRpc : StorageRpc {
     throw UnsupportedOperationException()
   }
 
-  override fun deleteAcl(bucket: String?, entity: String?,
-      options: Map<StorageRpc.Option, *>?): Boolean {
+  override fun deleteAcl(
+      bucket: String?, entity: String?,
+      options: Map<StorageRpc.Option, *>?
+  ): Boolean {
     throw UnsupportedOperationException()
   }
 
-  override fun deleteAcl(bucket: String?, `object`: String?, generation: Long?,
-      entity: String?): Boolean {
+  override fun deleteAcl(
+      bucket: String?, `object`: String?, generation: Long?,
+      entity: String?
+  ): Boolean {
     throw UnsupportedOperationException()
   }
 
-  override fun compose(sources: Iterable<StorageObject>?, target: StorageObject?,
-      targetOptions: Map<StorageRpc.Option, *>?): StorageObject {
+  override fun compose(
+      sources: Iterable<StorageObject>?, target: StorageObject?,
+      targetOptions: Map<StorageRpc.Option, *>?
+  ): StorageObject {
     throw UnsupportedOperationException()
   }
 
-  override fun setIamPolicy(bucket: String?, policy: Policy?,
-      options: Map<StorageRpc.Option, *>?): Policy {
+  override fun setIamPolicy(
+      bucket: String?, policy: Policy?,
+      options: Map<StorageRpc.Option, *>?
+  ): Policy {
     throw UnsupportedOperationException()
   }
 

--- a/misk/src/main/kotlin/misk/cloud/gcp/storage/LocalStorageRpc.kt
+++ b/misk/src/main/kotlin/misk/cloud/gcp/storage/LocalStorageRpc.kt
@@ -367,7 +367,8 @@ class LocalStorageRpc(root: Path, moshi: Moshi = Moshi.Builder().build()) : Base
         it != 0L && existingMetadata == null ->
           throw StorageException(404, "${blobId.fullName} does not exist")
         it != 0L && existingMetadata != null && it != existingMetadata.generation ->
-          throw StorageException(401,
+          throw StorageException(
+              401,
               "generation mismatch: ${existingMetadata.generation} != $it")
         else -> {
         }

--- a/misk/src/main/kotlin/misk/cloud/gcp/storage/StorageConfig.kt
+++ b/misk/src/main/kotlin/misk/cloud/gcp/storage/StorageConfig.kt
@@ -7,7 +7,7 @@ import misk.config.Config
 data class StorageConfig(
     val use_local_storage: Boolean = false,
     val local_storage: LocalStorageConfig? = null,
-    val transport : TransportConfig = TransportConfig()
+    val transport: TransportConfig = TransportConfig()
 ) : Config
 
 /** Configuration for local (emulated) storage */

--- a/misk/src/main/kotlin/misk/concurrent/WrappingListeningExecutorService.kt
+++ b/misk/src/main/kotlin/misk/concurrent/WrappingListeningExecutorService.kt
@@ -34,8 +34,10 @@ abstract class WrappingListeningExecutorService() : ForwardingListeningExecutorS
   }
 
   @Throws(InterruptedException::class)
-  override fun <T> invokeAll(callables: Collection<Callable<T>>, timeout: Long,
-      timeUnit: TimeUnit): List<Future<T>> {
+  override fun <T> invokeAll(
+      callables: Collection<Callable<T>>, timeout: Long,
+      timeUnit: TimeUnit
+  ): List<Future<T>> {
     return delegate().invokeAll(callables.map { wrap(it) }, timeout, timeUnit)
   }
 
@@ -45,8 +47,10 @@ abstract class WrappingListeningExecutorService() : ForwardingListeningExecutorS
   }
 
   @Throws(InterruptedException::class, ExecutionException::class, TimeoutException::class)
-  override fun <T> invokeAny(callables: Collection<Callable<T>>, timeout: Long,
-      timeUnit: TimeUnit): T {
+  override fun <T> invokeAny(
+      callables: Collection<Callable<T>>, timeout: Long,
+      timeUnit: TimeUnit
+  ): T {
     return delegate().invokeAny(callables.map { wrap(it) }, timeout, timeUnit)
   }
 

--- a/misk/src/main/kotlin/misk/config/ConfigModule.kt
+++ b/misk/src/main/kotlin/misk/config/ConfigModule.kt
@@ -34,7 +34,8 @@ class ConfigModule<T : Config>(
       }
       bindConfigClassRecursively(
           property.returnType.typeLiteral().rawType as Class<out Config>)
-      val subConfigProvider = SubConfigProvider(config,
+      val subConfigProvider = SubConfigProvider(
+          config,
           property as KProperty1<Config, Any?>)
       val subConfigTypeLiteral = TypeLiteral.get(
           property.returnType.javaType) as TypeLiteral<Any?>

--- a/misk/src/main/kotlin/misk/config/MiskConfig.kt
+++ b/misk/src/main/kotlin/misk/config/MiskConfig.kt
@@ -12,71 +12,71 @@ import java.io.InputStreamReader
 import java.net.URL
 
 object MiskConfig {
- @JvmStatic
- inline fun <reified T : Config> load(appName: String, environment: Environment): T {
-  return load(T::class.java, appName, environment)
- }
+  @JvmStatic
+  inline fun <reified T : Config> load(appName: String, environment: Environment): T {
+    return load(T::class.java, appName, environment)
+  }
 
- @JvmStatic
- fun <T : Config> load(
-   configClass: Class<out Config>,
-   appName: String,
-   environment: Environment
- ): T {
-  val mapper = ObjectMapper(YAMLFactory())
-  mapper.registerModule(KotlinModule())
-  mapper.registerModule(JavaTimeModule())
+  @JvmStatic
+  fun <T : Config> load(
+      configClass: Class<out Config>,
+      appName: String,
+      environment: Environment
+  ): T {
+    val mapper = ObjectMapper(YAMLFactory())
+    mapper.registerModule(KotlinModule())
+    mapper.registerModule(JavaTimeModule())
 
-  var jsonNode: JsonNode? = null
-  val missingConfigFiles = mutableListOf<String>()
-  for (configFileName in configFileNames(appName, environment)) {
-   val url = getResource(configClass, configFileName)
-   if (url == null) {
-    missingConfigFiles.add(configFileName)
-    continue
-   }
+    var jsonNode: JsonNode? = null
+    val missingConfigFiles = mutableListOf<String>()
+    for (configFileName in configFileNames(appName, environment)) {
+      val url = getResource(configClass, configFileName)
+      if (url == null) {
+        missingConfigFiles.add(configFileName)
+        continue
+      }
 
-   try {
-    open(url).use {
-     val objectReader = if (jsonNode == null) {
-      mapper.readerFor(JsonNode::class.java)
-     } else {
-      mapper.readerForUpdating(jsonNode)
-     }
-     jsonNode = objectReader.readValue(it)
+      try {
+        open(url).use {
+          val objectReader = if (jsonNode == null) {
+            mapper.readerFor(JsonNode::class.java)
+          } else {
+            mapper.readerForUpdating(jsonNode)
+          }
+          jsonNode = objectReader.readValue(it)
+        }
+      } catch (e: Exception) {
+        throw IllegalStateException("could not parse $configFileName: ${e.message}", e)
+      }
     }
-   } catch (e: Exception) {
-    throw IllegalStateException("could not parse $configFileName: ${e.message}", e)
-   }
+
+    if (jsonNode == null) {
+      val configFileMessage = missingConfigFiles.joinToString(", ")
+      throw IllegalStateException(
+          "could not find configuration files - checked [$configFileMessage]"
+      )
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    try {
+      return mapper.readValue(jsonNode.toString(), configClass) as T
+    } catch (e: MissingKotlinParameterException) {
+      throw IllegalStateException("could not find configuration for ${e.parameter.name}", e)
+    } catch (e: Exception) {
+      throw IllegalStateException(e)
+    }
   }
 
-  if (jsonNode == null) {
-   val configFileMessage = missingConfigFiles.joinToString(", ")
-   throw IllegalStateException(
-     "could not find configuration files - checked [$configFileMessage]"
-   )
+  /** @return the list of config file names in the order they should be read */
+  private fun configFileNames(appName: String, environment: Environment): List<String> =
+      listOf("common", environment.name.toLowerCase()).map { "$appName-$it.yaml" }
+
+  private fun open(url: URL): BufferedReader {
+    return BufferedReader(InputStreamReader(url.openStream()))
   }
 
-  @Suppress("UNCHECKED_CAST")
-  try {
-   return mapper.readValue(jsonNode.toString(), configClass) as T
-  } catch (e: MissingKotlinParameterException) {
-   throw IllegalStateException("could not find configuration for ${e.parameter.name}", e)
-  } catch (e: Exception) {
-   throw IllegalStateException(e)
-  }
- }
-
- /** @return the list of config file names in the order they should be read */
- private fun configFileNames(appName: String, environment: Environment): List<String> =
-   listOf("common", environment.name.toLowerCase()).map { "$appName-$it.yaml" }
-
- private fun open(url: URL): BufferedReader {
-  return BufferedReader(InputStreamReader(url.openStream()))
- }
-
- private fun getResource(
-   configClass: Class<out Config>,
-   fileName: String
- ) = configClass.classLoader.getResource(fileName)
+  private fun getResource(
+      configClass: Class<out Config>,
+      fileName: String
+  ) = configClass.classLoader.getResource(fileName)
 }

--- a/misk/src/main/kotlin/misk/environment/Environment.kt
+++ b/misk/src/main/kotlin/misk/environment/Environment.kt
@@ -5,22 +5,25 @@ import misk.logging.getLogger
 private val logger = getLogger<Environment>()
 
 enum class Environment {
- TESTING, DEVELOPMENT, STAGING, PRODUCTION;
+  TESTING,
+  DEVELOPMENT,
+  STAGING,
+  PRODUCTION;
 
- companion object {
-   private val environmentKey = "ENVIRONMENT"
+  companion object {
+    private val environmentKey = "ENVIRONMENT"
 
-   @JvmStatic
-   fun fromEnvironmentVariable(): Environment {
-     val environmentName = System.getenv(environmentKey)
-     val environment = if (environmentName != null) {
-       Environment.valueOf(environmentName)
-     } else {
-       logger.warn { "No environment variable with key $environmentKey found, running in DEVELOPMENT" }
-       Environment.DEVELOPMENT
-     }
-     logger.info { "Running with environment ${environment.name}" }
-     return environment
-   }
- }
+    @JvmStatic
+    fun fromEnvironmentVariable(): Environment {
+      val environmentName = System.getenv(environmentKey)
+      val environment = if (environmentName != null) {
+        Environment.valueOf(environmentName)
+      } else {
+        logger.warn { "No environment variable with key $environmentKey found, running in DEVELOPMENT" }
+        Environment.DEVELOPMENT
+      }
+      logger.info { "Running with environment ${environment.name}" }
+      return environment
+    }
+  }
 }

--- a/misk/src/main/kotlin/misk/flags/Flags.kt
+++ b/misk/src/main/kotlin/misk/flags/Flags.kt
@@ -40,8 +40,8 @@ open class Flags internal constructor(val name: String, val context: Context) {
       return Property(flag, default)
     }
 
-    private class Property(val flag: misk.flags.Flag<String>, val default: String)
-      : ReadOnlyProperty<Flags, String> {
+    private class Property(val flag: misk.flags.Flag<String>, val default: String) :
+        ReadOnlyProperty<Flags, String> {
       override fun getValue(thisRef: Flags, property: KProperty<*>): String =
           flag.get() ?: default
     }
@@ -59,8 +59,10 @@ open class Flags internal constructor(val name: String, val context: Context) {
       return Property(flag, default)
     }
 
-    private class Property(val flag: misk.flags.Flag<Int>, val default: Int)
-      : ReadOnlyProperty<Flags, Int> {
+    private class Property(
+        val flag: misk.flags.Flag<Int>,
+        val default: Int
+    ) : ReadOnlyProperty<Flags, Int> {
       override fun getValue(thisRef: Flags, property: KProperty<*>): Int =
           flag.get() ?: default
     }
@@ -78,8 +80,8 @@ open class Flags internal constructor(val name: String, val context: Context) {
       return Property(flag, default)
     }
 
-    private class Property(val flag: misk.flags.Flag<Boolean>, val default: Boolean)
-      : ReadOnlyProperty<Flags, Boolean> {
+    private class Property(val flag: misk.flags.Flag<Boolean>, val default: Boolean) :
+        ReadOnlyProperty<Flags, Boolean> {
       override fun getValue(thisRef: Flags, property: KProperty<*>): Boolean =
           flag.get() ?: default
     }
@@ -97,8 +99,8 @@ open class Flags internal constructor(val name: String, val context: Context) {
       return Property(flag, default)
     }
 
-    private class Property(val flag: misk.flags.Flag<Double>, val default: Double)
-      : ReadOnlyProperty<Flags, Double> {
+    private class Property(val flag: misk.flags.Flag<Double>, val default: Double) :
+        ReadOnlyProperty<Flags, Double> {
       override fun getValue(thisRef: Flags, property: KProperty<*>): Double =
           flag.get() ?: default
     }

--- a/misk/src/main/kotlin/misk/flags/FlagsModule.kt
+++ b/misk/src/main/kotlin/misk/flags/FlagsModule.kt
@@ -35,7 +35,8 @@ abstract class FlagsModule : KAbstractModule() {
       name: String,
       description: String,
       type: KClass<T>,
-      qualifier: Annotation = Names.named(name)) {
+      qualifier: Annotation = Names.named(name)
+  ) {
     bind(flagTypeLiteral(type))
         .annotatedWith(qualifier)
         .toProvider(FlagProvider(type, name, description))

--- a/misk/src/main/kotlin/misk/healthchecks/HealthCheck.kt
+++ b/misk/src/main/kotlin/misk/healthchecks/HealthCheck.kt
@@ -15,8 +15,8 @@ interface HealthCheck {
 }
 
 data class HealthStatus(
-  val isHealthy: Boolean,
-  val messages: List<String>
+    val isHealthy: Boolean,
+    val messages: List<String>
 ) {
   companion object {
     fun healthy() = HealthStatus(true, listOf())

--- a/misk/src/main/kotlin/misk/healthchecks/HealthChecksModule.kt
+++ b/misk/src/main/kotlin/misk/healthchecks/HealthChecksModule.kt
@@ -3,7 +3,7 @@ package misk.healthchecks
 import misk.inject.KAbstractModule
 
 class HealthChecksModule(
-  private vararg val healthCheckClasses: Class<out HealthCheck>
+    private vararg val healthCheckClasses: Class<out HealthCheck>
 ) : KAbstractModule() {
   override fun configure() {
     val setBinder = newSetBinder<HealthCheck>()

--- a/misk/src/main/kotlin/misk/inject/Guice.kt
+++ b/misk/src/main/kotlin/misk/inject/Guice.kt
@@ -26,8 +26,9 @@ inline fun <reified T : Any> Binder.newMultibinder(
 ): Multibinder<T> {
   val typeLiteral =
       parameterizedType<List<*>>(subtypeOf<T>()).typeLiteral() as TypeLiteral<List<T>>
-  bind(typeLiteral).toProvider(parameterizedType<ListProvider<*>>(
-      T::class.java).typeLiteral() as TypeLiteral<Provider<List<T>>>)
+  bind(typeLiteral).toProvider(
+      parameterizedType<ListProvider<*>>(
+          T::class.java).typeLiteral() as TypeLiteral<Provider<List<T>>>)
 
   return when (annotation) {
     null -> Multibinder.newSetBinder(this, T::class.java)

--- a/misk/src/main/kotlin/misk/inject/KAbstractModule.kt
+++ b/misk/src/main/kotlin/misk/inject/KAbstractModule.kt
@@ -5,7 +5,6 @@ import com.google.inject.binder.AnnotatedBindingBuilder
 import com.google.inject.binder.LinkedBindingBuilder
 import com.google.inject.binder.ScopedBindingBuilder
 import com.google.inject.multibindings.Multibinder
-import javax.inject.Provider
 
 /**
  * A class that provides helper methods for working with Kotlin and Guice, allowing implementing

--- a/misk/src/main/kotlin/misk/metrics/MetricsScope.kt
+++ b/misk/src/main/kotlin/misk/metrics/MetricsScope.kt
@@ -23,7 +23,8 @@ open class MetricsScope internal constructor(
   }
 
   fun <T> cachedGauge(name: String, duration: Duration, f: () -> T): Gauge<T> {
-    val supplier = Suppliers.memoizeWithExpiration({ f.invoke() }, duration.toMillis(),
+    val supplier = Suppliers.memoizeWithExpiration(
+        { f.invoke() }, duration.toMillis(),
         TimeUnit.MILLISECONDS)
     return metricRegistry.register(scopedName(name), Gauge<T> { supplier.get() })
   }

--- a/misk/src/main/kotlin/misk/metrics/backends/graphite/GraphiteBackendModule.kt
+++ b/misk/src/main/kotlin/misk/metrics/backends/graphite/GraphiteBackendModule.kt
@@ -23,15 +23,15 @@ class GraphiteBackendModule : AbstractModule() {
   @Provides
   @Singleton
   fun graphiteSender(config: GraphiteBackendConfig): GraphiteSender =
-    Graphite(config.host, config.port)
+      Graphite(config.host, config.port)
 
   @Provides
   @Singleton
   fun graphiteReporter(
-    @AppName appName: String,
-    instanceMetadata: InstanceMetadata,
-    metricRegistry: MetricRegistry,
-    sender: GraphiteSender
+      @AppName appName: String,
+      instanceMetadata: InstanceMetadata,
+      metricRegistry: MetricRegistry,
+      sender: GraphiteSender
   ): GraphiteReporter {
 
     val instanceName = Metrics.sanitize(instanceMetadata.instanceName)

--- a/misk/src/main/kotlin/misk/metrics/backends/signalfx/SignalFxBackendModule.kt
+++ b/misk/src/main/kotlin/misk/metrics/backends/signalfx/SignalFxBackendModule.kt
@@ -11,7 +11,7 @@ import misk.inject.addMultibinderBinding
 import misk.inject.to
 import javax.inject.Singleton
 
-class SignalFxBackendModule : KAbstractModule(){
+class SignalFxBackendModule : KAbstractModule() {
   override fun configure() {
     binder().addMultibinderBinding<Service>().to<SignalFxReporterService>()
   }

--- a/misk/src/main/kotlin/misk/metrics/backends/stackdriver/StackDriverBatchedSender.kt
+++ b/misk/src/main/kotlin/misk/metrics/backends/stackdriver/StackDriverBatchedSender.kt
@@ -11,8 +11,8 @@ import misk.logging.getLogger
 import javax.inject.Inject
 
 internal class StackDriverBatchedSender @Inject internal constructor(
-  val monitoring: Monitoring,
-  val config: StackDriverBackendConfig
+    val monitoring: Monitoring,
+    val config: StackDriverBackendConfig
 ) : StackDriverSender {
   companion object {
     val logger = getLogger<StackDriverSender>()

--- a/misk/src/main/kotlin/misk/metrics/backends/stackdriver/StackDriverReporter.kt
+++ b/misk/src/main/kotlin/misk/metrics/backends/stackdriver/StackDriverReporter.kt
@@ -29,7 +29,8 @@ internal class StackDriverReporter @Inject internal constructor(
     val instanceMetadata: InstanceMetadata,
     val sender: StackDriverSender,
     metricRegistry: com.codahale.metrics.MetricRegistry
-) : ScheduledReporter(metricRegistry, "stack-driver", null,
+) : ScheduledReporter(
+    metricRegistry, "stack-driver", null,
     TimeUnit.MILLISECONDS, TimeUnit.MILLISECONDS) {
   private val startTime = DateTime(clock.millis())
 
@@ -38,8 +39,10 @@ internal class StackDriverReporter @Inject internal constructor(
       counters: SortedMap<String, Counter>?,
       histograms: SortedMap<String, Histogram>?,
       meters: SortedMap<String, Meter>?,
-      timers: SortedMap<String, Timer>?) {
-    val timeSeries = toTimeSeries(gauges, counters, histograms, meters,
+      timers: SortedMap<String, Timer>?
+  ) {
+    val timeSeries = toTimeSeries(
+        gauges, counters, histograms, meters,
         timers, startTime, DateTime(clock.millis()))
     if (timeSeries.isEmpty()) {
       return
@@ -66,7 +69,8 @@ internal class StackDriverReporter @Inject internal constructor(
       meters: SortedMap<String, Meter>?,
       timers: SortedMap<String, Timer>?,
       startTime: DateTime,
-      now: DateTime): List<TimeSeries> {
+      now: DateTime
+  ): List<TimeSeries> {
     val timeSeries = ArrayList<TimeSeries>()
     gauges?.forEach { timeSeries.addAll(toTimeSeries(it.key, it.value, startTime, now)) }
     counters?.forEach { timeSeries.addAll(toTimeSeries(it.key, it.value, startTime, now)) }
@@ -100,25 +104,35 @@ internal class StackDriverReporter @Inject internal constructor(
   ): Array<TimeSeries> {
     val snapshot = timer.snapshot
     return arrayOf(
-        timeSeries(name, convertDuration(snapshot.max.toDouble()), startTime, now, "max",
+        timeSeries(
+            name, convertDuration(snapshot.max.toDouble()), startTime, now, "max",
             MetricKind.GAUGE),
-        timeSeries(name, convertDuration(snapshot.min.toDouble()), startTime, now, "min",
+        timeSeries(
+            name, convertDuration(snapshot.min.toDouble()), startTime, now, "min",
             MetricKind.GAUGE),
-        timeSeries(name, convertDuration(snapshot.mean), startTime, now, "mean",
+        timeSeries(
+            name, convertDuration(snapshot.mean), startTime, now, "mean",
             MetricKind.GAUGE),
-        timeSeries(name, convertDuration(snapshot.stdDev), startTime, now, "stdDev",
+        timeSeries(
+            name, convertDuration(snapshot.stdDev), startTime, now, "stdDev",
             MetricKind.GAUGE),
-        timeSeries(name, convertDuration(snapshot.median), startTime, now, "p50",
+        timeSeries(
+            name, convertDuration(snapshot.median), startTime, now, "p50",
             MetricKind.GAUGE),
-        timeSeries(name, convertDuration(snapshot.get75thPercentile()), startTime, now,
+        timeSeries(
+            name, convertDuration(snapshot.get75thPercentile()), startTime, now,
             "p75", MetricKind.GAUGE),
-        timeSeries(name, convertDuration(snapshot.get95thPercentile()), startTime, now,
+        timeSeries(
+            name, convertDuration(snapshot.get95thPercentile()), startTime, now,
             "p95", MetricKind.GAUGE),
-        timeSeries(name, convertDuration(snapshot.get98thPercentile()), startTime, now,
+        timeSeries(
+            name, convertDuration(snapshot.get98thPercentile()), startTime, now,
             "p98", MetricKind.GAUGE),
-        timeSeries(name, convertDuration(snapshot.get99thPercentile()), startTime, now,
+        timeSeries(
+            name, convertDuration(snapshot.get99thPercentile()), startTime, now,
             "p99", MetricKind.GAUGE),
-        timeSeries(name, convertDuration(snapshot.get999thPercentile()), startTime, now,
+        timeSeries(
+            name, convertDuration(snapshot.get999thPercentile()), startTime, now,
             "p999", MetricKind.GAUGE),
         *toTimeSeries(name, timer as Metered, startTime, now))
   }
@@ -137,15 +151,20 @@ internal class StackDriverReporter @Inject internal constructor(
         timeSeries(name, snapshot.mean, startTime, now, "mean", MetricKind.GAUGE),
         timeSeries(name, snapshot.stdDev, startTime, now, "stdDev", MetricKind.GAUGE),
         timeSeries(name, snapshot.median, startTime, now, "p50", MetricKind.GAUGE),
-        timeSeries(name, snapshot.get75thPercentile(), startTime, now, "p75",
+        timeSeries(
+            name, snapshot.get75thPercentile(), startTime, now, "p75",
             MetricKind.GAUGE),
-        timeSeries(name, snapshot.get95thPercentile(), startTime, now, "p95",
+        timeSeries(
+            name, snapshot.get95thPercentile(), startTime, now, "p95",
             MetricKind.GAUGE),
-        timeSeries(name, snapshot.get98thPercentile(), startTime, now, "p98",
+        timeSeries(
+            name, snapshot.get98thPercentile(), startTime, now, "p98",
             MetricKind.GAUGE),
-        timeSeries(name, snapshot.get99thPercentile(), startTime, now, "p99",
+        timeSeries(
+            name, snapshot.get99thPercentile(), startTime, now, "p99",
             MetricKind.GAUGE),
-        timeSeries(name, snapshot.get999thPercentile(), startTime, now, "p999",
+        timeSeries(
+            name, snapshot.get999thPercentile(), startTime, now, "p999",
             MetricKind.GAUGE))
   }
 
@@ -156,13 +175,17 @@ internal class StackDriverReporter @Inject internal constructor(
       now: DateTime
   ): Array<TimeSeries> = arrayOf(
       timeSeries(name, metered.count, startTime, now, "count", MetricKind.CUMULATIVE),
-      timeSeries(name, convertRate(metered.oneMinuteRate), startTime, now, "m1_rate",
+      timeSeries(
+          name, convertRate(metered.oneMinuteRate), startTime, now, "m1_rate",
           MetricKind.GAUGE),
-      timeSeries(name, convertRate(metered.meanRate), startTime, now, "mean_rate",
+      timeSeries(
+          name, convertRate(metered.meanRate), startTime, now, "mean_rate",
           MetricKind.GAUGE),
-      timeSeries(name, convertRate(metered.fiveMinuteRate), startTime, now, "m5_rate",
+      timeSeries(
+          name, convertRate(metered.fiveMinuteRate), startTime, now, "m5_rate",
           MetricKind.GAUGE),
-      timeSeries(name, convertRate(metered.fifteenMinuteRate), startTime, now, "m15_rate",
+      timeSeries(
+          name, convertRate(metered.fifteenMinuteRate), startTime, now, "m15_rate",
           MetricKind.GAUGE))
 
   private fun timeSeries(
@@ -198,7 +221,8 @@ internal class StackDriverReporter @Inject internal constructor(
   }
 
   private fun type(root: String, vararg others: String) =
-      pathJoiner.join(CUSTOM_METRICS_PREFIX,
+      pathJoiner.join(
+          CUSTOM_METRICS_PREFIX,
           appName, instanceMetadata.zone, instanceMetadata.instanceName,
           root, *others)
 

--- a/misk/src/main/kotlin/misk/okio/OkioExtensions.kt
+++ b/misk/src/main/kotlin/misk/okio/OkioExtensions.kt
@@ -1,6 +1,5 @@
 package misk.okio
 
-import okio.Buffer
 import okio.BufferedSource
 
 fun BufferedSource.forEachBlock(buffer: ByteArray, f: (buffer: ByteArray, bytesRead: Int) -> Unit) {

--- a/misk/src/main/kotlin/misk/scope/ActionScope.kt
+++ b/misk/src/main/kotlin/misk/scope/ActionScope.kt
@@ -115,12 +115,12 @@ class ActionScope @Inject internal constructor(
       val wrapped: KFunction<T>
   ) : KFunction<T> {
     override fun call(vararg args: Any?): T = scope.enter(seedData).use {
-          wrapped.call(*args)
-        }
+      wrapped.call(*args)
+    }
 
     override fun callBy(args: Map<KParameter, Any?>): T = scope.enter(seedData).use {
-          wrapped.callBy(args)
-        }
+      wrapped.callBy(args)
+    }
 
     override val annotations: List<Annotation> = wrapped.annotations
     override val isAbstract: Boolean = wrapped.isAbstract

--- a/misk/src/main/kotlin/misk/scope/ActionScoped.kt
+++ b/misk/src/main/kotlin/misk/scope/ActionScoped.kt
@@ -2,11 +2,11 @@ package misk.scope
 
 /** Provides access to a context object specific to the current action */
 interface ActionScoped<out T> {
-  fun get() : T
+  fun get(): T
 
   companion object {
     /** @return an [ActionScoped] hard-coded to a specific value, useful for tests */
-    fun <T> of(value: T) = object: ActionScoped<T> {
+    fun <T> of(value: T) = object : ActionScoped<T> {
       override fun get() = value
     }
   }

--- a/misk/src/main/kotlin/misk/scope/ActionScopedProviderModule.kt
+++ b/misk/src/main/kotlin/misk/scope/ActionScopedProviderModule.kt
@@ -46,7 +46,8 @@ abstract class ActionScopedProviderModule : KAbstractModule() {
   /** Binds an unqualified [ActionScoped] along with its provider */
   fun <T : Any> bindProvider(
       kclass: KClass<T>,
-      providerClass: KClass<out ActionScopedProvider<T>>) {
+      providerClass: KClass<out ActionScopedProvider<T>>
+  ) {
     bindProvider(
         Key.get(kclass.java),
         Key.get(actionScopedType(kclass)),
@@ -57,7 +58,8 @@ abstract class ActionScopedProviderModule : KAbstractModule() {
   fun <T : Any> bindProvider(
       kclass: KClass<T>,
       a: Annotation,
-      providerClass: KClass<out ActionScopedProvider<T>>) {
+      providerClass: KClass<out ActionScopedProvider<T>>
+  ) {
     bindProvider(
         Key.get(kclass.java, a),
         Key.get(actionScopedType(kclass), a),
@@ -68,7 +70,8 @@ abstract class ActionScopedProviderModule : KAbstractModule() {
   fun <T : Any> bindProvider(
       kclass: KClass<T>,
       a: KClass<Annotation>,
-      providerClass: KClass<out ActionScopedProvider<T>>) {
+      providerClass: KClass<out ActionScopedProvider<T>>
+  ) {
     bindProvider(
         Key.get(kclass.java, a.java),
         Key.get(actionScopedType(kclass), a.java),

--- a/misk/src/main/kotlin/misk/security/keys/KeyService.kt
+++ b/misk/src/main/kotlin/misk/security/keys/KeyService.kt
@@ -5,8 +5,8 @@ import okio.ByteString
 /** Handles encryption and decryption using keys stored in a key management service */
 interface KeyService {
   /** encrypts the provided plain text using the given stored key */
-  fun encrypt(keyAlias: String, plainText: ByteString) : ByteString
+  fun encrypt(keyAlias: String, plainText: ByteString): ByteString
 
   /** decrypts the provided cipher text using the given stored key */
-  fun decrypt(keyAlias: String, cipherText: ByteString) : ByteString
+  fun decrypt(keyAlias: String, cipherText: ByteString): ByteString
 }

--- a/misk/src/main/kotlin/misk/security/ssl/KeystoreExtensions.kt
+++ b/misk/src/main/kotlin/misk/security/ssl/KeystoreExtensions.kt
@@ -27,7 +27,8 @@ fun KeyStore.getCertificateAndKey(alias: String, passphrase: CharArray): Certifi
 }
 
 /** @return the one and only [CertificateAndKey] in the keystore */
-fun KeyStore.getCertificateAndKey(passphrase: CharArray) = getCertificateAndKey(onlyAlias,
+fun KeyStore.getCertificateAndKey(passphrase: CharArray) = getCertificateAndKey(
+    onlyAlias,
     passphrase)
 
 /** @return the only alias in the keystore, if the keystore only has a single entry */

--- a/misk/src/main/kotlin/misk/tracing/TracingModule.kt
+++ b/misk/src/main/kotlin/misk/tracing/TracingModule.kt
@@ -4,13 +4,14 @@ import misk.inject.KAbstractModule
 import misk.tracing.backends.jaeger.JaegerBackendModule
 
 class TracingModule(val config: TracingConfig) : KAbstractModule() {
- override fun configure() {
-  if (config.tracer.equals("jaeger", true)) {
-   install(JaegerBackendModule(config.backends.jaeger))
-   return
-  }
+  override fun configure() {
+    if (config.tracer.equals("jaeger", true)) {
+      install(JaegerBackendModule(config.backends.jaeger))
+      return
+    }
 
-  throw IllegalArgumentException("No backend for '${config.tracer}' tracer. Ensure that " +
-    "tracer name is spelled correctly and that a backend module exists for that tracer.")
- }
+    throw IllegalArgumentException(
+        "No backend for '${config.tracer}' tracer. Ensure that " +
+            "tracer name is spelled correctly and that a backend module exists for that tracer.")
+  }
 }

--- a/misk/src/main/kotlin/misk/tracing/backends/TracingBackendConfig.kt
+++ b/misk/src/main/kotlin/misk/tracing/backends/TracingBackendConfig.kt
@@ -4,5 +4,5 @@ import misk.config.Config
 import misk.tracing.backends.jaeger.JaegerBackendConfig
 
 data class TracingBackendConfig(
-  val jaeger: JaegerBackendConfig?
+    val jaeger: JaegerBackendConfig?
 ) : Config

--- a/misk/src/main/kotlin/misk/tracing/backends/jaeger/JaegarSamplerConfig.kt
+++ b/misk/src/main/kotlin/misk/tracing/backends/jaeger/JaegarSamplerConfig.kt
@@ -2,8 +2,8 @@ package misk.tracing.backends.jaeger
 
 import misk.config.Config
 
-data class JaegerSamplerConfig (
- val type: String?,
- val param: Number?,
- val manager_host_port: String?
+data class JaegerSamplerConfig(
+    val type: String?,
+    val param: Number?,
+    val manager_host_port: String?
 ) : Config

--- a/misk/src/main/kotlin/misk/tracing/backends/jaeger/JaegerBackendConfig.kt
+++ b/misk/src/main/kotlin/misk/tracing/backends/jaeger/JaegerBackendConfig.kt
@@ -3,6 +3,6 @@ package misk.tracing.backends.jaeger
 import misk.config.Config
 
 data class JaegerBackendConfig(
- val sampler: JaegerSamplerConfig?,
- val reporter: JaegerReporterConfig?
+    val sampler: JaegerSamplerConfig?,
+    val reporter: JaegerReporterConfig?
 ) : Config

--- a/misk/src/main/kotlin/misk/tracing/backends/jaeger/JaegerBackendModule.kt
+++ b/misk/src/main/kotlin/misk/tracing/backends/jaeger/JaegerBackendModule.kt
@@ -12,25 +12,25 @@ import misk.inject.to
 import misk.tracing.TracingService
 
 class JaegerBackendModule(val config: JaegerBackendConfig?) : KAbstractModule() {
- override fun configure() {
-  binder().addMultibinderBinding<Service>().to<TracingService>()
- }
+  override fun configure() {
+    binder().addMultibinderBinding<Service>().to<TracingService>()
+  }
 
- @Provides
- @Singleton
- fun jaegerTracer(@AppName appName: String): Tracer {
-  val reporter =
-    if (config?.reporter == null) Configuration.ReporterConfiguration()
-    else Configuration.ReporterConfiguration(
-      config.reporter.log_spans, config.reporter.agent_host,
-      config.reporter.agent_port, config.reporter.flush_interval_ms,
-      config.reporter.max_queue_size)
+  @Provides
+  @Singleton
+  fun jaegerTracer(@AppName appName: String): Tracer {
+    val reporter =
+        if (config?.reporter == null) Configuration.ReporterConfiguration()
+        else Configuration.ReporterConfiguration(
+            config.reporter.log_spans, config.reporter.agent_host,
+            config.reporter.agent_port, config.reporter.flush_interval_ms,
+            config.reporter.max_queue_size)
 
-  val sampler =
-    if (config?.sampler == null) Configuration.SamplerConfiguration()
-    else Configuration.SamplerConfiguration(
-      config.sampler.type, config.sampler.param, config.sampler.manager_host_port)
+    val sampler =
+        if (config?.sampler == null) Configuration.SamplerConfiguration()
+        else Configuration.SamplerConfiguration(
+            config.sampler.type, config.sampler.param, config.sampler.manager_host_port)
 
-  return Configuration(appName, sampler, reporter).tracer
- }
+    return Configuration(appName, sampler, reporter).tracer
+  }
 }

--- a/misk/src/main/kotlin/misk/tracing/backends/jaeger/JaegerReporterConfig.kt
+++ b/misk/src/main/kotlin/misk/tracing/backends/jaeger/JaegerReporterConfig.kt
@@ -2,10 +2,10 @@ package misk.tracing.backends.jaeger
 
 import misk.config.Config
 
-data class JaegerReporterConfig (
- val log_spans: Boolean?,
- val agent_host: String?,
- val agent_port: Int?,
- val flush_interval_ms: Int?,
- val max_queue_size: Int?
+data class JaegerReporterConfig(
+    val log_spans: Boolean?,
+    val agent_host: String?,
+    val agent_port: Int?,
+    val flush_interval_ms: Int?,
+    val max_queue_size: Int?
 ) : Config

--- a/misk/src/main/kotlin/misk/web/BoundAction.kt
+++ b/misk/src/main/kotlin/misk/web/BoundAction.kt
@@ -5,10 +5,8 @@ import misk.web.actions.WebAction
 import misk.web.actions.asChain
 import misk.web.extractors.ParameterExtractor
 import misk.web.mediatype.MediaRange
-import okhttp3.Headers
 import okhttp3.HttpUrl
 import okhttp3.MediaType
-import okio.Okio
 import org.eclipse.jetty.http.HttpMethod
 import java.util.regex.Matcher
 import javax.inject.Provider

--- a/misk/src/main/kotlin/misk/web/PathPattern.kt
+++ b/misk/src/main/kotlin/misk/web/PathPattern.kt
@@ -36,6 +36,7 @@ data class PathPattern(
     // more specific match
     return other.numRegexVariables - numRegexVariables
   }
+
   companion object {
     fun parse(pattern: String): PathPattern {
       val variableNames = ArrayList<String>()
@@ -51,7 +52,7 @@ data class PathPattern(
         when (pattern[pos]) {
           '{' -> {
             // Variables must start on path boundaries
-            require(pos == 0 || pattern[pos-1] == '/') {
+            require(pos == 0 || pattern[pos - 1] == '/') {
               "invalid path pattern $pattern; variables must start on path boundaries"
             }
 
@@ -111,7 +112,8 @@ data class PathPattern(
         }
       }
 
-      return PathPattern(Pattern.compile(result.toString()), variableNames, numRegexVariables,
+      return PathPattern(
+          Pattern.compile(result.toString()), variableNames, numRegexVariables,
           numSegments, lastVariableIsWildcardMatch)
     }
   }

--- a/misk/src/main/kotlin/misk/web/RealChain.kt
+++ b/misk/src/main/kotlin/misk/web/RealChain.kt
@@ -6,11 +6,11 @@ import misk.web.actions.WebAction
 import kotlin.reflect.KFunction
 
 internal class RealChain(
-  private val _action: WebAction,
-  private val _args: List<Any?>,
-  private val interceptors: List<Interceptor>,
-  private val _function: KFunction<*>,
-  private val index: Int = 0
+    private val _action: WebAction,
+    private val _args: List<Any?>,
+    private val interceptors: List<Interceptor>,
+    private val _function: KFunction<*>,
+    private val index: Int = 0
 ) : Chain {
 
   override val action: WebAction

--- a/misk/src/main/kotlin/misk/web/Request.kt
+++ b/misk/src/main/kotlin/misk/web/Request.kt
@@ -6,8 +6,8 @@ import okio.BufferedSource
 import org.eclipse.jetty.http.HttpMethod
 
 data class Request(
-  val url: HttpUrl,
-  val method: HttpMethod,
-  val headers: Headers = Headers.of(),
-  val body: BufferedSource
+    val url: HttpUrl,
+    val method: HttpMethod,
+    val headers: Headers = Headers.of(),
+    val body: BufferedSource
 )

--- a/misk/src/main/kotlin/misk/web/Response.kt
+++ b/misk/src/main/kotlin/misk/web/Response.kt
@@ -7,9 +7,9 @@ import javax.servlet.http.HttpServletResponse
 
 /** An HTTP response body, headers, and status code. */
 data class Response<out T>(
-  val body: T,
-  val headers: Headers = Headers.of(),
-  val statusCode: Int = 200
+    val body: T,
+    val headers: Headers = Headers.of(),
+    val statusCode: Int = 200
 )
 
 interface ResponseBody {

--- a/misk/src/main/kotlin/misk/web/WebActionModule.kt
+++ b/misk/src/main/kotlin/misk/web/WebActionModule.kt
@@ -32,12 +32,14 @@ class WebActionModule<A : WebAction> private constructor(
     @Suppress("UNCHECKED_CAST")
     val binder: Multibinder<BoundAction<A, *>> = Multibinder.newSetBinder(
         binder(),
-        parameterizedType<BoundAction<*, *>>(subtypeOf<WebAction>(),
+        parameterizedType<BoundAction<*, *>>(
+            subtypeOf<WebAction>(),
             subtypeOf<Any>()).typeLiteral()
     ) as Multibinder<BoundAction<A, *>>
     binder.addBinding().toProvider(
-            BoundActionProvider(provider, member, pathPattern, httpMethod,
-                acceptedContentTypes, responseContentType))
+        BoundActionProvider(
+            provider, member, pathPattern, httpMethod,
+            acceptedContentTypes, responseContentType))
   }
 
   companion object {
@@ -65,9 +67,11 @@ class WebActionModule<A : WebAction> private constructor(
           val acceptedContentTypes = member.acceptedContentTypes
 
           result = when (annotation) {
-            is Get -> WebActionModule(webActionClass, member, annotation.pathPattern,
+            is Get -> WebActionModule(
+                webActionClass, member, annotation.pathPattern,
                 HttpMethod.GET, acceptedContentTypes, responseContentType)
-            is Post -> WebActionModule(webActionClass, member, annotation.pathPattern,
+            is Post -> WebActionModule(
+                webActionClass, member, annotation.pathPattern,
                 HttpMethod.POST, acceptedContentTypes, responseContentType)
             else -> throw AssertionError()
           }
@@ -117,7 +121,8 @@ internal class BoundActionProvider<A : WebAction, R>(
     miskInterceptorFactories.mapNotNullTo(interceptors) { it.create(action) }
     userProvidedInterceptorFactories.mapNotNullTo(interceptors) { it.create(action) }
 
-    return BoundAction(provider, interceptors, parameterExtractorFactories, function,
+    return BoundAction(
+        provider, interceptors, parameterExtractorFactories, function,
         PathPattern.parse(pathPattern), httpMethod, acceptedContentTypes,
         responseContentType)
   }

--- a/misk/src/main/kotlin/misk/web/WebConfig.kt
+++ b/misk/src/main/kotlin/misk/web/WebConfig.kt
@@ -22,5 +22,6 @@ data class WebSslConfig(
     REQUIRED,
     DESIRED
   }
+
   fun createSSLContext() = SslContextFactory.create(keystore, truststore)
 }

--- a/misk/src/main/kotlin/misk/web/WebModule.kt
+++ b/misk/src/main/kotlin/misk/web/WebModule.kt
@@ -33,7 +33,7 @@ import javax.servlet.http.HttpServletRequest
 class WebModule : KAbstractModule() {
   override fun configure() {
     install(JettyModule())
-    install(object: ActionScopedProviderModule() {
+    install(object : ActionScopedProviderModule() {
       override fun configureProviders() {
         bindSeedData(Request::class)
         bindSeedData(HttpServletRequest::class)
@@ -52,23 +52,29 @@ class WebModule : KAbstractModule() {
     // installed, and the order of these interceptors is critical.
 
     // Handle all unexpected errors that occur during dispatch
-    binder().addMultibinderBindingWithAnnotation<Interceptor.Factory, MiskDefault>().to<InternalErrorInterceptorFactory>()
+    binder().addMultibinderBindingWithAnnotation<Interceptor.Factory, MiskDefault>()
+        .to<InternalErrorInterceptorFactory>()
 
     // Optionally log request and response details
-    binder().addMultibinderBindingWithAnnotation<Interceptor.Factory, MiskDefault>().to<RequestLoggingInterceptor.Factory>()
+    binder().addMultibinderBindingWithAnnotation<Interceptor.Factory, MiskDefault>()
+        .to<RequestLoggingInterceptor.Factory>()
 
     // Collect metrics on the status of results and response times of requests
-    binder().addMultibinderBindingWithAnnotation<Interceptor.Factory, MiskDefault>().to<MetricsInterceptor.Factory>()
+    binder().addMultibinderBindingWithAnnotation<Interceptor.Factory, MiskDefault>()
+        .to<MetricsInterceptor.Factory>()
 
     // Convert and log application level exceptions into their appropriate response format
-    binder().addMultibinderBindingWithAnnotation<Interceptor.Factory, MiskDefault>().to<ExceptionHandlingInterceptor.Factory>()
+    binder().addMultibinderBindingWithAnnotation<Interceptor.Factory, MiskDefault>()
+        .to<ExceptionHandlingInterceptor.Factory>()
 
     // Convert typed responses into a ResponseBody that can marshal the response according to
     // the client's requested content-typ
-    binder().addMultibinderBindingWithAnnotation<Interceptor.Factory, MiskDefault>().to<MarshallerInterceptor.Factory>()
+    binder().addMultibinderBindingWithAnnotation<Interceptor.Factory, MiskDefault>()
+        .to<MarshallerInterceptor.Factory>()
 
     // Wrap "raw" responses with a Response object
-    binder().addMultibinderBindingWithAnnotation<Interceptor.Factory, MiskDefault>().to<BoxResponseInterceptorFactory>()
+    binder().addMultibinderBindingWithAnnotation<Interceptor.Factory, MiskDefault>()
+        .to<BoxResponseInterceptorFactory>()
 
     // Register build-in exception mappers
     install(ExceptionMapperModule.create<ActionException, ActionExceptionMapper>())

--- a/misk/src/main/kotlin/misk/web/actions/WebActions.kt
+++ b/misk/src/main/kotlin/misk/web/actions/WebActions.kt
@@ -8,9 +8,9 @@ import kotlin.reflect.KFunction
 import kotlin.reflect.KParameter
 
 fun WebAction.asChain(
-  function: KFunction<*>,
-  args: List<Any?>,
-  vararg _interceptors: Interceptor
+    function: KFunction<*>,
+    args: List<Any?>,
+    vararg _interceptors: Interceptor
 ): Chain {
   val interceptors = Lists.newArrayList(_interceptors.iterator())
   interceptors.add(object : Interceptor {

--- a/misk/src/main/kotlin/misk/web/exceptions/ExceptionHandlingInterceptor.kt
+++ b/misk/src/main/kotlin/misk/web/exceptions/ExceptionHandlingInterceptor.kt
@@ -11,7 +11,6 @@ import misk.web.Response
 import misk.web.marshal.StringResponseBody
 import misk.web.mediatype.MediaTypes
 import okhttp3.Headers
-import org.slf4j.event.Level
 import java.lang.reflect.InvocationTargetException
 import java.util.concurrent.ExecutionException
 import javax.inject.Inject
@@ -50,7 +49,7 @@ class ExceptionHandlingInterceptor(
   }
 
   class Factory @Inject internal constructor(
-    private val mapperResolver: ExceptionMapperResolver
+      private val mapperResolver: ExceptionMapperResolver
   ) : Interceptor.Factory {
     override fun create(action: Action) = ExceptionHandlingInterceptor(action.name, mapperResolver)
   }
@@ -58,7 +57,8 @@ class ExceptionHandlingInterceptor(
   private companion object {
     val log = getLogger<ExceptionHandlingInterceptor>()
 
-    val INTERNAL_SERVER_ERROR_RESPONSE = Response(StringResponseBody("internal server error"),
+    val INTERNAL_SERVER_ERROR_RESPONSE = Response(
+        StringResponseBody("internal server error"),
         Headers.of(listOf("Content-Type" to MediaTypes.TEXT_PLAIN_UTF8).toMap()),
         StatusCode.INTERNAL_SERVER_ERROR.code
     )

--- a/misk/src/main/kotlin/misk/web/exceptions/ExceptionMapperModule.kt
+++ b/misk/src/main/kotlin/misk/web/exceptions/ExceptionMapperModule.kt
@@ -26,21 +26,21 @@ import kotlin.reflect.KClass
  * maps to the ActionExceptionMapper since uses the binding of the closest bound superclass.
  */
 class ExceptionMapperModule<M : ExceptionMapper<T>, in T : Throwable>(
-  private val exceptionClass: KClass<T>,
-  private val mapperClass: KClass<M>
+    private val exceptionClass: KClass<T>,
+    private val mapperClass: KClass<M>
 ) : KAbstractModule() {
   override fun configure() {
-   MapBinder.newMapBinder(binder(), exceptionTypeLiteral, exceptionMapperTypeLiteral)
-     .addBinding(exceptionClass)
-     .to(mapperClass.java)
+    MapBinder.newMapBinder(binder(), exceptionTypeLiteral, exceptionMapperTypeLiteral)
+        .addBinding(exceptionClass)
+        .to(mapperClass.java)
   }
 
   companion object {
-   inline fun <reified T : Throwable, reified M : ExceptionMapper<T>> create() = ExceptionMapperModule(
-     T::class, M::class
-   )
+    inline fun <reified T : Throwable, reified M : ExceptionMapper<T>> create() = ExceptionMapperModule(
+        T::class, M::class
+    )
 
-   private val exceptionMapperTypeLiteral = object : TypeLiteral<ExceptionMapper<*>>() {}
-   private val exceptionTypeLiteral = object : TypeLiteral<KClass<*>>() {}
+    private val exceptionMapperTypeLiteral = object : TypeLiteral<ExceptionMapper<*>>() {}
+    private val exceptionTypeLiteral = object : TypeLiteral<KClass<*>>() {}
   }
 }

--- a/misk/src/main/kotlin/misk/web/exceptions/ExceptionMapperResolver.kt
+++ b/misk/src/main/kotlin/misk/web/exceptions/ExceptionMapperResolver.kt
@@ -10,34 +10,34 @@ import kotlin.reflect.full.superclasses
 
 @Singleton
 class ExceptionMapperResolver @Inject internal constructor(
-  private val mappers: @JvmSuppressWildcards Map<KClass<*>, ExceptionMapper<*>>
+    private val mappers: @JvmSuppressWildcards Map<KClass<*>, ExceptionMapper<*>>
 ) {
 
- private val cache: ConcurrentMap<KClass<*>, ExceptionMapper<Throwable>> = ConcurrentHashMap()
+  private val cache: ConcurrentMap<KClass<*>, ExceptionMapper<Throwable>> = ConcurrentHashMap()
 
- @Suppress("UNCHECKED_CAST")
- fun mapperFor(th: Throwable): ExceptionMapper<Throwable>? {
-  // The resolved Mapper is always the same, so cache it
-  return cache.getOrPut(th::class, {
-   val mappedException = getSuperclasses(th::class).firstOrNull { mappers.containsKey(it) }
-   return mappers[mappedException] as ExceptionMapper<Throwable>?
-  })
- }
-
- private fun getSuperclasses(kClass: KClass<*>): List<KClass<*>> {
-  val dfs = DFS()
-  dfs.doDFS(kClass)
-  return dfs.result
- }
-
- private class DFS {
-  val result: MutableList<KClass<*>> = mutableListOf()
-
-  fun doDFS(node: KClass<*>) {
-   result.add(node)
-   node.superclasses
-     .filter { it.isSubclassOf(Throwable::class) }
-     .forEach({ doDFS(it) })
+  @Suppress("UNCHECKED_CAST")
+  fun mapperFor(th: Throwable): ExceptionMapper<Throwable>? {
+    // The resolved Mapper is always the same, so cache it
+    return cache.getOrPut(th::class, {
+      val mappedException = getSuperclasses(th::class).firstOrNull { mappers.containsKey(it) }
+      return mappers[mappedException] as ExceptionMapper<Throwable>?
+    })
   }
- }
+
+  private fun getSuperclasses(kClass: KClass<*>): List<KClass<*>> {
+    val dfs = DFS()
+    dfs.doDFS(kClass)
+    return dfs.result
+  }
+
+  private class DFS {
+    val result: MutableList<KClass<*>> = mutableListOf()
+
+    fun doDFS(node: KClass<*>) {
+      result.add(node)
+      node.superclasses
+          .filter { it.isSubclassOf(Throwable::class) }
+          .forEach({ doDFS(it) })
+    }
+  }
 }

--- a/misk/src/main/kotlin/misk/web/extractors/QueryStringParameterProcessor.kt
+++ b/misk/src/main/kotlin/misk/web/extractors/QueryStringParameterProcessor.kt
@@ -12,8 +12,8 @@ internal class QueryStringParameterProcessor constructor(parameter: KParameter) 
   private val name: String? = parameter.name ?: parameter.type.javaType.typeName
   private val isList: Boolean = parameter.type.classifier?.equals(List::class) ?: false
   private val stringConverter = converterFor(
-    if (isList) parameter.type.arguments.first().type!!
-    else parameter.type
+      if (isList) parameter.type.arguments.first().type!!
+      else parameter.type
   ) ?: throw IllegalArgumentException("Unable to create converter for ${parameter.name}")
 
   fun extractFunctionArgumentValue(parameterStrings: List<String>): Any? {
@@ -23,8 +23,8 @@ internal class QueryStringParameterProcessor constructor(parameter: KParameter) 
 
     try {
       return if (isList) parameterStrings.map { stringConverter(it) }
-       else stringConverter(parameterStrings.first())
-    } catch(e: IllegalArgumentException) {
+      else stringConverter(parameterStrings.first())
+    } catch (e: IllegalArgumentException) {
       throw IllegalArgumentException("Invalid format for parameter: $name", e)
     }
   }

--- a/misk/src/main/kotlin/misk/web/extractors/StringConverter.kt
+++ b/misk/src/main/kotlin/misk/web/extractors/StringConverter.kt
@@ -20,39 +20,39 @@ private val booleanTypeNullable: KType = Boolean::class.createType(nullable = tr
 internal typealias StringConverter = (String) -> Any?
 
 internal fun converterFor(type: KType): StringConverter? = when (type) {
- stringType -> { it -> it }
- stringTypeNullable -> { it -> it }
- intType -> numberConversionWrapper { it.toInt() }
- intTypeNullable -> numberConversionWrapper { it.toInt() }
- longType -> numberConversionWrapper { it.toLong() }
- longTypeNullable -> numberConversionWrapper { it.toLong() }
- doubleType -> numberConversionWrapper { it.toDouble() }
- doubleTypeNullable -> numberConversionWrapper { it.toDouble() }
- booleanType -> numberConversionWrapper { it.toBoolean() }
- booleanTypeNullable -> numberConversionWrapper { it.toBoolean() }
- else -> createFromValueOf(type)
+  stringType -> { it -> it }
+  stringTypeNullable -> { it -> it }
+  intType -> numberConversionWrapper { it.toInt() }
+  intTypeNullable -> numberConversionWrapper { it.toInt() }
+  longType -> numberConversionWrapper { it.toLong() }
+  longTypeNullable -> numberConversionWrapper { it.toLong() }
+  doubleType -> numberConversionWrapper { it.toDouble() }
+  doubleTypeNullable -> numberConversionWrapper { it.toDouble() }
+  booleanType -> numberConversionWrapper { it.toBoolean() }
+  booleanTypeNullable -> numberConversionWrapper { it.toBoolean() }
+  else -> createFromValueOf(type)
 }
 
 private fun numberConversionWrapper(wrappedFunc: StringConverter): StringConverter {
- return {
-  try {
-   wrappedFunc(it)
-  } catch(e: NumberFormatException) {
-   throw IllegalArgumentException("Invalid parameter format: $it", e)
+  return {
+    try {
+      wrappedFunc(it)
+    } catch (e: NumberFormatException) {
+      throw IllegalArgumentException("Invalid parameter format: $it", e)
+    }
   }
- }
 }
 
 private fun createFromValueOf(type: KType): StringConverter? {
- try {
-  @Suppress("UNCHECKED_CAST")
-  val javaClass = type.javaType as Class<Any>?
-  val valueOfMethod = javaClass?.getMethod("valueOf", String::class.java)
-  if (valueOfMethod != null) {
-   return { param -> valueOfMethod(null, param) }
+  try {
+    @Suppress("UNCHECKED_CAST")
+    val javaClass = type.javaType as Class<Any>?
+    val valueOfMethod = javaClass?.getMethod("valueOf", String::class.java)
+    if (valueOfMethod != null) {
+      return { param -> valueOfMethod(null, param) }
+    }
+  } catch (e: ClassCastException) {
+  } catch (e: NoSuchMethodException) {
   }
- } catch(e: ClassCastException) {
- } catch(e: NoSuchMethodException) {
- }
- return null
+  return null
 }

--- a/misk/src/main/kotlin/misk/web/interceptors/MarshallerInterceptor.kt
+++ b/misk/src/main/kotlin/misk/web/interceptors/MarshallerInterceptor.kt
@@ -1,6 +1,5 @@
 package misk.web.interceptors
 
-import com.google.inject.TypeLiteral
 import misk.Action
 import misk.Chain
 import misk.Interceptor
@@ -16,8 +15,8 @@ import kotlin.reflect.KType
 import kotlin.reflect.full.findAnnotation
 
 @Singleton
-internal class MarshallerInterceptor constructor(private val marshaller: Marshaller<Any>)
-  : Interceptor {
+internal class MarshallerInterceptor constructor(private val marshaller: Marshaller<Any>) :
+    Interceptor {
   override fun intercept(chain: Chain): Response<Any> {
     @Suppress("UNCHECKED_CAST")
     val response = chain.proceed(chain.args) as Response<Any>
@@ -57,8 +56,8 @@ internal class MarshallerInterceptor constructor(private val marshaller: Marshal
     }
 
     private fun genericMarshallerFor(mediaType: MediaType?, type: KType): Marshaller<Any> {
-      return GenericMarshallers.from(mediaType, type) ?:
-          throw IllegalArgumentException("no marshaller for $mediaType as $type")
+      return GenericMarshallers.from(mediaType, type) ?: throw IllegalArgumentException(
+          "no marshaller for $mediaType as $type")
     }
   }
 }

--- a/misk/src/main/kotlin/misk/web/jetty/WebActionsServlet.kt
+++ b/misk/src/main/kotlin/misk/web/jetty/WebActionsServlet.kt
@@ -41,7 +41,7 @@ internal class WebActionsServlet @Inject constructor(
       val candidateActions = boundActions.mapNotNull { it.match(request, asRequest.url) }
       val bestAction = candidateActions.sorted().firstOrNull()
       bestAction?.handle(asRequest, response)
-      logger.debug {"Request handled by WebActionServlet" }
+      logger.debug { "Request handled by WebActionServlet" }
     }
   }
 }

--- a/misk/src/main/kotlin/misk/web/mediatype/MediaRange.kt
+++ b/misk/src/main/kotlin/misk/web/mediatype/MediaRange.kt
@@ -49,8 +49,8 @@ data class MediaRange(
     return Matcher(this, true)
   }
 
-  data class Matcher(private val mediaRange: MediaRange, val matchesCharset: Boolean = false)
-    : Comparable<Matcher> {
+  data class Matcher(private val mediaRange: MediaRange, val matchesCharset: Boolean = false) :
+      Comparable<Matcher> {
     override fun compareTo(other: Matcher): Int {
       val mediaRangeComparison = mediaRange.compareTo(other.mediaRange)
       if (mediaRangeComparison != 0) return mediaRangeComparison


### PR DESCRIPTION
This fixes some places where my re-indenter cut 2-space indented files down to 1.
It also fixes some places where wrapped parameters were not indented +4.

And some other assorted reformattings to follow IntelliJ's rules. Probably the
most interesting is that if parameters are at all multiline, they are strictly
multiline.