### PR TITLE
Mechanically reformat the Misk codebase.

### DIFF
--- a/exemplar/src/main/java/com/squareup/exemplar/ExemplarJavaApp.java
+++ b/exemplar/src/main/java/com/squareup/exemplar/ExemplarJavaApp.java
@@ -7,7 +7,6 @@ import misk.config.MiskConfig;
 import misk.environment.Environment;
 import misk.environment.EnvironmentModule;
 import misk.hibernate.HibernateModule;
-import misk.moshi.MoshiModule;
 import misk.web.WebModule;
 
 public class ExemplarJavaApp {

--- a/exemplar/src/main/kotlin/com/squareup/exemplar/ExemplarModule.kt
+++ b/exemplar/src/main/kotlin/com/squareup/exemplar/ExemplarModule.kt
@@ -6,10 +6,10 @@ import com.squareup.exemplar.actions.HelloWebAction
 import com.squareup.exemplar.actions.HelloWebPostAction
 import misk.metrics.web.MetricsJsonAction
 import misk.web.WebActionModule
-import misk.web.actions.ReadinessCheckAction
 import misk.web.actions.InternalErrorAction
 import misk.web.actions.LivenessCheckAction
 import misk.web.actions.NotFoundAction
+import misk.web.actions.ReadinessCheckAction
 
 class ExemplarModule : AbstractModule() {
   override fun configure() {

--- a/exemplar/src/main/kotlin/com/squareup/exemplar/actions/EchoFormAction.kt
+++ b/exemplar/src/main/kotlin/com/squareup/exemplar/actions/EchoFormAction.kt
@@ -19,10 +19,10 @@ class EchoFormAction : WebAction {
   }
 
   data class Form(
-      val string: String,
-      val int: Int,
-      val nullable: String?,
-      val optional: String = "optional",
-      @FormField("list-of-strings") val list: List<String>
+    val string: String,
+    val int: Int,
+    val nullable: String?,
+    val optional: String = "optional",
+    @FormField("list-of-strings") val list: List<String>
   )
 }

--- a/exemplar/src/main/kotlin/com/squareup/exemplar/actions/HelloWebAction.kt
+++ b/exemplar/src/main/kotlin/com/squareup/exemplar/actions/HelloWebAction.kt
@@ -15,10 +15,10 @@ class HelloWebAction : WebAction {
   @Get("/hello/{name}")
   @ResponseContentType(MediaTypes.APPLICATION_JSON)
   fun hello(
-      @PathParam name: String,
-      @RequestHeaders headers: Headers,
-      @QueryParam nickName: String?,
-      @QueryParam greetings: List<String>?
+    @PathParam name: String,
+    @RequestHeaders headers: Headers,
+    @QueryParam nickName: String?,
+    @QueryParam greetings: List<String>?
   ): HelloResponse {
     return HelloResponse(
         greetings?.joinToString(separator = " ") ?: "YO",

--- a/exemplar/src/test/kotlin/com/squareup/exemplar/HelloWebActionTest.kt
+++ b/exemplar/src/test/kotlin/com/squareup/exemplar/HelloWebActionTest.kt
@@ -2,19 +2,19 @@ package com.squareup.exemplar
 
 import com.squareup.exemplar.actions.HelloResponse
 import com.squareup.exemplar.actions.HelloWebAction
-import org.assertj.core.api.Assertions.assertThat
 import misk.testing.MiskTest
 import okhttp3.Headers
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import javax.inject.Inject
 
 @MiskTest
 class HelloWebActionTest {
- @Inject lateinit var helloWebAction: HelloWebAction
+  @Inject lateinit var helloWebAction: HelloWebAction
 
- @Test
- fun test() {
-  assertThat(helloWebAction.hello("sandy", Headers.of(), null, null))
-    .isEqualTo(HelloResponse("YO", "SANDY"))
- }
+  @Test
+  fun test() {
+    assertThat(helloWebAction.hello("sandy", Headers.of(), null, null))
+        .isEqualTo(HelloResponse("YO", "SANDY"))
+  }
 }

--- a/misk/src/main/kotlin/misk/MiskApplication.kt
+++ b/misk/src/main/kotlin/misk/MiskApplication.kt
@@ -80,11 +80,11 @@ class MiskApplication(private val modules: List<Module>, commands: List<MiskComm
     val injector = Guice.createInjector(modules)
     val serviceManager = injector.getInstance<ServiceManager>()
     Runtime.getRuntime().addShutdownHook(object : Thread() {
-          override fun run() {
-            serviceManager.stopAsync()
-            serviceManager.awaitStopped()
-          }
-        })
+      override fun run() {
+        serviceManager.stopAsync()
+        serviceManager.awaitStopped()
+      }
+    })
 
     serviceManager.startAsync()
     serviceManager.awaitHealthy()

--- a/misk/src/main/kotlin/misk/MiskCommand.kt
+++ b/misk/src/main/kotlin/misk/MiskCommand.kt
@@ -12,7 +12,10 @@ import javax.inject.Inject
  * pick the appropriate command based on the name, create an injector based on that
  * command's modules, use the injector to initialize the command, and then run the command.
  */
-abstract class MiskCommand(internal val name: String, internal val modules: List<Module>) : Runnable {
+abstract class MiskCommand(
+  internal val name: String,
+  internal val modules: List<Module>
+) : Runnable {
   constructor(name: String, vararg modules: Module) : this(name, modules.toList())
 
   @Inject

--- a/misk/src/main/kotlin/misk/client/HttpClientModule.kt
+++ b/misk/src/main/kotlin/misk/client/HttpClientModule.kt
@@ -10,8 +10,8 @@ import javax.inject.Inject
 /** Provides an [OkHttpClient] and [ProtoMessageHttpClient] for a peer service */
 // TODO(mmihic): Replace with something that binds a typed client via retrofit
 class HttpClientModule constructor(
-    private val name: String,
-    private val annotation: Annotation? = null
+  private val name: String,
+  private val annotation: Annotation? = null
 ) : KAbstractModule() {
   override fun configure() {
     val httpClientKey =
@@ -33,8 +33,8 @@ class HttpClientModule constructor(
   }
 
   private class ProtoMessageHttpClientProvider(
-      private val name: String,
-      private val httpClientProvider: Provider<OkHttpClient>
+    private val name: String,
+    private val httpClientProvider: Provider<OkHttpClient>
   ) : Provider<ProtoMessageHttpClient> {
     @Inject
     lateinit var moshi: Moshi

--- a/misk/src/main/kotlin/misk/client/HttpClientsConfig.kt
+++ b/misk/src/main/kotlin/misk/client/HttpClientsConfig.kt
@@ -10,11 +10,11 @@ import java.util.concurrent.TimeUnit
 import javax.net.ssl.X509TrustManager
 
 data class HttpClientsConfig(
-    private val defaultConnectTimeout: Duration? = null,
-    private val defaultWriteTimeout: Duration? = null,
-    private val defaultReadTimeout: Duration? = null,
-    private val ssl: HttpClientSSLConfig? = null,
-    val endpoints: Map<String, HttpClientEndpointConfig> = mapOf()
+  private val defaultConnectTimeout: Duration? = null,
+  private val defaultWriteTimeout: Duration? = null,
+  private val defaultReadTimeout: Duration? = null,
+  private val ssl: HttpClientSSLConfig? = null,
+  val endpoints: Map<String, HttpClientEndpointConfig> = mapOf()
 ) : Config {
   /** @return a client built from this configuration */
   fun newHttpClient(clientName: String): OkHttpClient {
@@ -46,16 +46,16 @@ data class HttpClientsConfig(
 }
 
 data class HttpClientSSLConfig(
-    val keystore: KeystoreConfig?,
-    val truststore: KeystoreConfig
+  val keystore: KeystoreConfig?,
+  val truststore: KeystoreConfig
 ) {
   fun createSSLContext() = SslContextFactory.create(keystore, truststore)
 }
 
 data class HttpClientEndpointConfig(
-    val url: String,
-    val connectTimeout: Duration? = null,
-    val writeTimeout: Duration? = null,
-    val readTimeout: Duration? = null,
-    val ssl: HttpClientSSLConfig? = null
+  val url: String,
+  val connectTimeout: Duration? = null,
+  val writeTimeout: Duration? = null,
+  val readTimeout: Duration? = null,
+  val ssl: HttpClientSSLConfig? = null
 )

--- a/misk/src/main/kotlin/misk/client/ProtoMessageHttpClient.kt
+++ b/misk/src/main/kotlin/misk/client/ProtoMessageHttpClient.kt
@@ -13,9 +13,9 @@ import okhttp3.RequestBody
  * classes.
  */
 class ProtoMessageHttpClient constructor(
-    baseUrl: String,
-    private val moshi: Moshi,
-    private val okHttp: OkHttpClient
+  baseUrl: String,
+  private val moshi: Moshi,
+  private val okHttp: OkHttpClient
 ) {
   private val httpUrl = HttpUrl.parse(baseUrl) ?: throw IllegalArgumentException(
       "could not parse $baseUrl")

--- a/misk/src/main/kotlin/misk/client/TypedHttpClientModule.kt
+++ b/misk/src/main/kotlin/misk/client/TypedHttpClientModule.kt
@@ -11,9 +11,9 @@ import kotlin.reflect.KClass
 
 /** Creates a retrofit-backed typed client given an API interface and an HTTP configuration */
 class TypedHttpClientModule<T : Any>(
-    private val kclass: KClass<T>,
-    private val name: String,
-    private val annotation: Annotation? = null
+  private val kclass: KClass<T>,
+  private val name: String,
+  private val annotation: Annotation? = null
 ) : KAbstractModule() {
   override fun configure() {
     install(HttpClientModule(name, annotation))
@@ -24,16 +24,16 @@ class TypedHttpClientModule<T : Any>(
 
   companion object {
     inline fun <reified T : Any> create(
-        name: String,
-        annotation: Annotation? = null
+      name: String,
+      annotation: Annotation? = null
     ): TypedHttpClientModule<T> {
       return TypedHttpClientModule(T::class, name, annotation)
     }
   }
 
   private class TypedClientProvider<T : Any>(
-      val kclass: KClass<T>,
-      val name: String
+    val kclass: KClass<T>,
+    val name: String
   ) : Provider<T> {
     @Inject
     private lateinit var httpClientsConfig: HttpClientsConfig

--- a/misk/src/main/kotlin/misk/cloud/aws/environment/AwsInstanceMetadataProvider.kt
+++ b/misk/src/main/kotlin/misk/cloud/aws/environment/AwsInstanceMetadataProvider.kt
@@ -6,7 +6,7 @@ import okhttp3.Request
 import javax.inject.Provider
 
 internal class AwsInstanceMetadataProvider(
-    val serverUrl: String = AWS_INSTANCE_METADATA_SERVER
+  val serverUrl: String = AWS_INSTANCE_METADATA_SERVER
 ) : Provider<InstanceMetadata> {
 
   companion object {

--- a/misk/src/main/kotlin/misk/cloud/gcp/GoogleCloudModule.kt
+++ b/misk/src/main/kotlin/misk/cloud/gcp/GoogleCloudModule.kt
@@ -84,8 +84,8 @@ class GoogleCloudModule : KAbstractModule() {
 
 /** Logs cloud configuration on startup */
 private class GoogleCloud @Inject internal constructor(
-    private val datastore: Datastore,
-    private val storage: Storage
+  private val datastore: Datastore,
+  private val storage: Storage
 ) : AbstractIdleService() {
   override fun startUp() {
     log.info { "running as project ${datastore.options.projectId}" }

--- a/misk/src/main/kotlin/misk/cloud/gcp/TransportConfig.kt
+++ b/misk/src/main/kotlin/misk/cloud/gcp/TransportConfig.kt
@@ -2,7 +2,7 @@ package misk.cloud.gcp
 
 /** Transport configuration for GCP services. */
 data class TransportConfig(
-    val connect_timeout_ms: Int = -1,
-    val read_timeout_ms: Int = -1,
-    val host: String? = null
+  val connect_timeout_ms: Int = -1,
+  val read_timeout_ms: Int = -1,
+  val host: String? = null
 )

--- a/misk/src/main/kotlin/misk/cloud/gcp/datastore/DatastoreConfig.kt
+++ b/misk/src/main/kotlin/misk/cloud/gcp/datastore/DatastoreConfig.kt
@@ -5,5 +5,5 @@ import misk.config.Config
 
 /** Configuration for talking to Google datastore */
 data class DatastoreConfig(
-    val transport: TransportConfig = TransportConfig()
+  val transport: TransportConfig = TransportConfig()
 ) : Config

--- a/misk/src/main/kotlin/misk/cloud/gcp/datastore/DatastoreExtensions.kt
+++ b/misk/src/main/kotlin/misk/cloud/gcp/datastore/DatastoreExtensions.kt
@@ -15,7 +15,7 @@ fun Entity.getByteString(name: String) = getBlob(name).toByteString()
 fun <T> Entity.getProto(name: String, protoAdapter: ProtoAdapter<T>): T =
     protoAdapter.decode(getByteString(name))
 
-fun Entity.Builder.set(name: String, bytes: ByteString) : Entity.Builder =
+fun Entity.Builder.set(name: String, bytes: ByteString): Entity.Builder =
     set(name, Blob.copyFrom(bytes.asByteBuffer()))
 
 fun <T> QueryResults<T>.asList(): List<T> = asSequence().toList()

--- a/misk/src/main/kotlin/misk/cloud/gcp/environment/GcpInstanceMetadataProvider.kt
+++ b/misk/src/main/kotlin/misk/cloud/gcp/environment/GcpInstanceMetadataProvider.kt
@@ -7,7 +7,7 @@ import javax.inject.Inject
 import javax.inject.Provider
 
 internal class GcpInstanceMetadataProvider @Inject internal constructor(
-    val serverUrl: String = GCP_INSTANCE_METADATA_SERVER
+  val serverUrl: String = GCP_INSTANCE_METADATA_SERVER
 ) : Provider<InstanceMetadata> {
 
   companion object {

--- a/misk/src/main/kotlin/misk/cloud/gcp/security/keys/GcpKeyService.kt
+++ b/misk/src/main/kotlin/misk/cloud/gcp/security/keys/GcpKeyService.kt
@@ -9,8 +9,8 @@ import java.nio.ByteBuffer
 import javax.inject.Inject
 
 internal class GcpKeyService @Inject internal constructor(
-    kms: CloudKMS,
-    val config: GcpKmsConfig
+  kms: CloudKMS,
+  val config: GcpKmsConfig
 ) : KeyService {
   val cryptoKeys = kms.projects().locations().keyRings().cryptoKeys()
 

--- a/misk/src/main/kotlin/misk/cloud/gcp/security/keys/GcpKmsConfig.kt
+++ b/misk/src/main/kotlin/misk/cloud/gcp/security/keys/GcpKmsConfig.kt
@@ -3,8 +3,8 @@ package misk.cloud.gcp.security.keys
 import misk.config.Config
 
 data class GcpKmsConfig(
-    val project_id: String,
-    val key_locations: Map<String, GcpKeyLocation>
+  val project_id: String,
+  val key_locations: Map<String, GcpKeyLocation>
 ) : Config
 
 data class GcpKeyLocation(val location: String, val key_ring: String, val key_name: String) {

--- a/misk/src/main/kotlin/misk/cloud/gcp/storage/BaseCustomStorageRpc.kt
+++ b/misk/src/main/kotlin/misk/cloud/gcp/storage/BaseCustomStorageRpc.kt
@@ -68,18 +68,18 @@ abstract class BaseCustomStorageRpc : StorageRpc {
   }
 
   override fun getAcl(
-      bucket: String?,
-      entity: String?,
-      options: Map<StorageRpc.Option, *>?
+    bucket: String?,
+    entity: String?,
+    options: Map<StorageRpc.Option, *>?
   ): BucketAccessControl {
     throw UnsupportedOperationException()
   }
 
   override fun getAcl(
-      bucket: String?,
-      obj: String?,
-      generation: Long?,
-      entity: String?
+    bucket: String?,
+    obj: String?,
+    generation: Long?,
+    entity: String?
   ): ObjectAccessControl {
     throw UnsupportedOperationException()
   }
@@ -89,9 +89,9 @@ abstract class BaseCustomStorageRpc : StorageRpc {
   }
 
   override fun testIamPermissions(
-      bucket: String,
-      permissions: List<String>,
-      options: Map<StorageRpc.Option, *>
+    bucket: String,
+    permissions: List<String>,
+    options: Map<StorageRpc.Option, *>
   ): TestIamPermissionsResponse {
     throw UnsupportedOperationException()
   }
@@ -109,15 +109,17 @@ abstract class BaseCustomStorageRpc : StorageRpc {
     throw UnsupportedOperationException()
   }
 
-  override fun listAcls(bucket: String?,
-      options: Map<StorageRpc.Option, *>?): List<BucketAccessControl> {
+  override fun listAcls(
+    bucket: String?,
+    options: Map<StorageRpc.Option, *>?
+  ): List<BucketAccessControl> {
     throw UnsupportedOperationException()
   }
 
   override fun listAcls(
-      bucket: String?,
-      obj: String?,
-      generation: Long?
+    bucket: String?,
+    obj: String?,
+    generation: Long?
   ): List<ObjectAccessControl> {
     throw UnsupportedOperationException()
   }
@@ -126,23 +128,31 @@ abstract class BaseCustomStorageRpc : StorageRpc {
     throw UnsupportedOperationException()
   }
 
-  override fun deleteAcl(bucket: String?, entity: String?,
-      options: Map<StorageRpc.Option, *>?): Boolean {
+  override fun deleteAcl(
+    bucket: String?, entity: String?,
+    options: Map<StorageRpc.Option, *>?
+  ): Boolean {
     throw UnsupportedOperationException()
   }
 
-  override fun deleteAcl(bucket: String?, `object`: String?, generation: Long?,
-      entity: String?): Boolean {
+  override fun deleteAcl(
+    bucket: String?, `object`: String?, generation: Long?,
+    entity: String?
+  ): Boolean {
     throw UnsupportedOperationException()
   }
 
-  override fun compose(sources: Iterable<StorageObject>?, target: StorageObject?,
-      targetOptions: Map<StorageRpc.Option, *>?): StorageObject {
+  override fun compose(
+    sources: Iterable<StorageObject>?, target: StorageObject?,
+    targetOptions: Map<StorageRpc.Option, *>?
+  ): StorageObject {
     throw UnsupportedOperationException()
   }
 
-  override fun setIamPolicy(bucket: String?, policy: Policy?,
-      options: Map<StorageRpc.Option, *>?): Policy {
+  override fun setIamPolicy(
+    bucket: String?, policy: Policy?,
+    options: Map<StorageRpc.Option, *>?
+  ): Policy {
     throw UnsupportedOperationException()
   }
 

--- a/misk/src/main/kotlin/misk/cloud/gcp/storage/LocalStorageRpc.kt
+++ b/misk/src/main/kotlin/misk/cloud/gcp/storage/LocalStorageRpc.kt
@@ -103,9 +103,9 @@ class LocalStorageRpc(root: Path, moshi: Moshi = Moshi.Builder().build()) : Base
   private val uploads = mutableMapOf<String, Upload>()
 
   override fun create(
-      obj: StorageObject,
-      content: InputStream,
-      options: Map<StorageRpc.Option, *>
+    obj: StorageObject,
+    content: InputStream,
+    options: Map<StorageRpc.Option, *>
   ): StorageObject? {
     try {
       val upload = beginUpload(obj, options)
@@ -124,8 +124,8 @@ class LocalStorageRpc(root: Path, moshi: Moshi = Moshi.Builder().build()) : Base
   }
 
   override fun list(
-      bucket: String,
-      options: Map<StorageRpc.Option, *>
+    bucket: String,
+    options: Map<StorageRpc.Option, *>
   ): Tuple<String, Iterable<StorageObject>> {
     try {
       val delimiter = options[StorageRpc.Option.DELIMITER]?.toString()
@@ -222,10 +222,10 @@ class LocalStorageRpc(root: Path, moshi: Moshi = Moshi.Builder().build()) : Base
   }
 
   override fun read(
-      from: StorageObject,
-      options: Map<StorageRpc.Option, *>,
-      zposition: Long,
-      zbytes: Int
+    from: StorageObject,
+    options: Map<StorageRpc.Option, *>,
+    zposition: Long,
+    zbytes: Int
   ): Tuple<String, ByteArray> = try {
     withReadLock(from.blobId) {
       val metadata = getMetadataForReading(from.blobId, options)
@@ -251,12 +251,12 @@ class LocalStorageRpc(root: Path, moshi: Moshi = Moshi.Builder().build()) : Base
       beginUpload(obj, options).id
 
   override fun write(
-      uploadId: String,
-      toWrite: ByteArray,
-      toWriteOffset: Int,
-      destOffset: Long,
-      length: Int,
-      last: Boolean
+    uploadId: String,
+    toWrite: ByteArray,
+    toWriteOffset: Int,
+    destOffset: Long,
+    length: Int,
+    last: Boolean
   ) {
     try {
       val upload = continueUpload(uploadId, toWrite, toWriteOffset, destOffset, length)
@@ -356,8 +356,8 @@ class LocalStorageRpc(root: Path, moshi: Moshi = Moshi.Builder().build()) : Base
   }
 
   private fun getMetadataForWriting(
-      blobId: BlobId,
-      options: Map<StorageRpc.Option, *>
+    blobId: BlobId,
+    options: Map<StorageRpc.Option, *>
   ): BlobMetadata? {
     val existingMetadata = readMetadata(blobId)
     options.generationMatch?.let {
@@ -378,8 +378,8 @@ class LocalStorageRpc(root: Path, moshi: Moshi = Moshi.Builder().build()) : Base
   }
 
   private fun getMetadataForReading(
-      blobId: BlobId,
-      options: Map<StorageRpc.Option, *>
+    blobId: BlobId,
+    options: Map<StorageRpc.Option, *>
   ): BlobMetadata? {
     val metadata = readMetadata(blobId) ?: return null
     options.generationMatch?.let {
@@ -422,11 +422,11 @@ class LocalStorageRpc(root: Path, moshi: Moshi = Moshi.Builder().build()) : Base
   }
 
   private fun continueUpload(
-      uploadId: String,
-      toWrite: ByteArray,
-      toWriteOffset: Int,
-      destOffset: Long,
-      length: Int
+    uploadId: String,
+    toWrite: ByteArray,
+    toWriteOffset: Int,
+    destOffset: Long,
+    length: Int
   ): Upload = try {
     // Copy bytes into the temporary file for this upload
     internalLock.read {
@@ -510,11 +510,11 @@ class LocalStorageRpc(root: Path, moshi: Moshi = Moshi.Builder().build()) : Base
   }
 
   private class BlobMetadata(
-      val generation: Long,
-      val metageneration: Long,
-      val userProperties: Map<String, String>,
-      val contentType: String?,
-      val contentEncoding: String?
+    val generation: Long,
+    val metageneration: Long,
+    val userProperties: Map<String, String>,
+    val contentType: String?,
+    val contentEncoding: String?
   ) {
     fun toStorageObject(blobId: BlobId, size: Long = 0): StorageObject =
         StorageObject()
@@ -532,10 +532,10 @@ class LocalStorageRpc(root: Path, moshi: Moshi = Moshi.Builder().build()) : Base
   }
 
   private class Upload(
-      val id: String,
-      val blobId: BlobId,
-      val tempFile: Path,
-      val targetMetadata: BlobMetadata
+    val id: String,
+    val blobId: BlobId,
+    val tempFile: Path,
+    val targetMetadata: BlobMetadata
   )
 
   /** @return a new version of the given metadata, updated based on the storage object */

--- a/misk/src/main/kotlin/misk/cloud/gcp/storage/StorageConfig.kt
+++ b/misk/src/main/kotlin/misk/cloud/gcp/storage/StorageConfig.kt
@@ -5,9 +5,9 @@ import misk.config.Config
 
 /** Configuration for talking to Google Cloud Storage */
 data class StorageConfig(
-    val use_local_storage: Boolean = false,
-    val local_storage: LocalStorageConfig? = null,
-    val transport : TransportConfig = TransportConfig()
+  val use_local_storage: Boolean = false,
+  val local_storage: LocalStorageConfig? = null,
+  val transport: TransportConfig = TransportConfig()
 ) : Config
 
 /** Configuration for local (emulated) storage */

--- a/misk/src/main/kotlin/misk/concurrent/WrappingListeningExecutorService.kt
+++ b/misk/src/main/kotlin/misk/concurrent/WrappingListeningExecutorService.kt
@@ -34,8 +34,10 @@ abstract class WrappingListeningExecutorService() : ForwardingListeningExecutorS
   }
 
   @Throws(InterruptedException::class)
-  override fun <T> invokeAll(callables: Collection<Callable<T>>, timeout: Long,
-      timeUnit: TimeUnit): List<Future<T>> {
+  override fun <T> invokeAll(
+    callables: Collection<Callable<T>>, timeout: Long,
+    timeUnit: TimeUnit
+  ): List<Future<T>> {
     return delegate().invokeAll(callables.map { wrap(it) }, timeout, timeUnit)
   }
 
@@ -45,8 +47,10 @@ abstract class WrappingListeningExecutorService() : ForwardingListeningExecutorS
   }
 
   @Throws(InterruptedException::class, ExecutionException::class, TimeoutException::class)
-  override fun <T> invokeAny(callables: Collection<Callable<T>>, timeout: Long,
-      timeUnit: TimeUnit): T {
+  override fun <T> invokeAny(
+    callables: Collection<Callable<T>>, timeout: Long,
+    timeUnit: TimeUnit
+  ): T {
     return delegate().invokeAny(callables.map { wrap(it) }, timeout, timeUnit)
   }
 

--- a/misk/src/main/kotlin/misk/config/ConfigModule.kt
+++ b/misk/src/main/kotlin/misk/config/ConfigModule.kt
@@ -15,9 +15,9 @@ import kotlin.reflect.full.isSubtypeOf
 import kotlin.reflect.jvm.javaType
 
 class ConfigModule<T : Config>(
-    private val configClass: Class<T>,
-    private val appName: String,
-    private val config: T
+  private val configClass: Class<T>,
+  private val appName: String,
+  private val config: T
 ) : KAbstractModule() {
   @Suppress("UNCHECKED_CAST")
   override fun configure() {
@@ -57,8 +57,8 @@ class ConfigModule<T : Config>(
   }
 
   internal class SubConfigProvider<T : Config>(
-      private val config: T,
-      private val subconfigGetter: KProperty1<Config, Any?>
+    private val config: T,
+    private val subconfigGetter: KProperty1<Config, Any?>
   ) : Provider<Any?> {
     override fun get(): Any? {
       return subconfigGetter.get(config)

--- a/misk/src/main/kotlin/misk/config/MiskConfig.kt
+++ b/misk/src/main/kotlin/misk/config/MiskConfig.kt
@@ -12,71 +12,71 @@ import java.io.InputStreamReader
 import java.net.URL
 
 object MiskConfig {
- @JvmStatic
- inline fun <reified T : Config> load(appName: String, environment: Environment): T {
-  return load(T::class.java, appName, environment)
- }
+  @JvmStatic
+  inline fun <reified T : Config> load(appName: String, environment: Environment): T {
+    return load(T::class.java, appName, environment)
+  }
 
- @JvmStatic
- fun <T : Config> load(
-   configClass: Class<out Config>,
-   appName: String,
-   environment: Environment
- ): T {
-  val mapper = ObjectMapper(YAMLFactory())
-  mapper.registerModule(KotlinModule())
-  mapper.registerModule(JavaTimeModule())
+  @JvmStatic
+  fun <T : Config> load(
+    configClass: Class<out Config>,
+    appName: String,
+    environment: Environment
+  ): T {
+    val mapper = ObjectMapper(YAMLFactory())
+    mapper.registerModule(KotlinModule())
+    mapper.registerModule(JavaTimeModule())
 
-  var jsonNode: JsonNode? = null
-  val missingConfigFiles = mutableListOf<String>()
-  for (configFileName in configFileNames(appName, environment)) {
-   val url = getResource(configClass, configFileName)
-   if (url == null) {
-    missingConfigFiles.add(configFileName)
-    continue
-   }
+    var jsonNode: JsonNode? = null
+    val missingConfigFiles = mutableListOf<String>()
+    for (configFileName in configFileNames(appName, environment)) {
+      val url = getResource(configClass, configFileName)
+      if (url == null) {
+        missingConfigFiles.add(configFileName)
+        continue
+      }
 
-   try {
-    open(url).use {
-     val objectReader = if (jsonNode == null) {
-      mapper.readerFor(JsonNode::class.java)
-     } else {
-      mapper.readerForUpdating(jsonNode)
-     }
-     jsonNode = objectReader.readValue(it)
+      try {
+        open(url).use {
+          val objectReader = if (jsonNode == null) {
+            mapper.readerFor(JsonNode::class.java)
+          } else {
+            mapper.readerForUpdating(jsonNode)
+          }
+          jsonNode = objectReader.readValue(it)
+        }
+      } catch (e: Exception) {
+        throw IllegalStateException("could not parse $configFileName: ${e.message}", e)
+      }
     }
-   } catch (e: Exception) {
-    throw IllegalStateException("could not parse $configFileName: ${e.message}", e)
-   }
+
+    if (jsonNode == null) {
+      val configFileMessage = missingConfigFiles.joinToString(", ")
+      throw IllegalStateException(
+          "could not find configuration files - checked [$configFileMessage]"
+      )
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    try {
+      return mapper.readValue(jsonNode.toString(), configClass) as T
+    } catch (e: MissingKotlinParameterException) {
+      throw IllegalStateException("could not find configuration for ${e.parameter.name}", e)
+    } catch (e: Exception) {
+      throw IllegalStateException(e)
+    }
   }
 
-  if (jsonNode == null) {
-   val configFileMessage = missingConfigFiles.joinToString(", ")
-   throw IllegalStateException(
-     "could not find configuration files - checked [$configFileMessage]"
-   )
+  /** @return the list of config file names in the order they should be read */
+  private fun configFileNames(appName: String, environment: Environment): List<String> =
+      listOf("common", environment.name.toLowerCase()).map { "$appName-$it.yaml" }
+
+  private fun open(url: URL): BufferedReader {
+    return BufferedReader(InputStreamReader(url.openStream()))
   }
 
-  @Suppress("UNCHECKED_CAST")
-  try {
-   return mapper.readValue(jsonNode.toString(), configClass) as T
-  } catch (e: MissingKotlinParameterException) {
-   throw IllegalStateException("could not find configuration for ${e.parameter.name}", e)
-  } catch (e: Exception) {
-   throw IllegalStateException(e)
-  }
- }
-
- /** @return the list of config file names in the order they should be read */
- private fun configFileNames(appName: String, environment: Environment): List<String> =
-   listOf("common", environment.name.toLowerCase()).map { "$appName-$it.yaml" }
-
- private fun open(url: URL): BufferedReader {
-  return BufferedReader(InputStreamReader(url.openStream()))
- }
-
- private fun getResource(
-   configClass: Class<out Config>,
-   fileName: String
- ) = configClass.classLoader.getResource(fileName)
+  private fun getResource(
+    configClass: Class<out Config>,
+    fileName: String
+  ) = configClass.classLoader.getResource(fileName)
 }

--- a/misk/src/main/kotlin/misk/environment/Environment.kt
+++ b/misk/src/main/kotlin/misk/environment/Environment.kt
@@ -5,22 +5,25 @@ import misk.logging.getLogger
 private val logger = getLogger<Environment>()
 
 enum class Environment {
- TESTING, DEVELOPMENT, STAGING, PRODUCTION;
+  TESTING,
+  DEVELOPMENT,
+  STAGING,
+  PRODUCTION;
 
- companion object {
-   private val environmentKey = "ENVIRONMENT"
+  companion object {
+    private val environmentKey = "ENVIRONMENT"
 
-   @JvmStatic
-   fun fromEnvironmentVariable(): Environment {
-     val environmentName = System.getenv(environmentKey)
-     val environment = if (environmentName != null) {
-       Environment.valueOf(environmentName)
-     } else {
-       logger.warn { "No environment variable with key $environmentKey found, running in DEVELOPMENT" }
-       Environment.DEVELOPMENT
-     }
-     logger.info { "Running with environment ${environment.name}" }
-     return environment
-   }
- }
+    @JvmStatic
+    fun fromEnvironmentVariable(): Environment {
+      val environmentName = System.getenv(environmentKey)
+      val environment = if (environmentName != null) {
+        Environment.valueOf(environmentName)
+      } else {
+        logger.warn { "No environment variable with key $environmentKey found, running in DEVELOPMENT" }
+        Environment.DEVELOPMENT
+      }
+      logger.info { "Running with environment ${environment.name}" }
+      return environment
+    }
+  }
 }

--- a/misk/src/main/kotlin/misk/exceptions/Exceptions.kt
+++ b/misk/src/main/kotlin/misk/exceptions/Exceptions.kt
@@ -18,9 +18,9 @@ enum class StatusCode(val code: Int) {
 
 /** Base class for exceptions thrown by actions, translated into responses */
 open class ActionException(
-    val statusCode: StatusCode,
-    message: String = statusCode.name,
-    cause: Throwable? = null
+  val statusCode: StatusCode,
+  message: String = statusCode.name,
+  cause: Throwable? = null
 ) : Exception(message, cause)
 
 /** Base exception for when resources are not found */

--- a/misk/src/main/kotlin/misk/flags/Flags.kt
+++ b/misk/src/main/kotlin/misk/flags/Flags.kt
@@ -13,8 +13,8 @@ interface Flag<out T> {
 }
 
 class JsonFlag<out T : Any> internal constructor(
-    private val stringFlag: Flag<String>,
-    private val adapter: JsonAdapter<T>
+  private val stringFlag: Flag<String>,
+  private val adapter: JsonAdapter<T>
 ) : Flag<T> {
   override val name = stringFlag.name
   override val description = stringFlag.description
@@ -23,15 +23,15 @@ class JsonFlag<out T : Any> internal constructor(
 
 open class Flags internal constructor(val name: String, val context: Context) {
   data class Context(
-      val prefix: String,
-      val moshi: Moshi,
-      val flagStore: FlagStore
+    val prefix: String,
+    val moshi: Moshi,
+    val flagStore: FlagStore
   )
 
   class StringFlag(
-      private val description: String,
-      private val name: String? = null,
-      private val default: String = ""
+    private val description: String,
+    private val name: String? = null,
+    private val default: String = ""
   ) {
     operator fun provideDelegate(thisRef: Flags, prop: KProperty<*>):
         ReadOnlyProperty<Flags, String> {
@@ -40,17 +40,17 @@ open class Flags internal constructor(val name: String, val context: Context) {
       return Property(flag, default)
     }
 
-    private class Property(val flag: misk.flags.Flag<String>, val default: String)
-      : ReadOnlyProperty<Flags, String> {
+    private class Property(val flag: misk.flags.Flag<String>, val default: String) :
+        ReadOnlyProperty<Flags, String> {
       override fun getValue(thisRef: Flags, property: KProperty<*>): String =
           flag.get() ?: default
     }
   }
 
   class IntFlag(
-      private val description: String,
-      private val name: String? = null,
-      private val default: Int = 0
+    private val description: String,
+    private val name: String? = null,
+    private val default: Int = 0
   ) {
     operator fun provideDelegate(thisRef: Flags, prop: KProperty<*>):
         ReadOnlyProperty<Flags, Int> {
@@ -59,17 +59,19 @@ open class Flags internal constructor(val name: String, val context: Context) {
       return Property(flag, default)
     }
 
-    private class Property(val flag: misk.flags.Flag<Int>, val default: Int)
-      : ReadOnlyProperty<Flags, Int> {
+    private class Property(
+      val flag: misk.flags.Flag<Int>,
+      val default: Int
+    ) : ReadOnlyProperty<Flags, Int> {
       override fun getValue(thisRef: Flags, property: KProperty<*>): Int =
           flag.get() ?: default
     }
   }
 
   class BooleanFlag(
-      private val description: String,
-      private val name: String? = null,
-      private val default: Boolean = false
+    private val description: String,
+    private val name: String? = null,
+    private val default: Boolean = false
   ) {
     operator fun provideDelegate(thisRef: Flags, prop: KProperty<*>):
         ReadOnlyProperty<Flags, Boolean> {
@@ -78,17 +80,17 @@ open class Flags internal constructor(val name: String, val context: Context) {
       return Property(flag, default)
     }
 
-    private class Property(val flag: misk.flags.Flag<Boolean>, val default: Boolean)
-      : ReadOnlyProperty<Flags, Boolean> {
+    private class Property(val flag: misk.flags.Flag<Boolean>, val default: Boolean) :
+        ReadOnlyProperty<Flags, Boolean> {
       override fun getValue(thisRef: Flags, property: KProperty<*>): Boolean =
           flag.get() ?: default
     }
   }
 
   class DoubleFlag(
-      private val description: String,
-      private val name: String? = null,
-      private val default: Double = 0.0
+    private val description: String,
+    private val name: String? = null,
+    private val default: Double = 0.0
   ) {
     operator fun provideDelegate(thisRef: Flags, prop: KProperty<*>):
         ReadOnlyProperty<Flags, Double> {
@@ -97,24 +99,24 @@ open class Flags internal constructor(val name: String, val context: Context) {
       return Property(flag, default)
     }
 
-    private class Property(val flag: misk.flags.Flag<Double>, val default: Double)
-      : ReadOnlyProperty<Flags, Double> {
+    private class Property(val flag: misk.flags.Flag<Double>, val default: Double) :
+        ReadOnlyProperty<Flags, Double> {
       override fun getValue(thisRef: Flags, property: KProperty<*>): Double =
           flag.get() ?: default
     }
   }
 
   inline fun <reified T : Any> JsonFlag(
-      description: String,
-      name: String? = null,
-      default: T? = null
+    description: String,
+    name: String? = null,
+    default: T? = null
   ) = JsonFlagInternal(T::class, description, name, default)
 
   class JsonFlagInternal<T : Any>(
-      private val kclass: KClass<T>,
-      private val description: String,
-      private val name: String? = null,
-      private val default: T? = null
+    private val kclass: KClass<T>,
+    private val description: String,
+    private val name: String? = null,
+    private val default: T? = null
   ) {
     operator fun provideDelegate(thisRef: Flags, prop: KProperty<*>):
         ReadOnlyProperty<Flags, T?> {
@@ -125,9 +127,9 @@ open class Flags internal constructor(val name: String, val context: Context) {
     }
 
     private class Property<T : Any>(
-        val flag: misk.flags.Flag<String>,
-        val adapter: JsonAdapter<T>,
-        val default: T?
+      val flag: misk.flags.Flag<String>,
+      val adapter: JsonAdapter<T>,
+      val default: T?
     ) : ReadOnlyProperty<Flags, T?> {
       override fun getValue(thisRef: Flags, property: KProperty<*>): T? =
           flag.get()?.let { adapter.fromJson(it) } ?: default
@@ -136,9 +138,9 @@ open class Flags internal constructor(val name: String, val context: Context) {
 
   companion object {
     internal fun propertyFlagName(
-        thisRef: Flags,
-        explicitName: String?,
-        prop: KProperty<*>
+      thisRef: Flags,
+      explicitName: String?,
+      prop: KProperty<*>
     ): String {
       val name = explicitName ?: prop.name
       return if (thisRef.context.prefix.isEmpty()) {

--- a/misk/src/main/kotlin/misk/flags/FlagsModule.kt
+++ b/misk/src/main/kotlin/misk/flags/FlagsModule.kt
@@ -24,18 +24,19 @@ abstract class FlagsModule : KAbstractModule() {
   protected abstract fun configureFlags()
 
   inline fun <reified T : Any> bindFlag(
-      name: String,
-      description: String,
-      qualifier: Annotation = Names.named(name)
+    name: String,
+    description: String,
+    qualifier: Annotation = Names.named(name)
   ) {
     bindFlag(name, description, T::class, qualifier)
   }
 
   fun <T : Any> bindFlag(
-      name: String,
-      description: String,
-      type: KClass<T>,
-      qualifier: Annotation = Names.named(name)) {
+    name: String,
+    description: String,
+    type: KClass<T>,
+    qualifier: Annotation = Names.named(name)
+  ) {
     bind(flagTypeLiteral(type))
         .annotatedWith(qualifier)
         .toProvider(FlagProvider(type, name, description))
@@ -46,9 +47,9 @@ abstract class FlagsModule : KAbstractModule() {
       bindFlags(T::class, prefix, qualifier)
 
   fun <T : Flags> bindFlags(
-      type: KClass<T>,
-      prefix: String = "",
-      qualifier: Annotation? = null
+    type: KClass<T>,
+    prefix: String = "",
+    qualifier: Annotation? = null
   ) {
     val actualQualifier = qualifier ?: if (!prefix.isEmpty()) Names.named(prefix) else null
     val constructor = type.constructors.firstOrNull {
@@ -70,16 +71,16 @@ abstract class FlagsModule : KAbstractModule() {
   }
 
   inline fun <reified T : Any> bindJsonFlag(
-      name: String,
-      description: String,
-      qualifier: Annotation = Names.named(name)
+    name: String,
+    description: String,
+    qualifier: Annotation = Names.named(name)
   ) = bindJsonFlag(T::class, name, description, qualifier)
 
   fun <T : Any> bindJsonFlag(
-      type: KClass<T>,
-      name: String,
-      description: String,
-      a: Annotation = Names.named(name)
+    type: KClass<T>,
+    name: String,
+    description: String,
+    a: Annotation = Names.named(name)
   ) {
     val flagType = parameterizedType<JsonFlag<T>>(type.java)
 
@@ -92,9 +93,9 @@ abstract class FlagsModule : KAbstractModule() {
   }
 
   private class FlagProvider<T : Any>(
-      val type: KClass<T>,
-      val name: String,
-      val description: String
+    val type: KClass<T>,
+    val name: String,
+    val description: String
   ) : Provider<Flag<T>> {
     @Inject
     lateinit var flagStore: FlagStore
@@ -105,9 +106,9 @@ abstract class FlagsModule : KAbstractModule() {
   }
 
   private class JsonFlagProvider<T : Any>(
-      val type: KClass<T>,
-      val name: String,
-      val description: String
+    val type: KClass<T>,
+    val name: String,
+    val description: String
   ) : Provider<JsonFlag<T>> {
     @Inject
     lateinit var flagStore: FlagStore
@@ -123,8 +124,8 @@ abstract class FlagsModule : KAbstractModule() {
   }
 
   private class FlagsProvider<T : Any>(
-      val constructor: KFunction<T>,
-      val prefix: String
+    val constructor: KFunction<T>,
+    val prefix: String
   ) : Provider<T> {
     @Inject
     lateinit var flagStore: FlagStore

--- a/misk/src/main/kotlin/misk/flags/memory/InMemoryFlagStore.kt
+++ b/misk/src/main/kotlin/misk/flags/memory/InMemoryFlagStore.kt
@@ -19,9 +19,9 @@ class InMemoryFlagStore : FlagStore {
 
   @Suppress("UNCHECKED_CAST")
   override fun <T : Any> registerFlag(
-      name: String,
-      description: String,
-      type: KClass<T>
+    name: String,
+    description: String,
+    type: KClass<T>
   ): InMemoryFlag<T> {
     return when (type) {
       Int::class -> registerFlag(InMemoryIntFlag(name, description)) as InMemoryFlag<T>

--- a/misk/src/main/kotlin/misk/flags/memory/InMemoryFlags.kt
+++ b/misk/src/main/kotlin/misk/flags/memory/InMemoryFlags.kt
@@ -12,8 +12,8 @@ interface InMemoryFlag<T> : Flag<T> {
 }
 
 class InMemoryBooleanFlag internal constructor(
-    override val name: String,
-    override val description: String
+  override val name: String,
+  override val description: String
 ) : InMemoryFlag<Boolean> {
 
   private val set = AtomicBoolean()
@@ -28,8 +28,8 @@ class InMemoryBooleanFlag internal constructor(
 }
 
 class InMemoryIntFlag internal constructor(
-    override val name: String,
-    override val description: String
+  override val name: String,
+  override val description: String
 ) : InMemoryFlag<Int> {
 
   private val set = AtomicBoolean()
@@ -44,8 +44,8 @@ class InMemoryIntFlag internal constructor(
 }
 
 class InMemoryDoubleFlag internal constructor(
-    override val name: String,
-    override val description: String
+  override val name: String,
+  override val description: String
 ) : InMemoryFlag<Double> {
 
   private val set = AtomicBoolean()
@@ -60,8 +60,8 @@ class InMemoryDoubleFlag internal constructor(
 }
 
 class InMemoryStringFlag internal constructor(
-    override val name: String,
-    override val description: String
+  override val name: String,
+  override val description: String
 ) : InMemoryFlag<String> {
 
   private val value = AtomicReference<String>()

--- a/misk/src/main/kotlin/misk/inject/Guice.kt
+++ b/misk/src/main/kotlin/misk/inject/Guice.kt
@@ -22,7 +22,7 @@ inline fun <reified T : Any> LinkedBindingBuilder<in T>.to() = to(T::class.java)
 
 @Suppress("UNCHECKED_CAST")
 inline fun <reified T : Any> Binder.newMultibinder(
-    annotation: Class<out Annotation>? = null
+  annotation: Class<out Annotation>? = null
 ): Multibinder<T> {
   val typeLiteral =
       parameterizedType<List<*>>(subtypeOf<T>()).typeLiteral() as TypeLiteral<List<T>>
@@ -40,7 +40,7 @@ inline fun <reified T : Any, reified A : Annotation> Binder.addMultibinderBindin
 
 @Suppress("UNCHECKED_CAST")
 inline fun <reified T : Any> Binder.addMultibinderBinding(
-    annotation: Class<out Annotation>? = null
+  annotation: Class<out Annotation>? = null
 ): LinkedBindingBuilder<T> = newMultibinder<T>(annotation).addBinding()
 
 fun ScopedBindingBuilder.asSingleton() {

--- a/misk/src/main/kotlin/misk/inject/KAbstractModule.kt
+++ b/misk/src/main/kotlin/misk/inject/KAbstractModule.kt
@@ -5,7 +5,6 @@ import com.google.inject.binder.AnnotatedBindingBuilder
 import com.google.inject.binder.LinkedBindingBuilder
 import com.google.inject.binder.ScopedBindingBuilder
 import com.google.inject.multibindings.Multibinder
-import javax.inject.Provider
 
 /**
  * A class that provides helper methods for working with Kotlin and Guice, allowing implementing
@@ -24,7 +23,7 @@ import javax.inject.Provider
  */
 abstract class KAbstractModule : AbstractModule() {
   protected class KotlinAnnotatedBindingBuilder<X>(
-      private val annotatedBuilder: AnnotatedBindingBuilder<X>
+    private val annotatedBuilder: AnnotatedBindingBuilder<X>
   ) : AnnotatedBindingBuilder<X> by annotatedBuilder {
     inline fun <reified T : Annotation> annotatedWith(): LinkedBindingBuilder<X> {
       return annotatedWith(T::class.java)

--- a/misk/src/main/kotlin/misk/metrics/Metrics.kt
+++ b/misk/src/main/kotlin/misk/metrics/Metrics.kt
@@ -9,7 +9,7 @@ import java.util.SortedMap
 import javax.inject.Inject
 
 class Metrics @Inject internal constructor(
-    metricRegistry: MetricRegistry
+  metricRegistry: MetricRegistry
 ) : MetricsScope("", metricRegistry) {
   val timers: SortedMap<String, Timer> get() = metricRegistry.timers
   val counters: SortedMap<String, Counter> get() = metricRegistry.counters

--- a/misk/src/main/kotlin/misk/metrics/MetricsScope.kt
+++ b/misk/src/main/kotlin/misk/metrics/MetricsScope.kt
@@ -11,8 +11,8 @@ import java.time.Duration
 import java.util.concurrent.TimeUnit
 
 open class MetricsScope internal constructor(
-    internal val root: String,
-    internal val metricRegistry: MetricRegistry
+  internal val root: String,
+  internal val metricRegistry: MetricRegistry
 ) {
   fun counter(name: String): Counter {
     return metricRegistry.counter(scopedName(name))

--- a/misk/src/main/kotlin/misk/metrics/backends/MetricsBackendConfig.kt
+++ b/misk/src/main/kotlin/misk/metrics/backends/MetricsBackendConfig.kt
@@ -6,7 +6,7 @@ import misk.metrics.backends.signalfx.SignalFxBackendConfig
 import misk.metrics.backends.stackdriver.StackDriverBackendConfig
 
 data class MetricsBackendConfig(
-    val graphite: GraphiteBackendConfig?,
-    val stack_driver: StackDriverBackendConfig?,
-    val signal_fx: SignalFxBackendConfig?
+  val graphite: GraphiteBackendConfig?,
+  val stack_driver: StackDriverBackendConfig?,
+  val signal_fx: SignalFxBackendConfig?
 ) : Config

--- a/misk/src/main/kotlin/misk/metrics/backends/graphite/GraphiteBackendModule.kt
+++ b/misk/src/main/kotlin/misk/metrics/backends/graphite/GraphiteBackendModule.kt
@@ -23,7 +23,7 @@ class GraphiteBackendModule : AbstractModule() {
   @Provides
   @Singleton
   fun graphiteSender(config: GraphiteBackendConfig): GraphiteSender =
-    Graphite(config.host, config.port)
+      Graphite(config.host, config.port)
 
   @Provides
   @Singleton

--- a/misk/src/main/kotlin/misk/metrics/backends/graphite/GraphiteReporterService.kt
+++ b/misk/src/main/kotlin/misk/metrics/backends/graphite/GraphiteReporterService.kt
@@ -6,8 +6,8 @@ import java.util.concurrent.TimeUnit
 import javax.inject.Inject
 
 internal class GraphiteReporterService @Inject internal constructor(
-    private val config: GraphiteBackendConfig,
-    private val reporter: GraphiteReporter
+  private val config: GraphiteBackendConfig,
+  private val reporter: GraphiteReporter
 ) : AbstractIdleService() {
   override fun startUp() = reporter.start(config.interval.toMillis(), TimeUnit.MILLISECONDS)
   override fun shutDown() = reporter.stop()

--- a/misk/src/main/kotlin/misk/metrics/backends/signalfx/SignalFxBackendConfig.kt
+++ b/misk/src/main/kotlin/misk/metrics/backends/signalfx/SignalFxBackendConfig.kt
@@ -4,6 +4,6 @@ import misk.config.Config
 import java.time.Duration
 
 data class SignalFxBackendConfig(
-    val access_token: String,
-    val interval: Duration
+  val access_token: String,
+  val interval: Duration
 ) : Config

--- a/misk/src/main/kotlin/misk/metrics/backends/signalfx/SignalFxBackendModule.kt
+++ b/misk/src/main/kotlin/misk/metrics/backends/signalfx/SignalFxBackendModule.kt
@@ -11,7 +11,7 @@ import misk.inject.addMultibinderBinding
 import misk.inject.to
 import javax.inject.Singleton
 
-class SignalFxBackendModule : KAbstractModule(){
+class SignalFxBackendModule : KAbstractModule() {
   override fun configure() {
     binder().addMultibinderBinding<Service>().to<SignalFxReporterService>()
   }
@@ -19,9 +19,9 @@ class SignalFxBackendModule : KAbstractModule(){
   @Provides
   @Singleton
   fun signalFxReporter(
-      @AppName appName: String,
-      config: SignalFxBackendConfig,
-      metricRegistry: MetricRegistry
+    @AppName appName: String,
+    config: SignalFxBackendConfig,
+    metricRegistry: MetricRegistry
   ): SignalFxReporter {
     return SignalFxReporter.Builder(
         metricRegistry,

--- a/misk/src/main/kotlin/misk/metrics/backends/signalfx/SignalFxReporterService.kt
+++ b/misk/src/main/kotlin/misk/metrics/backends/signalfx/SignalFxReporterService.kt
@@ -6,8 +6,8 @@ import java.util.concurrent.TimeUnit
 import javax.inject.Inject
 
 internal class SignalFxReporterService @Inject internal constructor(
-    private val config: SignalFxBackendConfig,
-    private val reporter: SignalFxReporter
+  private val config: SignalFxBackendConfig,
+  private val reporter: SignalFxReporter
 ) : AbstractIdleService() {
   override fun startUp() = reporter.start(config.interval.toMillis(), TimeUnit.MILLISECONDS)
   override fun shutDown() = reporter.stop()

--- a/misk/src/main/kotlin/misk/metrics/backends/stackdriver/StackDriverBackendConfig.kt
+++ b/misk/src/main/kotlin/misk/metrics/backends/stackdriver/StackDriverBackendConfig.kt
@@ -4,7 +4,7 @@ import misk.config.Config
 import java.time.Duration
 
 data class StackDriverBackendConfig(
-    val project_id: String,
-    val interval: Duration,
-    val batch_size: Int = 200
+  val project_id: String,
+  val interval: Duration,
+  val batch_size: Int = 200
 ) : Config

--- a/misk/src/main/kotlin/misk/metrics/backends/stackdriver/StackDriverReporter.kt
+++ b/misk/src/main/kotlin/misk/metrics/backends/stackdriver/StackDriverReporter.kt
@@ -24,21 +24,22 @@ import java.util.concurrent.TimeUnit
 import javax.inject.Inject
 
 internal class StackDriverReporter @Inject internal constructor(
-    val clock: Clock,
-    @AppName val appName: String,
-    val instanceMetadata: InstanceMetadata,
-    val sender: StackDriverSender,
-    metricRegistry: com.codahale.metrics.MetricRegistry
+  val clock: Clock,
+  @AppName val appName: String,
+  val instanceMetadata: InstanceMetadata,
+  val sender: StackDriverSender,
+  metricRegistry: com.codahale.metrics.MetricRegistry
 ) : ScheduledReporter(metricRegistry, "stack-driver", null,
     TimeUnit.MILLISECONDS, TimeUnit.MILLISECONDS) {
   private val startTime = DateTime(clock.millis())
 
   override fun report(
-      gauges: SortedMap<String, Gauge<Any>>?,
-      counters: SortedMap<String, Counter>?,
-      histograms: SortedMap<String, Histogram>?,
-      meters: SortedMap<String, Meter>?,
-      timers: SortedMap<String, Timer>?) {
+    gauges: SortedMap<String, Gauge<Any>>?,
+    counters: SortedMap<String, Counter>?,
+    histograms: SortedMap<String, Histogram>?,
+    meters: SortedMap<String, Meter>?,
+    timers: SortedMap<String, Timer>?
+  ) {
     val timeSeries = toTimeSeries(gauges, counters, histograms, meters,
         timers, startTime, DateTime(clock.millis()))
     if (timeSeries.isEmpty()) {
@@ -60,13 +61,14 @@ internal class StackDriverReporter @Inject internal constructor(
   }
 
   fun toTimeSeries(
-      gauges: SortedMap<String, Gauge<Any>>?,
-      counters: SortedMap<String, Counter>?,
-      histograms: SortedMap<String, Histogram>?,
-      meters: SortedMap<String, Meter>?,
-      timers: SortedMap<String, Timer>?,
-      startTime: DateTime,
-      now: DateTime): List<TimeSeries> {
+    gauges: SortedMap<String, Gauge<Any>>?,
+    counters: SortedMap<String, Counter>?,
+    histograms: SortedMap<String, Histogram>?,
+    meters: SortedMap<String, Meter>?,
+    timers: SortedMap<String, Timer>?,
+    startTime: DateTime,
+    now: DateTime
+  ): List<TimeSeries> {
     val timeSeries = ArrayList<TimeSeries>()
     gauges?.forEach { timeSeries.addAll(toTimeSeries(it.key, it.value, startTime, now)) }
     counters?.forEach { timeSeries.addAll(toTimeSeries(it.key, it.value, startTime, now)) }
@@ -77,26 +79,26 @@ internal class StackDriverReporter @Inject internal constructor(
   }
 
   fun toTimeSeries(
-      name: String,
-      gauge: Gauge<Any>,
-      startTime: DateTime,
-      now: DateTime
+    name: String,
+    gauge: Gauge<Any>,
+    startTime: DateTime,
+    now: DateTime
   ): Array<TimeSeries> = arrayOf(
       timeSeries(name, gauge.value, startTime, now, "value", MetricKind.GAUGE))
 
   fun toTimeSeries(
-      name: String,
-      counter: Counter,
-      startTime: DateTime,
-      now: DateTime
+    name: String,
+    counter: Counter,
+    startTime: DateTime,
+    now: DateTime
   ): Array<TimeSeries> = arrayOf(
       timeSeries(name, counter.count, startTime, now, "count", MetricKind.CUMULATIVE))
 
   fun toTimeSeries(
-      name: String,
-      timer: Timer,
-      startTime: DateTime,
-      now: DateTime
+    name: String,
+    timer: Timer,
+    startTime: DateTime,
+    now: DateTime
   ): Array<TimeSeries> {
     val snapshot = timer.snapshot
     return arrayOf(
@@ -124,10 +126,10 @@ internal class StackDriverReporter @Inject internal constructor(
   }
 
   fun toTimeSeries(
-      name: String,
-      hist: Histogram,
-      startTime: DateTime,
-      now: DateTime
+    name: String,
+    hist: Histogram,
+    startTime: DateTime,
+    now: DateTime
   ): Array<TimeSeries> {
     val snapshot = hist.snapshot
     return arrayOf(
@@ -150,10 +152,10 @@ internal class StackDriverReporter @Inject internal constructor(
   }
 
   fun toTimeSeries(
-      name: String,
-      metered: Metered,
-      startTime: DateTime,
-      now: DateTime
+    name: String,
+    metered: Metered,
+    startTime: DateTime,
+    now: DateTime
   ): Array<TimeSeries> = arrayOf(
       timeSeries(name, metered.count, startTime, now, "count", MetricKind.CUMULATIVE),
       timeSeries(name, convertRate(metered.oneMinuteRate), startTime, now, "m1_rate",
@@ -166,30 +168,30 @@ internal class StackDriverReporter @Inject internal constructor(
           MetricKind.GAUGE))
 
   private fun timeSeries(
-      name: String,
-      pointValue: Any,
-      startTime: DateTime,
-      now: DateTime,
-      subType: String,
-      metricKind: MetricKind
+    name: String,
+    pointValue: Any,
+    startTime: DateTime,
+    now: DateTime,
+    subType: String,
+    metricKind: MetricKind
   ): TimeSeries = TimeSeries()
       .setMetricKind(metricKind.name)
       .setMetric(metric(type(name, subType)))
       .setPoints(listOf(point(metricKind, startTime, now, typedValue(pointValue))))
 
   private fun point(
-      metricKind: MetricKind,
-      startTime: DateTime,
-      now: DateTime,
-      value: TypedValue
+    metricKind: MetricKind,
+    startTime: DateTime,
+    now: DateTime,
+    value: TypedValue
   ): Point = Point()
       .setInterval(timeInterval(startTime, now, metricKind))
       .setValue(value)
 
   private fun timeInterval(
-      startTime: DateTime,
-      now: DateTime,
-      metricKind: MetricKind
+    startTime: DateTime,
+    now: DateTime,
+    metricKind: MetricKind
   ): TimeInterval = when (metricKind) {
     MetricKind.CUMULATIVE -> TimeInterval()
         .setStartTime(startTime.toStringRfc3339())

--- a/misk/src/main/kotlin/misk/metrics/backends/stackdriver/StackDriverReporterService.kt
+++ b/misk/src/main/kotlin/misk/metrics/backends/stackdriver/StackDriverReporterService.kt
@@ -5,8 +5,8 @@ import java.util.concurrent.TimeUnit
 import javax.inject.Inject
 
 internal class StackDriverReporterService @Inject internal constructor(
-    private val config: StackDriverBackendConfig,
-    private val reporter: StackDriverReporter
+  private val config: StackDriverBackendConfig,
+  private val reporter: StackDriverReporter
 ) : AbstractIdleService() {
   override fun startUp() = reporter.start(config.interval.toMillis(), TimeUnit.MILLISECONDS)
   override fun shutDown() = reporter.stop()

--- a/misk/src/main/kotlin/misk/metrics/web/JsonMetrics.kt
+++ b/misk/src/main/kotlin/misk/metrics/web/JsonMetrics.kt
@@ -17,12 +17,12 @@ data class JsonGauge<T>(val value: T) {
 }
 
 data class JsonTimer(
-    val count: Long,
-    val oneMinuteRate: Double,
-    val fiveMinuteRate: Double,
-    val fifteenMinuteRate: Double,
-    val meanRate: Double,
-    val snapshot: JsonHistogramSnapshot
+  val count: Long,
+  val oneMinuteRate: Double,
+  val fiveMinuteRate: Double,
+  val fifteenMinuteRate: Double,
+  val meanRate: Double,
+  val snapshot: JsonHistogramSnapshot
 ) {
   constructor(timer: Timer) : this(
       timer.count,
@@ -35,16 +35,16 @@ data class JsonTimer(
 }
 
 data class JsonHistogramSnapshot(
-    val min: Double,
-    val max: Double,
-    val mean: Double,
-    val stdDev: Double,
-    val p50: Double,
-    val p75: Double,
-    val p95: Double,
-    val p98: Double,
-    val p99: Double,
-    val p999: Double
+  val min: Double,
+  val max: Double,
+  val mean: Double,
+  val stdDev: Double,
+  val p50: Double,
+  val p75: Double,
+  val p95: Double,
+  val p98: Double,
+  val p99: Double,
+  val p999: Double
 ) {
   constructor(snapshot: Snapshot, conversionFactor: Double = 1.0) : this(
       min = snapshot.min.toDouble() * conversionFactor,
@@ -64,10 +64,10 @@ data class JsonHistogram(val count: Long, val snapshot: JsonHistogramSnapshot) {
 }
 
 data class JsonMetrics(
-    val counters: Map<String, JsonCounter>,
-    val timers: Map<String, JsonTimer>,
-    val histograms: Map<String, JsonHistogram>,
-    val gauges: Map<String, JsonGauge<Any>>
+  val counters: Map<String, JsonCounter>,
+  val timers: Map<String, JsonTimer>,
+  val histograms: Map<String, JsonHistogram>,
+  val gauges: Map<String, JsonGauge<Any>>
 ) {
   constructor(metrics: Metrics) : this(
       metrics.counters.map { it.key to JsonCounter(it.value) }.toMap(),

--- a/misk/src/main/kotlin/misk/moshi/okio/ByteStringAdapter.kt
+++ b/misk/src/main/kotlin/misk/moshi/okio/ByteStringAdapter.kt
@@ -28,9 +28,9 @@ internal class ByteStringAdapter : JsonAdapter<ByteString?>() {
 
   class Factory : JsonAdapter.Factory {
     override fun create(
-        type: Type,
-        annotations: Set<Annotation>,
-        moshi: Moshi
+      type: Type,
+      annotations: Set<Annotation>,
+      moshi: Moshi
     ): JsonAdapter<*>? {
       return if (type == ByteString::class.java) {
         ByteStringAdapter()

--- a/misk/src/main/kotlin/misk/moshi/wire/FieldBinding.kt
+++ b/misk/src/main/kotlin/misk/moshi/wire/FieldBinding.kt
@@ -12,10 +12,10 @@ import java.lang.reflect.InvocationTargetException
 import java.lang.reflect.Method
 
 internal class FieldBinding(
-    wireField: WireField,
-    builderType: Class<Message.Builder<*, *>>,
-    private val messageField: Field,
-    moshi: Moshi
+  wireField: WireField,
+  builderType: Class<Message.Builder<*, *>>,
+  private val messageField: Field,
+  moshi: Moshi
 ) {
   val name: String = messageField.name
 
@@ -86,8 +86,8 @@ internal class FieldBinding(
 
   companion object {
     private fun getBuilderField(
-        builderType: Class<Message.Builder<*, *>>,
-        name: String
+      builderType: Class<Message.Builder<*, *>>,
+      name: String
     ): Field {
       try {
         return builderType.getField(name)
@@ -97,9 +97,9 @@ internal class FieldBinding(
     }
 
     private fun getBuilderMethod(
-        builderType: Class<Message.Builder<*, *>>,
-        name: String,
-        type: Class<*>
+      builderType: Class<Message.Builder<*, *>>,
+      name: String,
+      type: Class<*>
     ): Method {
       try {
         return builderType.getMethod(name, type)

--- a/misk/src/main/kotlin/misk/moshi/wire/MapAdapter.kt
+++ b/misk/src/main/kotlin/misk/moshi/wire/MapAdapter.kt
@@ -6,8 +6,8 @@ import com.squareup.moshi.JsonWriter
 
 /** Handles JSON marshalling / unmarshalling for type-safe maps */
 internal class MapAdapter(
-    private val keyConverter: (String) -> Any,
-    private val valueAdapter: JsonAdapter<Any?>
+  private val keyConverter: (String) -> Any,
+  private val valueAdapter: JsonAdapter<Any?>
 ) : JsonAdapter<Map<Any, Any>>() {
   override fun fromJson(reader: JsonReader): Map<Any, Any>? {
     val nextToken = reader.peek()

--- a/misk/src/main/kotlin/misk/moshi/wire/WireMessageAdapter.kt
+++ b/misk/src/main/kotlin/misk/moshi/wire/WireMessageAdapter.kt
@@ -10,8 +10,8 @@ import java.lang.reflect.Type
 
 /** Json marshaling for Wire messages, correctly using Builders to construct properly formed type */
 internal class WireMessageAdapter(
-    messageType: Class<Message<*, *>>,
-    private val moshi: Moshi
+  messageType: Class<Message<*, *>>,
+  private val moshi: Moshi
 ) : JsonAdapter<Any?>() {
   @Suppress("UNCHECKED_CAST")
   private val builderType = try {
@@ -71,9 +71,9 @@ internal class WireMessageAdapter(
 
   class Factory : JsonAdapter.Factory {
     override fun create(
-        type: Type,
-        annotations: Set<Annotation>,
-        moshi: Moshi
+      type: Type,
+      annotations: Set<Annotation>,
+      moshi: Moshi
     ): JsonAdapter<*>? {
       return if (type is Class<*> && type.superclass == Message::class.java) {
         @Suppress("UNCHECKED_CAST")

--- a/misk/src/main/kotlin/misk/okio/OkioExtensions.kt
+++ b/misk/src/main/kotlin/misk/okio/OkioExtensions.kt
@@ -1,6 +1,5 @@
 package misk.okio
 
-import okio.Buffer
 import okio.BufferedSource
 
 fun BufferedSource.forEachBlock(buffer: ByteArray, f: (buffer: ByteArray, bytesRead: Int) -> Unit) {

--- a/misk/src/main/kotlin/misk/scope/ActionScope.kt
+++ b/misk/src/main/kotlin/misk/scope/ActionScope.kt
@@ -17,7 +17,7 @@ class ActionScope @Inject internal constructor(
     // on ActionScopedProviders, which might depend on other ActionScopeds. We break
     // this circular dependency by injecting a map of Provider<ActionScopedProvider>
     // rather than the map of ActionScopedProvider directly
-    private val providers: @JvmSuppressWildcards Map<Key<*>, Provider<ActionScopedProvider<*>>>
+  private val providers: @JvmSuppressWildcards Map<Key<*>, Provider<ActionScopedProvider<*>>>
 ) : AutoCloseable {
   companion object {
     private val tls = ThreadLocal<LinkedHashMap<Key<*>, Any>>()
@@ -110,17 +110,17 @@ class ActionScope @Inject internal constructor(
   }
 
   private class WrappedKFunction<T>(
-      val seedData: Map<Key<*>, Any>,
-      val scope: ActionScope,
-      val wrapped: KFunction<T>
+    val seedData: Map<Key<*>, Any>,
+    val scope: ActionScope,
+    val wrapped: KFunction<T>
   ) : KFunction<T> {
     override fun call(vararg args: Any?): T = scope.enter(seedData).use {
-          wrapped.call(*args)
-        }
+      wrapped.call(*args)
+    }
 
     override fun callBy(args: Map<KParameter, Any?>): T = scope.enter(seedData).use {
-          wrapped.callBy(args)
-        }
+      wrapped.callBy(args)
+    }
 
     override val annotations: List<Annotation> = wrapped.annotations
     override val isAbstract: Boolean = wrapped.isAbstract

--- a/misk/src/main/kotlin/misk/scope/ActionScoped.kt
+++ b/misk/src/main/kotlin/misk/scope/ActionScoped.kt
@@ -2,11 +2,11 @@ package misk.scope
 
 /** Provides access to a context object specific to the current action */
 interface ActionScoped<out T> {
-  fun get() : T
+  fun get(): T
 
   companion object {
     /** @return an [ActionScoped] hard-coded to a specific value, useful for tests */
-    fun <T> of(value: T) = object: ActionScoped<T> {
+    fun <T> of(value: T) = object : ActionScoped<T> {
       override fun get() = value
     }
   }

--- a/misk/src/main/kotlin/misk/scope/ActionScopedProviderModule.kt
+++ b/misk/src/main/kotlin/misk/scope/ActionScopedProviderModule.kt
@@ -45,8 +45,9 @@ abstract class ActionScopedProviderModule : KAbstractModule() {
 
   /** Binds an unqualified [ActionScoped] along with its provider */
   fun <T : Any> bindProvider(
-      kclass: KClass<T>,
-      providerClass: KClass<out ActionScopedProvider<T>>) {
+    kclass: KClass<T>,
+    providerClass: KClass<out ActionScopedProvider<T>>
+  ) {
     bindProvider(
         Key.get(kclass.java),
         Key.get(actionScopedType(kclass)),
@@ -55,9 +56,10 @@ abstract class ActionScopedProviderModule : KAbstractModule() {
 
   /** Binds an annotation qualified [ActionScoped] along with its provider */
   fun <T : Any> bindProvider(
-      kclass: KClass<T>,
-      a: Annotation,
-      providerClass: KClass<out ActionScopedProvider<T>>) {
+    kclass: KClass<T>,
+    a: Annotation,
+    providerClass: KClass<out ActionScopedProvider<T>>
+  ) {
     bindProvider(
         Key.get(kclass.java, a),
         Key.get(actionScopedType(kclass), a),
@@ -66,9 +68,10 @@ abstract class ActionScopedProviderModule : KAbstractModule() {
 
   /** Binds an annotation qualified [ActionScoped] along with its provider */
   fun <T : Any> bindProvider(
-      kclass: KClass<T>,
-      a: KClass<Annotation>,
-      providerClass: KClass<out ActionScopedProvider<T>>) {
+    kclass: KClass<T>,
+    a: KClass<Annotation>,
+    providerClass: KClass<out ActionScopedProvider<T>>
+  ) {
     bindProvider(
         Key.get(kclass.java, a.java),
         Key.get(actionScopedType(kclass), a.java),
@@ -76,9 +79,9 @@ abstract class ActionScopedProviderModule : KAbstractModule() {
   }
 
   private fun <T : Any> bindProvider(
-      key: Key<T>,
-      actionScopedKey: Key<ActionScoped<T>>,
-      providerProvider: Provider<out ActionScopedProvider<T>>
+    key: Key<T>,
+    actionScopedKey: Key<ActionScoped<T>>,
+    providerProvider: Provider<out ActionScopedProvider<T>>
   ) {
     MapBinder.newMapBinder(binder(), KEY_TYPE, ACTION_SCOPED_PROVIDER_TYPE)
         .addBinding(key)

--- a/misk/src/main/kotlin/misk/scope/RealActionScoped.kt
+++ b/misk/src/main/kotlin/misk/scope/RealActionScoped.kt
@@ -4,8 +4,8 @@ import com.google.inject.Key
 import javax.inject.Inject
 
 internal class RealActionScoped<T> @Inject internal constructor(
-    val key: Key<T>,
-    val scope: ActionScope
+  val key: Key<T>,
+  val scope: ActionScope
 ) : ActionScoped<T> {
   override fun get(): T = scope.get(key)
 }

--- a/misk/src/main/kotlin/misk/scope/executor/ActionScopedExecutorService.kt
+++ b/misk/src/main/kotlin/misk/scope/executor/ActionScopedExecutorService.kt
@@ -12,8 +12,8 @@ import java.util.concurrent.ExecutorService
  * submitted by the current thread
  */
 class ActionScopedExecutorService(
-    target: ExecutorService,
-    private val scope: ActionScope
+  target: ExecutorService,
+  private val scope: ActionScope
 ) : WrappingListeningExecutorService() {
 
   private val target = MoreExecutors.listeningDecorator(target)

--- a/misk/src/main/kotlin/misk/security/keys/KeyService.kt
+++ b/misk/src/main/kotlin/misk/security/keys/KeyService.kt
@@ -5,8 +5,8 @@ import okio.ByteString
 /** Handles encryption and decryption using keys stored in a key management service */
 interface KeyService {
   /** encrypts the provided plain text using the given stored key */
-  fun encrypt(keyAlias: String, plainText: ByteString) : ByteString
+  fun encrypt(keyAlias: String, plainText: ByteString): ByteString
 
   /** decrypts the provided cipher text using the given stored key */
-  fun decrypt(keyAlias: String, cipherText: ByteString) : ByteString
+  fun decrypt(keyAlias: String, cipherText: ByteString): ByteString
 }

--- a/misk/src/main/kotlin/misk/security/ssl/KeyStoreX509KeyManager.kt
+++ b/misk/src/main/kotlin/misk/security/ssl/KeyStoreX509KeyManager.kt
@@ -13,22 +13,22 @@ import javax.net.ssl.X509ExtendedKeyManager
  * for periodically reloading from disk if needed
  */
 internal class KeyStoreX509KeyManager(
-    private val passphrase: CharArray,
-    private val lazyKeyStore: () -> KeyStore
+  private val passphrase: CharArray,
+  private val lazyKeyStore: () -> KeyStore
 ) : X509ExtendedKeyManager() {
 
   constructor(passphrase: CharArray, keyStore: KeyStore) : this(passphrase, { keyStore })
 
   override fun chooseServerAlias(
-      keyType: String,
-      issuers: Array<out Principal>,
-      socket: Socket
+    keyType: String,
+    issuers: Array<out Principal>,
+    socket: Socket
   ) = getPrivateKeyAlias()
 
   override fun chooseClientAlias(
-      keyTypes: Array<out String>,
-      issuers: Array<out Principal>,
-      socket: Socket
+    keyTypes: Array<out String>,
+    issuers: Array<out Principal>,
+    socket: Socket
   ) = getPrivateKeyAlias()
 
   override fun getClientAliases(keyType: String, issuers: Array<out Principal>): Array<String> {

--- a/misk/src/main/kotlin/misk/security/ssl/KeystoreConfig.kt
+++ b/misk/src/main/kotlin/misk/security/ssl/KeystoreConfig.kt
@@ -4,9 +4,9 @@ import misk.security.ssl.Keystores.TYPE_JCEKS
 import java.io.FileInputStream
 
 data class KeystoreConfig(
-    val path: String,
-    val passphrase: String? = null,
-    val type: String = TYPE_JCEKS
+  val path: String,
+  val passphrase: String? = null,
+  val type: String = TYPE_JCEKS
 ) {
   fun load() = Keystores.load(FileInputStream(path), type, passphrase)
 }

--- a/misk/src/main/kotlin/misk/tracing/TracingModule.kt
+++ b/misk/src/main/kotlin/misk/tracing/TracingModule.kt
@@ -4,13 +4,13 @@ import misk.inject.KAbstractModule
 import misk.tracing.backends.jaeger.JaegerBackendModule
 
 class TracingModule(val config: TracingConfig) : KAbstractModule() {
- override fun configure() {
-  if (config.tracer.equals("jaeger", true)) {
-   install(JaegerBackendModule(config.backends.jaeger))
-   return
-  }
+  override fun configure() {
+    if (config.tracer.equals("jaeger", true)) {
+      install(JaegerBackendModule(config.backends.jaeger))
+      return
+    }
 
-  throw IllegalArgumentException("No backend for '${config.tracer}' tracer. Ensure that " +
-    "tracer name is spelled correctly and that a backend module exists for that tracer.")
- }
+    throw IllegalArgumentException("No backend for '${config.tracer}' tracer. Ensure that " +
+        "tracer name is spelled correctly and that a backend module exists for that tracer.")
+  }
 }

--- a/misk/src/main/kotlin/misk/tracing/TracingService.kt
+++ b/misk/src/main/kotlin/misk/tracing/TracingService.kt
@@ -6,7 +6,7 @@ import io.opentracing.util.GlobalTracer
 import javax.inject.Inject
 
 internal class TracingService @Inject internal constructor(
-    private val tracer: Tracer
+  private val tracer: Tracer
 ) : AbstractIdleService() {
   override fun startUp() = GlobalTracer.register(tracer)
   override fun shutDown() {}

--- a/misk/src/main/kotlin/misk/tracing/backends/jaeger/JaegarSamplerConfig.kt
+++ b/misk/src/main/kotlin/misk/tracing/backends/jaeger/JaegarSamplerConfig.kt
@@ -2,8 +2,8 @@ package misk.tracing.backends.jaeger
 
 import misk.config.Config
 
-data class JaegerSamplerConfig (
- val type: String?,
- val param: Number?,
- val manager_host_port: String?
+data class JaegerSamplerConfig(
+  val type: String?,
+  val param: Number?,
+  val manager_host_port: String?
 ) : Config

--- a/misk/src/main/kotlin/misk/tracing/backends/jaeger/JaegerBackendConfig.kt
+++ b/misk/src/main/kotlin/misk/tracing/backends/jaeger/JaegerBackendConfig.kt
@@ -3,6 +3,6 @@ package misk.tracing.backends.jaeger
 import misk.config.Config
 
 data class JaegerBackendConfig(
- val sampler: JaegerSamplerConfig?,
- val reporter: JaegerReporterConfig?
+  val sampler: JaegerSamplerConfig?,
+  val reporter: JaegerReporterConfig?
 ) : Config

--- a/misk/src/main/kotlin/misk/tracing/backends/jaeger/JaegerBackendModule.kt
+++ b/misk/src/main/kotlin/misk/tracing/backends/jaeger/JaegerBackendModule.kt
@@ -12,25 +12,25 @@ import misk.inject.to
 import misk.tracing.TracingService
 
 class JaegerBackendModule(val config: JaegerBackendConfig?) : KAbstractModule() {
- override fun configure() {
-  binder().addMultibinderBinding<Service>().to<TracingService>()
- }
+  override fun configure() {
+    binder().addMultibinderBinding<Service>().to<TracingService>()
+  }
 
- @Provides
- @Singleton
- fun jaegerTracer(@AppName appName: String): Tracer {
-  val reporter =
-    if (config?.reporter == null) Configuration.ReporterConfiguration()
-    else Configuration.ReporterConfiguration(
-      config.reporter.log_spans, config.reporter.agent_host,
-      config.reporter.agent_port, config.reporter.flush_interval_ms,
-      config.reporter.max_queue_size)
+  @Provides
+  @Singleton
+  fun jaegerTracer(@AppName appName: String): Tracer {
+    val reporter =
+        if (config?.reporter == null) Configuration.ReporterConfiguration()
+        else Configuration.ReporterConfiguration(
+            config.reporter.log_spans, config.reporter.agent_host,
+            config.reporter.agent_port, config.reporter.flush_interval_ms,
+            config.reporter.max_queue_size)
 
-  val sampler =
-    if (config?.sampler == null) Configuration.SamplerConfiguration()
-    else Configuration.SamplerConfiguration(
-      config.sampler.type, config.sampler.param, config.sampler.manager_host_port)
+    val sampler =
+        if (config?.sampler == null) Configuration.SamplerConfiguration()
+        else Configuration.SamplerConfiguration(
+            config.sampler.type, config.sampler.param, config.sampler.manager_host_port)
 
-  return Configuration(appName, sampler, reporter).tracer
- }
+    return Configuration(appName, sampler, reporter).tracer
+  }
 }

--- a/misk/src/main/kotlin/misk/tracing/backends/jaeger/JaegerReporterConfig.kt
+++ b/misk/src/main/kotlin/misk/tracing/backends/jaeger/JaegerReporterConfig.kt
@@ -2,10 +2,10 @@ package misk.tracing.backends.jaeger
 
 import misk.config.Config
 
-data class JaegerReporterConfig (
- val log_spans: Boolean?,
- val agent_host: String?,
- val agent_port: Int?,
- val flush_interval_ms: Int?,
- val max_queue_size: Int?
+data class JaegerReporterConfig(
+  val log_spans: Boolean?,
+  val agent_host: String?,
+  val agent_port: Int?,
+  val flush_interval_ms: Int?,
+  val max_queue_size: Int?
 ) : Config

--- a/misk/src/main/kotlin/misk/web/BoundAction.kt
+++ b/misk/src/main/kotlin/misk/web/BoundAction.kt
@@ -5,10 +5,8 @@ import misk.web.actions.WebAction
 import misk.web.actions.asChain
 import misk.web.extractors.ParameterExtractor
 import misk.web.mediatype.MediaRange
-import okhttp3.Headers
 import okhttp3.HttpUrl
 import okhttp3.MediaType
-import okio.Okio
 import org.eclipse.jetty.http.HttpMethod
 import java.util.regex.Matcher
 import javax.inject.Provider
@@ -22,22 +20,22 @@ import kotlin.reflect.KParameter
  * response.
  */
 internal class BoundAction<A : WebAction, out R>(
-    private val webActionProvider: Provider<A>,
-    val interceptors: MutableList<Interceptor>,
-    parameterExtractorFactories: List<ParameterExtractor.Factory>,
-    val function: KFunction<R>,
-    val pathPattern: PathPattern,
-    private val httpMethod: HttpMethod,
-    private val acceptedContentTypes: List<MediaRange>,
-    private val responseContentType: MediaType?
+  private val webActionProvider: Provider<A>,
+  val interceptors: MutableList<Interceptor>,
+  parameterExtractorFactories: List<ParameterExtractor.Factory>,
+  val function: KFunction<R>,
+  val pathPattern: PathPattern,
+  private val httpMethod: HttpMethod,
+  private val acceptedContentTypes: List<MediaRange>,
+  private val responseContentType: MediaType?
 ) {
   private val parameterExtractors = function.parameters
       .drop(1) // the first parameter is always _this_
       .map { findParameterExtractor(parameterExtractorFactories, it) }
 
   private fun findParameterExtractor(
-      parameterExtractorFactories: List<ParameterExtractor.Factory>,
-      parameter: KParameter
+    parameterExtractorFactories: List<ParameterExtractor.Factory>,
+    parameter: KParameter
   ): ParameterExtractor {
     var result: ParameterExtractor? = null
     for (factory in parameterExtractorFactories) {
@@ -116,9 +114,9 @@ private fun HttpServletRequest.accepts(): List<MediaRange> {
 
 /** Matches a request to an action. Can be sorted to pick the most specific match amongst a set of candidates */
 internal class RequestMatch(
-    val action: BoundAction<*, *>,
-    private val pathMatcher: Matcher,
-    private val responseContentTypeMatch: MediaRange.Matcher?
+  val action: BoundAction<*, *>,
+  private val pathMatcher: Matcher,
+  private val responseContentTypeMatch: MediaRange.Matcher?
 ) : Comparable<RequestMatch> {
   override fun compareTo(other: RequestMatch): Int {
     val patternDiff = action.pathPattern.compareTo(other.action.pathPattern)

--- a/misk/src/main/kotlin/misk/web/PathPattern.kt
+++ b/misk/src/main/kotlin/misk/web/PathPattern.kt
@@ -9,11 +9,11 @@ import java.util.regex.Pattern
  * characters.
  */
 data class PathPattern(
-    val pattern: Pattern,
-    val variableNames: List<String>,
-    val numRegexVariables: Int,
-    val numSegments: Int,
-    val matchesWildcardPath: Boolean
+  val pattern: Pattern,
+  val variableNames: List<String>,
+  val numRegexVariables: Int,
+  val numSegments: Int,
+  val matchesWildcardPath: Boolean
 ) : Comparable<PathPattern> {
 
   /** Compares path patterns by specificity, with the more specific pattern ordered first */
@@ -36,6 +36,7 @@ data class PathPattern(
     // more specific match
     return other.numRegexVariables - numRegexVariables
   }
+
   companion object {
     fun parse(pattern: String): PathPattern {
       val variableNames = ArrayList<String>()
@@ -51,7 +52,7 @@ data class PathPattern(
         when (pattern[pos]) {
           '{' -> {
             // Variables must start on path boundaries
-            require(pos == 0 || pattern[pos-1] == '/') {
+            require(pos == 0 || pattern[pos - 1] == '/') {
               "invalid path pattern $pattern; variables must start on path boundaries"
             }
 

--- a/misk/src/main/kotlin/misk/web/WebActionModule.kt
+++ b/misk/src/main/kotlin/misk/web/WebActionModule.kt
@@ -20,12 +20,12 @@ import kotlin.reflect.KFunction
 import kotlin.reflect.full.findAnnotation
 
 class WebActionModule<A : WebAction> private constructor(
-    val webActionClass: KClass<A>,
-    val member: KFunction<*>,
-    val pathPattern: String,
-    val httpMethod: HttpMethod,
-    val acceptedContentTypes: List<MediaRange>,
-    val responseContentType: MediaType?
+  val webActionClass: KClass<A>,
+  val member: KFunction<*>,
+  val pathPattern: String,
+  val httpMethod: HttpMethod,
+  val acceptedContentTypes: List<MediaRange>,
+  val responseContentType: MediaType?
 ) : AbstractModule() {
   override fun configure() {
     val provider = getProvider(webActionClass.java)
@@ -36,8 +36,8 @@ class WebActionModule<A : WebAction> private constructor(
             subtypeOf<Any>()).typeLiteral()
     ) as Multibinder<BoundAction<A, *>>
     binder.addBinding().toProvider(
-            BoundActionProvider(provider, member, pathPattern, httpMethod,
-                acceptedContentTypes, responseContentType))
+        BoundActionProvider(provider, member, pathPattern, httpMethod,
+            acceptedContentTypes, responseContentType))
   }
 
   companion object {
@@ -92,12 +92,12 @@ private val KFunction<*>.responseContentType: MediaType?
   }
 
 internal class BoundActionProvider<A : WebAction, R>(
-    val provider: Provider<A>,
-    val function: KFunction<R>,
-    val pathPattern: String,
-    val httpMethod: HttpMethod,
-    val acceptedContentTypes: List<MediaRange>,
-    val responseContentType: MediaType?
+  val provider: Provider<A>,
+  val function: KFunction<R>,
+  val pathPattern: String,
+  val httpMethod: HttpMethod,
+  val acceptedContentTypes: List<MediaRange>,
+  val responseContentType: MediaType?
 ) : Provider<BoundAction<A, *>> {
 
   @Inject

--- a/misk/src/main/kotlin/misk/web/WebConfig.kt
+++ b/misk/src/main/kotlin/misk/web/WebConfig.kt
@@ -5,22 +5,23 @@ import misk.security.ssl.KeystoreConfig
 import misk.security.ssl.SslContextFactory
 
 data class WebConfig(
-    val port: Int,
-    val idle_timeout: Long,
-    val host: String? = null,
-    val ssl: WebSslConfig? = null
+  val port: Int,
+  val idle_timeout: Long,
+  val host: String? = null,
+  val ssl: WebSslConfig? = null
 ) : Config
 
 data class WebSslConfig(
-    val port: Int,
-    val keystore: KeystoreConfig,
-    val truststore: KeystoreConfig? = null,
-    val mutual_auth: MutualAuth = MutualAuth.REQUIRED
+  val port: Int,
+  val keystore: KeystoreConfig,
+  val truststore: KeystoreConfig? = null,
+  val mutual_auth: MutualAuth = MutualAuth.REQUIRED
 ) {
   enum class MutualAuth {
     NONE,
     REQUIRED,
     DESIRED
   }
+
   fun createSSLContext() = SslContextFactory.create(keystore, truststore)
 }

--- a/misk/src/main/kotlin/misk/web/WebModule.kt
+++ b/misk/src/main/kotlin/misk/web/WebModule.kt
@@ -33,7 +33,7 @@ import javax.servlet.http.HttpServletRequest
 class WebModule : KAbstractModule() {
   override fun configure() {
     install(JettyModule())
-    install(object: ActionScopedProviderModule() {
+    install(object : ActionScopedProviderModule() {
       override fun configureProviders() {
         bindSeedData(Request::class)
         bindSeedData(HttpServletRequest::class)
@@ -52,23 +52,29 @@ class WebModule : KAbstractModule() {
     // installed, and the order of these interceptors is critical.
 
     // Handle all unexpected errors that occur during dispatch
-    binder().addMultibinderBindingWithAnnotation<Interceptor.Factory, MiskDefault>().to<InternalErrorInterceptorFactory>()
+    binder().addMultibinderBindingWithAnnotation<Interceptor.Factory, MiskDefault>()
+        .to<InternalErrorInterceptorFactory>()
 
     // Optionally log request and response details
-    binder().addMultibinderBindingWithAnnotation<Interceptor.Factory, MiskDefault>().to<RequestLoggingInterceptor.Factory>()
+    binder().addMultibinderBindingWithAnnotation<Interceptor.Factory, MiskDefault>()
+        .to<RequestLoggingInterceptor.Factory>()
 
     // Collect metrics on the status of results and response times of requests
-    binder().addMultibinderBindingWithAnnotation<Interceptor.Factory, MiskDefault>().to<MetricsInterceptor.Factory>()
+    binder().addMultibinderBindingWithAnnotation<Interceptor.Factory, MiskDefault>()
+        .to<MetricsInterceptor.Factory>()
 
     // Convert and log application level exceptions into their appropriate response format
-    binder().addMultibinderBindingWithAnnotation<Interceptor.Factory, MiskDefault>().to<ExceptionHandlingInterceptor.Factory>()
+    binder().addMultibinderBindingWithAnnotation<Interceptor.Factory, MiskDefault>()
+        .to<ExceptionHandlingInterceptor.Factory>()
 
     // Convert typed responses into a ResponseBody that can marshal the response according to
     // the client's requested content-typ
-    binder().addMultibinderBindingWithAnnotation<Interceptor.Factory, MiskDefault>().to<MarshallerInterceptor.Factory>()
+    binder().addMultibinderBindingWithAnnotation<Interceptor.Factory, MiskDefault>()
+        .to<MarshallerInterceptor.Factory>()
 
     // Wrap "raw" responses with a Response object
-    binder().addMultibinderBindingWithAnnotation<Interceptor.Factory, MiskDefault>().to<BoxResponseInterceptorFactory>()
+    binder().addMultibinderBindingWithAnnotation<Interceptor.Factory, MiskDefault>()
+        .to<BoxResponseInterceptorFactory>()
 
     // Register build-in exception mappers
     install(ExceptionMapperModule.create<ActionException, ActionExceptionMapper>())

--- a/misk/src/main/kotlin/misk/web/exceptions/ExceptionHandlingInterceptor.kt
+++ b/misk/src/main/kotlin/misk/web/exceptions/ExceptionHandlingInterceptor.kt
@@ -11,7 +11,6 @@ import misk.web.Response
 import misk.web.marshal.StringResponseBody
 import misk.web.mediatype.MediaTypes
 import okhttp3.Headers
-import org.slf4j.event.Level
 import java.lang.reflect.InvocationTargetException
 import java.util.concurrent.ExecutionException
 import javax.inject.Inject
@@ -24,8 +23,8 @@ import javax.inject.Inject
  * mapped by installing [ExceptionMapper] via the [ExceptionMapperModule]
  */
 class ExceptionHandlingInterceptor(
-    private val actionName: String,
-    private val mapperResolver: ExceptionMapperResolver
+  private val actionName: String,
+  private val mapperResolver: ExceptionMapperResolver
 ) : Interceptor {
 
   override fun intercept(chain: Chain): Any? = try {

--- a/misk/src/main/kotlin/misk/web/exceptions/ExceptionMapperModule.kt
+++ b/misk/src/main/kotlin/misk/web/exceptions/ExceptionMapperModule.kt
@@ -30,17 +30,17 @@ class ExceptionMapperModule<M : ExceptionMapper<T>, in T : Throwable>(
   private val mapperClass: KClass<M>
 ) : KAbstractModule() {
   override fun configure() {
-   MapBinder.newMapBinder(binder(), exceptionTypeLiteral, exceptionMapperTypeLiteral)
-     .addBinding(exceptionClass)
-     .to(mapperClass.java)
+    MapBinder.newMapBinder(binder(), exceptionTypeLiteral, exceptionMapperTypeLiteral)
+        .addBinding(exceptionClass)
+        .to(mapperClass.java)
   }
 
   companion object {
-   inline fun <reified T : Throwable, reified M : ExceptionMapper<T>> create() = ExceptionMapperModule(
-     T::class, M::class
-   )
+    inline fun <reified T : Throwable, reified M : ExceptionMapper<T>> create() = ExceptionMapperModule(
+        T::class, M::class
+    )
 
-   private val exceptionMapperTypeLiteral = object : TypeLiteral<ExceptionMapper<*>>() {}
-   private val exceptionTypeLiteral = object : TypeLiteral<KClass<*>>() {}
+    private val exceptionMapperTypeLiteral = object : TypeLiteral<ExceptionMapper<*>>() {}
+    private val exceptionTypeLiteral = object : TypeLiteral<KClass<*>>() {}
   }
 }

--- a/misk/src/main/kotlin/misk/web/exceptions/ExceptionMapperResolver.kt
+++ b/misk/src/main/kotlin/misk/web/exceptions/ExceptionMapperResolver.kt
@@ -13,31 +13,31 @@ class ExceptionMapperResolver @Inject internal constructor(
   private val mappers: @JvmSuppressWildcards Map<KClass<*>, ExceptionMapper<*>>
 ) {
 
- private val cache: ConcurrentMap<KClass<*>, ExceptionMapper<Throwable>> = ConcurrentHashMap()
+  private val cache: ConcurrentMap<KClass<*>, ExceptionMapper<Throwable>> = ConcurrentHashMap()
 
- @Suppress("UNCHECKED_CAST")
- fun mapperFor(th: Throwable): ExceptionMapper<Throwable>? {
-  // The resolved Mapper is always the same, so cache it
-  return cache.getOrPut(th::class, {
-   val mappedException = getSuperclasses(th::class).firstOrNull { mappers.containsKey(it) }
-   return mappers[mappedException] as ExceptionMapper<Throwable>?
-  })
- }
-
- private fun getSuperclasses(kClass: KClass<*>): List<KClass<*>> {
-  val dfs = DFS()
-  dfs.doDFS(kClass)
-  return dfs.result
- }
-
- private class DFS {
-  val result: MutableList<KClass<*>> = mutableListOf()
-
-  fun doDFS(node: KClass<*>) {
-   result.add(node)
-   node.superclasses
-     .filter { it.isSubclassOf(Throwable::class) }
-     .forEach({ doDFS(it) })
+  @Suppress("UNCHECKED_CAST")
+  fun mapperFor(th: Throwable): ExceptionMapper<Throwable>? {
+    // The resolved Mapper is always the same, so cache it
+    return cache.getOrPut(th::class, {
+      val mappedException = getSuperclasses(th::class).firstOrNull { mappers.containsKey(it) }
+      return mappers[mappedException] as ExceptionMapper<Throwable>?
+    })
   }
- }
+
+  private fun getSuperclasses(kClass: KClass<*>): List<KClass<*>> {
+    val dfs = DFS()
+    dfs.doDFS(kClass)
+    return dfs.result
+  }
+
+  private class DFS {
+    val result: MutableList<KClass<*>> = mutableListOf()
+
+    fun doDFS(node: KClass<*>) {
+      result.add(node)
+      node.superclasses
+          .filter { it.isSubclassOf(Throwable::class) }
+          .forEach({ doDFS(it) })
+    }
+  }
 }

--- a/misk/src/main/kotlin/misk/web/extractors/FormValueParameterExtractorFactory.kt
+++ b/misk/src/main/kotlin/misk/web/extractors/FormValueParameterExtractorFactory.kt
@@ -24,9 +24,9 @@ object FormValueParameterExtractorFactory : ParameterExtractor.Factory {
    * parameter doesn't occur in the request, or can't be parsed into the correct type.
    */
   override fun create(
-      function: KFunction<*>,
-      parameter: KParameter,
-      pathPattern: PathPattern
+    function: KFunction<*>,
+    parameter: KParameter,
+    pathPattern: PathPattern
   ): ParameterExtractor? {
     parameter.findAnnotation<FormValue>() ?: return null
     if (parameter.type.classifier !is KClass<*>) return null
@@ -50,9 +50,9 @@ object FormValueParameterExtractorFactory : ParameterExtractor.Factory {
 
     return object : ParameterExtractor {
       override fun extract(
-          webAction: WebAction,
-          request: Request,
-          pathMatcher: Matcher
+        webAction: WebAction,
+        request: Request,
+        pathMatcher: Matcher
       ): Any? {
         val formValueMapping = parseBody(request.body)
         val parameterMap = LinkedHashMap<KParameter, Any?>()
@@ -71,8 +71,8 @@ object FormValueParameterExtractorFactory : ParameterExtractor.Factory {
   }
 
   private fun getParameterValue(
-      p: ConstructorParameter,
-      value: Collection<String>?
+    p: ConstructorParameter,
+    value: Collection<String>?
   ): Any? {
     if (p.isList) {
       return value?.map { p.converter?.invoke(it) }?.toList()
@@ -107,11 +107,11 @@ object FormValueParameterExtractorFactory : ParameterExtractor.Factory {
   private fun String.urlDecode(): String = URLDecoder.decode(this, "utf-8")
 
   private data class ConstructorParameter(
-      val kParameter: KParameter,
-      val name: String?,
-      val optional: Boolean,
-      val nullable: Boolean,
-      val isList: Boolean,
-      val converter: StringConverter?
+    val kParameter: KParameter,
+    val name: String?,
+    val optional: Boolean,
+    val nullable: Boolean,
+    val isList: Boolean,
+    val converter: StringConverter?
   )
 }

--- a/misk/src/main/kotlin/misk/web/extractors/HeadersParameterExtractorFactory.kt
+++ b/misk/src/main/kotlin/misk/web/extractors/HeadersParameterExtractorFactory.kt
@@ -21,9 +21,9 @@ object HeadersParameterExtractorFactory : ParameterExtractor.Factory {
   }
 
   override fun create(
-      function: KFunction<*>,
-      parameter: KParameter,
-      pathPattern: PathPattern
+    function: KFunction<*>,
+    parameter: KParameter,
+    pathPattern: PathPattern
   ): ParameterExtractor? {
     if (parameter.findAnnotation<RequestHeaders>() == null) return null
 

--- a/misk/src/main/kotlin/misk/web/extractors/ParameterExtractor.kt
+++ b/misk/src/main/kotlin/misk/web/extractors/ParameterExtractor.kt
@@ -22,9 +22,9 @@ interface ParameterExtractor {
      * examples.
      */
     fun create(
-        function: KFunction<*>,
-        parameter: KParameter,
-        pathPattern: PathPattern
+      function: KFunction<*>,
+      parameter: KParameter,
+      pathPattern: PathPattern
     ): ParameterExtractor?
   }
 }

--- a/misk/src/main/kotlin/misk/web/extractors/PathPatternParameterExtractor.kt
+++ b/misk/src/main/kotlin/misk/web/extractors/PathPatternParameterExtractor.kt
@@ -16,9 +16,9 @@ object PathPatternParameterExtractorFactory : ParameterExtractor.Factory {
    * and returns it as a [String]. If the parameter name doesn't occur in [pathPattern], returns null.
    */
   override fun create(
-      function: KFunction<*>,
-      parameter: KParameter,
-      pathPattern: PathPattern
+    function: KFunction<*>,
+    parameter: KParameter,
+    pathPattern: PathPattern
   ): ParameterExtractor? {
     val pathParamAnnotation = parameter.findAnnotation<PathParam>() ?: return null
     val parameterName =
@@ -35,9 +35,9 @@ object PathPatternParameterExtractorFactory : ParameterExtractor.Factory {
         )
     return object : ParameterExtractor {
       override fun extract(
-          webAction: WebAction,
-          request: Request,
-          pathMatcher: Matcher
+        webAction: WebAction,
+        request: Request,
+        pathMatcher: Matcher
       ): Any? {
         val pathParam = pathMatcher.group(patternIndex + 1)
         return converter(pathParam)

--- a/misk/src/main/kotlin/misk/web/extractors/QueryStringParameterExtractor.kt
+++ b/misk/src/main/kotlin/misk/web/extractors/QueryStringParameterExtractor.kt
@@ -16,9 +16,9 @@ object QueryStringParameterExtractorFactory : ParameterExtractor.Factory {
    * parameter doesn't occur in the request, or can't be parsed into the correct type.
    */
   override fun create(
-      function: KFunction<*>,
-      parameter: KParameter,
-      pathPattern: PathPattern
+    function: KFunction<*>,
+    parameter: KParameter,
+    pathPattern: PathPattern
   ): ParameterExtractor? {
     val queryParamAnnotation = parameter.findAnnotation<QueryParam>() ?: return null
     val parameterName =
@@ -28,9 +28,9 @@ object QueryStringParameterExtractorFactory : ParameterExtractor.Factory {
 
     return object : ParameterExtractor {
       override fun extract(
-          webAction: WebAction,
-          request: Request,
-          pathMatcher: Matcher
+        webAction: WebAction,
+        request: Request,
+        pathMatcher: Matcher
       ): Any? {
         val parameterValues: List<String> = request.url.queryParameterValues(parameterName)
         return queryParamProcessor.extractFunctionArgumentValue(parameterValues)

--- a/misk/src/main/kotlin/misk/web/extractors/QueryStringParameterProcessor.kt
+++ b/misk/src/main/kotlin/misk/web/extractors/QueryStringParameterProcessor.kt
@@ -12,8 +12,8 @@ internal class QueryStringParameterProcessor constructor(parameter: KParameter) 
   private val name: String? = parameter.name ?: parameter.type.javaType.typeName
   private val isList: Boolean = parameter.type.classifier?.equals(List::class) ?: false
   private val stringConverter = converterFor(
-    if (isList) parameter.type.arguments.first().type!!
-    else parameter.type
+      if (isList) parameter.type.arguments.first().type!!
+      else parameter.type
   ) ?: throw IllegalArgumentException("Unable to create converter for ${parameter.name}")
 
   fun extractFunctionArgumentValue(parameterStrings: List<String>): Any? {
@@ -23,8 +23,8 @@ internal class QueryStringParameterProcessor constructor(parameter: KParameter) 
 
     try {
       return if (isList) parameterStrings.map { stringConverter(it) }
-       else stringConverter(parameterStrings.first())
-    } catch(e: IllegalArgumentException) {
+      else stringConverter(parameterStrings.first())
+    } catch (e: IllegalArgumentException) {
       throw IllegalArgumentException("Invalid format for parameter: $name", e)
     }
   }

--- a/misk/src/main/kotlin/misk/web/extractors/RequestBodyParameterExtractor.kt
+++ b/misk/src/main/kotlin/misk/web/extractors/RequestBodyParameterExtractor.kt
@@ -14,8 +14,8 @@ import kotlin.reflect.KParameter
 import kotlin.reflect.full.findAnnotation
 
 internal class RequestBodyParameterExtractor(
-    private val parameter: KParameter,
-    private val unmarshallerFactories: List<Unmarshaller.Factory>
+  private val parameter: KParameter,
+  private val unmarshallerFactories: List<Unmarshaller.Factory>
 ) : ParameterExtractor {
   override fun extract(webAction: WebAction, request: Request, pathMatcher: Matcher): Any? {
     val mediaType = request.headers["Content-Type"]?.let { MediaType.parse(it) }
@@ -28,12 +28,12 @@ internal class RequestBodyParameterExtractor(
   }
 
   class Factory @Inject internal constructor(
-      @JvmSuppressWildcards private val unmarshallerFactories: List<Unmarshaller.Factory>
+    @JvmSuppressWildcards private val unmarshallerFactories: List<Unmarshaller.Factory>
   ) : ParameterExtractor.Factory {
     override fun create(
-        function: KFunction<*>,
-        parameter: KParameter,
-        pathPattern: PathPattern
+      function: KFunction<*>,
+      parameter: KParameter,
+      pathPattern: PathPattern
     ): ParameterExtractor? {
       if (parameter.findAnnotation<RequestBody>() == null) return null
       return RequestBodyParameterExtractor(parameter, unmarshallerFactories)

--- a/misk/src/main/kotlin/misk/web/extractors/StringConverter.kt
+++ b/misk/src/main/kotlin/misk/web/extractors/StringConverter.kt
@@ -20,39 +20,39 @@ private val booleanTypeNullable: KType = Boolean::class.createType(nullable = tr
 internal typealias StringConverter = (String) -> Any?
 
 internal fun converterFor(type: KType): StringConverter? = when (type) {
- stringType -> { it -> it }
- stringTypeNullable -> { it -> it }
- intType -> numberConversionWrapper { it.toInt() }
- intTypeNullable -> numberConversionWrapper { it.toInt() }
- longType -> numberConversionWrapper { it.toLong() }
- longTypeNullable -> numberConversionWrapper { it.toLong() }
- doubleType -> numberConversionWrapper { it.toDouble() }
- doubleTypeNullable -> numberConversionWrapper { it.toDouble() }
- booleanType -> numberConversionWrapper { it.toBoolean() }
- booleanTypeNullable -> numberConversionWrapper { it.toBoolean() }
- else -> createFromValueOf(type)
+  stringType -> { it -> it }
+  stringTypeNullable -> { it -> it }
+  intType -> numberConversionWrapper { it.toInt() }
+  intTypeNullable -> numberConversionWrapper { it.toInt() }
+  longType -> numberConversionWrapper { it.toLong() }
+  longTypeNullable -> numberConversionWrapper { it.toLong() }
+  doubleType -> numberConversionWrapper { it.toDouble() }
+  doubleTypeNullable -> numberConversionWrapper { it.toDouble() }
+  booleanType -> numberConversionWrapper { it.toBoolean() }
+  booleanTypeNullable -> numberConversionWrapper { it.toBoolean() }
+  else -> createFromValueOf(type)
 }
 
 private fun numberConversionWrapper(wrappedFunc: StringConverter): StringConverter {
- return {
-  try {
-   wrappedFunc(it)
-  } catch(e: NumberFormatException) {
-   throw IllegalArgumentException("Invalid parameter format: $it", e)
+  return {
+    try {
+      wrappedFunc(it)
+    } catch (e: NumberFormatException) {
+      throw IllegalArgumentException("Invalid parameter format: $it", e)
+    }
   }
- }
 }
 
 private fun createFromValueOf(type: KType): StringConverter? {
- try {
-  @Suppress("UNCHECKED_CAST")
-  val javaClass = type.javaType as Class<Any>?
-  val valueOfMethod = javaClass?.getMethod("valueOf", String::class.java)
-  if (valueOfMethod != null) {
-   return { param -> valueOfMethod(null, param) }
+  try {
+    @Suppress("UNCHECKED_CAST")
+    val javaClass = type.javaType as Class<Any>?
+    val valueOfMethod = javaClass?.getMethod("valueOf", String::class.java)
+    if (valueOfMethod != null) {
+      return { param -> valueOfMethod(null, param) }
+    }
+  } catch (e: ClassCastException) {
+  } catch (e: NoSuchMethodException) {
   }
- } catch(e: ClassCastException) {
- } catch(e: NoSuchMethodException) {
- }
- return null
+  return null
 }

--- a/misk/src/main/kotlin/misk/web/interceptors/MarshallerInterceptor.kt
+++ b/misk/src/main/kotlin/misk/web/interceptors/MarshallerInterceptor.kt
@@ -1,6 +1,5 @@
 package misk.web.interceptors
 
-import com.google.inject.TypeLiteral
 import misk.Action
 import misk.Chain
 import misk.Interceptor
@@ -16,8 +15,8 @@ import kotlin.reflect.KType
 import kotlin.reflect.full.findAnnotation
 
 @Singleton
-internal class MarshallerInterceptor constructor(private val marshaller: Marshaller<Any>)
-  : Interceptor {
+internal class MarshallerInterceptor constructor(private val marshaller: Marshaller<Any>) :
+    Interceptor {
   override fun intercept(chain: Chain): Response<Any> {
     @Suppress("UNCHECKED_CAST")
     val response = chain.proceed(chain.args) as Response<Any>
@@ -33,7 +32,7 @@ internal class MarshallerInterceptor constructor(private val marshaller: Marshal
   }
 
   class Factory @Inject internal constructor(
-      @JvmSuppressWildcards private val marshallerFactories: List<Marshaller.Factory>
+    @JvmSuppressWildcards private val marshallerFactories: List<Marshaller.Factory>
   ) : Interceptor.Factory {
     override fun create(action: Action): Interceptor? {
       return findMarshaller(action)?.let { MarshallerInterceptor(it) }
@@ -57,8 +56,8 @@ internal class MarshallerInterceptor constructor(private val marshaller: Marshal
     }
 
     private fun genericMarshallerFor(mediaType: MediaType?, type: KType): Marshaller<Any> {
-      return GenericMarshallers.from(mediaType, type) ?:
-          throw IllegalArgumentException("no marshaller for $mediaType as $type")
+      return GenericMarshallers.from(mediaType, type) ?: throw IllegalArgumentException(
+          "no marshaller for $mediaType as $type")
     }
   }
 }

--- a/misk/src/main/kotlin/misk/web/jetty/JettyService.kt
+++ b/misk/src/main/kotlin/misk/web/jetty/JettyService.kt
@@ -28,8 +28,8 @@ private val logger = getLogger<JettyService>()
 
 @Singleton
 class JettyService @Inject internal constructor(
-    private val webActionsServlet: WebActionsServlet,
-    private val webConfig: WebConfig
+  private val webActionsServlet: WebActionsServlet,
+  private val webConfig: WebConfig
 ) : AbstractIdleService() {
   private val server = Server()
 

--- a/misk/src/main/kotlin/misk/web/jetty/WebActionsServlet.kt
+++ b/misk/src/main/kotlin/misk/web/jetty/WebActionsServlet.kt
@@ -20,8 +20,8 @@ private val logger = getLogger<WebActionsServlet>()
 
 @Singleton
 internal class WebActionsServlet @Inject constructor(
-    private val boundActions: MutableSet<BoundAction<out WebAction, *>>,
-    private val scope: ActionScope
+  private val boundActions: MutableSet<BoundAction<out WebAction, *>>,
+  private val scope: ActionScope
 ) : HttpServlet() {
   override fun doGet(request: HttpServletRequest, response: HttpServletResponse) {
     handleCall(request, response)
@@ -41,7 +41,7 @@ internal class WebActionsServlet @Inject constructor(
       val candidateActions = boundActions.mapNotNull { it.match(request, asRequest.url) }
       val bestAction = candidateActions.sorted().firstOrNull()
       bestAction?.handle(asRequest, response)
-      logger.debug {"Request handled by WebActionServlet" }
+      logger.debug { "Request handled by WebActionServlet" }
     }
   }
 }

--- a/misk/src/main/kotlin/misk/web/mediatype/MediaRange.kt
+++ b/misk/src/main/kotlin/misk/web/mediatype/MediaRange.kt
@@ -5,12 +5,12 @@ import java.nio.charset.Charset
 
 /** An RFC-2616 media range */
 data class MediaRange(
-    val type: String,
-    val subtype: String,
-    val charset: Charset? = null,
-    val qualityFactor: Double = 1.0,
-    val parameters: Map<String, String> = mapOf(),
-    val extensions: Map<String, String> = mapOf()
+  val type: String,
+  val subtype: String,
+  val charset: Charset? = null,
+  val qualityFactor: Double = 1.0,
+  val parameters: Map<String, String> = mapOf(),
+  val extensions: Map<String, String> = mapOf()
 ) : Comparable<MediaRange> {
   override fun compareTo(other: MediaRange): Int {
     if (type == WILDCARD && other.type != WILDCARD) return 1
@@ -49,8 +49,8 @@ data class MediaRange(
     return Matcher(this, true)
   }
 
-  data class Matcher(private val mediaRange: MediaRange, val matchesCharset: Boolean = false)
-    : Comparable<Matcher> {
+  data class Matcher(private val mediaRange: MediaRange, val matchesCharset: Boolean = false) :
+      Comparable<Matcher> {
     override fun compareTo(other: Matcher): Int {
       val mediaRangeComparison = mediaRange.compareTo(other.mediaRange)
       if (mediaRangeComparison != 0) return mediaRangeComparison

--- a/misk/src/test/java/com/squareup/protos/test/parsing/Robot.java
+++ b/misk/src/test/java/com/squareup/protos/test/parsing/Robot.java
@@ -10,11 +10,6 @@ import com.squareup.wire.ProtoWriter;
 import com.squareup.wire.WireField;
 import com.squareup.wire.internal.Internal;
 import java.io.IOException;
-import java.lang.Integer;
-import java.lang.Object;
-import java.lang.Override;
-import java.lang.String;
-import java.lang.StringBuilder;
 import okio.ByteString;
 
 public final class Robot extends Message<Robot, Robot.Builder> {
@@ -134,10 +129,14 @@ public final class Robot extends Message<Robot, Robot.Builder> {
     public Robot decode(ProtoReader reader) throws IOException {
       Builder builder = new Builder();
       long token = reader.beginMessage();
-      for (int tag; (tag = reader.nextTag()) != -1;) {
+      for (int tag; (tag = reader.nextTag()) != -1; ) {
         switch (tag) {
-          case 1: builder.robot_id(ProtoAdapter.INT32.decode(reader)); break;
-          case 2: builder.robot_token(ProtoAdapter.STRING.decode(reader)); break;
+          case 1:
+            builder.robot_id(ProtoAdapter.INT32.decode(reader));
+            break;
+          case 2:
+            builder.robot_token(ProtoAdapter.STRING.decode(reader));
+            break;
           default: {
             FieldEncoding fieldEncoding = reader.peekFieldEncoding();
             Object value = fieldEncoding.rawProtoAdapter().decode(reader);

--- a/misk/src/test/java/com/squareup/protos/test/parsing/Shipment.java
+++ b/misk/src/test/java/com/squareup/protos/test/parsing/Shipment.java
@@ -12,13 +12,6 @@ import com.squareup.wire.WireEnum;
 import com.squareup.wire.WireField;
 import com.squareup.wire.internal.Internal;
 import java.io.IOException;
-import java.lang.Boolean;
-import java.lang.Double;
-import java.lang.Long;
-import java.lang.Object;
-import java.lang.Override;
-import java.lang.String;
-import java.lang.StringBuilder;
 import java.util.List;
 import okio.ByteString;
 
@@ -130,7 +123,9 @@ public final class Shipment extends Message<Shipment, Shipment.Builder> {
       State status, Double load_ratio, Boolean deleted, ByteString source_signature,
       ByteString destination_signature, List<String> notes, String account_token, String card_token,
       String transfer_id) {
-    this(shipment_id, shipment_token, source, destination, status, load_ratio, deleted, source_signature, destination_signature, notes, account_token, card_token, transfer_id, ByteString.EMPTY);
+    this(shipment_id, shipment_token, source, destination, status, load_ratio, deleted,
+        source_signature, destination_signature, notes, account_token, card_token, transfer_id,
+        ByteString.EMPTY);
   }
 
   public Shipment(Long shipment_id, String shipment_token, Warehouse source, Warehouse destination,
@@ -139,7 +134,8 @@ public final class Shipment extends Message<Shipment, Shipment.Builder> {
       String transfer_id, ByteString unknownFields) {
     super(ADAPTER, unknownFields);
     if (Internal.countNonNull(account_token, card_token, transfer_id) > 1) {
-      throw new IllegalArgumentException("at most one of account_token, card_token, transfer_id may be non-null");
+      throw new IllegalArgumentException(
+          "at most one of account_token, card_token, transfer_id may be non-null");
     }
     this.shipment_id = shipment_id;
     this.shipment_token = shipment_token;
@@ -231,7 +227,9 @@ public final class Shipment extends Message<Shipment, Shipment.Builder> {
     if (load_ratio != null) builder.append(", load_ratio=").append(load_ratio);
     if (deleted != null) builder.append(", deleted=").append(deleted);
     if (source_signature != null) builder.append(", source_signature=").append(source_signature);
-    if (destination_signature != null) builder.append(", destination_signature=").append(destination_signature);
+    if (destination_signature != null) {
+      builder.append(", destination_signature=").append(destination_signature);
+    }
     if (!notes.isEmpty()) builder.append(", notes=").append(notes);
     if (account_token != null) builder.append(", account_token=").append(account_token);
     if (card_token != null) builder.append(", card_token=").append(card_token);
@@ -344,7 +342,9 @@ public final class Shipment extends Message<Shipment, Shipment.Builder> {
 
     @Override
     public Shipment build() {
-      return new Shipment(shipment_id, shipment_token, source, destination, status, load_ratio, deleted, source_signature, destination_signature, notes, account_token, card_token, transfer_id, super.buildUnknownFields());
+      return new Shipment(shipment_id, shipment_token, source, destination, status, load_ratio,
+          deleted, source_signature, destination_signature, notes, account_token, card_token,
+          transfer_id, super.buildUnknownFields());
     }
   }
 
@@ -370,11 +370,16 @@ public final class Shipment extends Message<Shipment, Shipment.Builder> {
      */
     public static State fromValue(int value) {
       switch (value) {
-        case 0: return VALIDATING;
-        case 1: return PICKING_UP;
-        case 2: return DELIVERING;
-        case 4: return CONSUMING;
-        default: return null;
+        case 0:
+          return VALIDATING;
+        case 1:
+          return PICKING_UP;
+        case 2:
+          return DELIVERING;
+        case 4:
+          return CONSUMING;
+        default:
+          return null;
       }
     }
 
@@ -440,12 +445,20 @@ public final class Shipment extends Message<Shipment, Shipment.Builder> {
     public Shipment decode(ProtoReader reader) throws IOException {
       Builder builder = new Builder();
       long token = reader.beginMessage();
-      for (int tag; (tag = reader.nextTag()) != -1;) {
+      for (int tag; (tag = reader.nextTag()) != -1; ) {
         switch (tag) {
-          case 1: builder.shipment_id(ProtoAdapter.INT64.decode(reader)); break;
-          case 2: builder.shipment_token(ProtoAdapter.STRING.decode(reader)); break;
-          case 4: builder.source(Warehouse.ADAPTER.decode(reader)); break;
-          case 5: builder.destination(Warehouse.ADAPTER.decode(reader)); break;
+          case 1:
+            builder.shipment_id(ProtoAdapter.INT64.decode(reader));
+            break;
+          case 2:
+            builder.shipment_token(ProtoAdapter.STRING.decode(reader));
+            break;
+          case 4:
+            builder.source(Warehouse.ADAPTER.decode(reader));
+            break;
+          case 5:
+            builder.destination(Warehouse.ADAPTER.decode(reader));
+            break;
           case 6: {
             try {
               builder.status(State.ADAPTER.decode(reader));
@@ -454,14 +467,30 @@ public final class Shipment extends Message<Shipment, Shipment.Builder> {
             }
             break;
           }
-          case 7: builder.load_ratio(ProtoAdapter.DOUBLE.decode(reader)); break;
-          case 8: builder.deleted(ProtoAdapter.BOOL.decode(reader)); break;
-          case 9: builder.source_signature(ProtoAdapter.BYTES.decode(reader)); break;
-          case 10: builder.destination_signature(ProtoAdapter.BYTES.decode(reader)); break;
-          case 12: builder.notes.add(ProtoAdapter.STRING.decode(reader)); break;
-          case 13: builder.account_token(ProtoAdapter.STRING.decode(reader)); break;
-          case 14: builder.card_token(ProtoAdapter.STRING.decode(reader)); break;
-          case 15: builder.transfer_id(ProtoAdapter.STRING.decode(reader)); break;
+          case 7:
+            builder.load_ratio(ProtoAdapter.DOUBLE.decode(reader));
+            break;
+          case 8:
+            builder.deleted(ProtoAdapter.BOOL.decode(reader));
+            break;
+          case 9:
+            builder.source_signature(ProtoAdapter.BYTES.decode(reader));
+            break;
+          case 10:
+            builder.destination_signature(ProtoAdapter.BYTES.decode(reader));
+            break;
+          case 12:
+            builder.notes.add(ProtoAdapter.STRING.decode(reader));
+            break;
+          case 13:
+            builder.account_token(ProtoAdapter.STRING.decode(reader));
+            break;
+          case 14:
+            builder.card_token(ProtoAdapter.STRING.decode(reader));
+            break;
+          case 15:
+            builder.transfer_id(ProtoAdapter.STRING.decode(reader));
+            break;
           default: {
             FieldEncoding fieldEncoding = reader.peekFieldEncoding();
             Object value = fieldEncoding.rawProtoAdapter().decode(reader);
@@ -477,7 +506,9 @@ public final class Shipment extends Message<Shipment, Shipment.Builder> {
     public Shipment redact(Shipment value) {
       Builder builder = value.newBuilder();
       if (builder.source != null) builder.source = Warehouse.ADAPTER.redact(builder.source);
-      if (builder.destination != null) builder.destination = Warehouse.ADAPTER.redact(builder.destination);
+      if (builder.destination != null) {
+        builder.destination = Warehouse.ADAPTER.redact(builder.destination);
+      }
       builder.clearUnknownFields();
       return builder.build();
     }

--- a/misk/src/test/java/com/squareup/protos/test/parsing/Warehouse.java
+++ b/misk/src/test/java/com/squareup/protos/test/parsing/Warehouse.java
@@ -10,12 +10,6 @@ import com.squareup.wire.ProtoWriter;
 import com.squareup.wire.WireField;
 import com.squareup.wire.internal.Internal;
 import java.io.IOException;
-import java.lang.Integer;
-import java.lang.Long;
-import java.lang.Object;
-import java.lang.Override;
-import java.lang.String;
-import java.lang.StringBuilder;
 import java.util.List;
 import java.util.Map;
 import okio.ByteString;
@@ -70,7 +64,8 @@ public final class Warehouse extends Message<Warehouse, Warehouse.Builder> {
 
   public Warehouse(Long warehouse_id, String warehouse_token, Warehouse central_repo,
       List<Warehouse> alternates, Map<String, String> dropoff_points, Map<Integer, Robot> robots) {
-    this(warehouse_id, warehouse_token, central_repo, alternates, dropoff_points, robots, ByteString.EMPTY);
+    this(warehouse_id, warehouse_token, central_repo, alternates, dropoff_points, robots,
+        ByteString.EMPTY);
   }
 
   public Warehouse(Long warehouse_id, String warehouse_token, Warehouse central_repo,
@@ -194,14 +189,17 @@ public final class Warehouse extends Message<Warehouse, Warehouse.Builder> {
 
     @Override
     public Warehouse build() {
-      return new Warehouse(warehouse_id, warehouse_token, central_repo, alternates, dropoff_points, robots, super.buildUnknownFields());
+      return new Warehouse(warehouse_id, warehouse_token, central_repo, alternates, dropoff_points,
+          robots, super.buildUnknownFields());
     }
   }
 
   private static final class ProtoAdapter_Warehouse extends ProtoAdapter<Warehouse> {
-    private final ProtoAdapter<Map<String, String>> dropoff_points = ProtoAdapter.newMapAdapter(ProtoAdapter.STRING, ProtoAdapter.STRING);
+    private final ProtoAdapter<Map<String, String>> dropoff_points =
+        ProtoAdapter.newMapAdapter(ProtoAdapter.STRING, ProtoAdapter.STRING);
 
-    private final ProtoAdapter<Map<Integer, Robot>> robots = ProtoAdapter.newMapAdapter(ProtoAdapter.INT32, Robot.ADAPTER);
+    private final ProtoAdapter<Map<Integer, Robot>> robots =
+        ProtoAdapter.newMapAdapter(ProtoAdapter.INT32, Robot.ADAPTER);
 
     public ProtoAdapter_Warehouse() {
       super(FieldEncoding.LENGTH_DELIMITED, Warehouse.class);
@@ -233,14 +231,26 @@ public final class Warehouse extends Message<Warehouse, Warehouse.Builder> {
     public Warehouse decode(ProtoReader reader) throws IOException {
       Builder builder = new Builder();
       long token = reader.beginMessage();
-      for (int tag; (tag = reader.nextTag()) != -1;) {
+      for (int tag; (tag = reader.nextTag()) != -1; ) {
         switch (tag) {
-          case 1: builder.warehouse_id(ProtoAdapter.INT64.decode(reader)); break;
-          case 2: builder.warehouse_token(ProtoAdapter.STRING.decode(reader)); break;
-          case 3: builder.central_repo(Warehouse.ADAPTER.decode(reader)); break;
-          case 4: builder.alternates.add(Warehouse.ADAPTER.decode(reader)); break;
-          case 6: builder.dropoff_points.putAll(dropoff_points.decode(reader)); break;
-          case 7: builder.robots.putAll(robots.decode(reader)); break;
+          case 1:
+            builder.warehouse_id(ProtoAdapter.INT64.decode(reader));
+            break;
+          case 2:
+            builder.warehouse_token(ProtoAdapter.STRING.decode(reader));
+            break;
+          case 3:
+            builder.central_repo(Warehouse.ADAPTER.decode(reader));
+            break;
+          case 4:
+            builder.alternates.add(Warehouse.ADAPTER.decode(reader));
+            break;
+          case 6:
+            builder.dropoff_points.putAll(dropoff_points.decode(reader));
+            break;
+          case 7:
+            builder.robots.putAll(robots.decode(reader));
+            break;
           default: {
             FieldEncoding fieldEncoding = reader.peekFieldEncoding();
             Object value = fieldEncoding.rawProtoAdapter().decode(reader);
@@ -255,7 +265,9 @@ public final class Warehouse extends Message<Warehouse, Warehouse.Builder> {
     @Override
     public Warehouse redact(Warehouse value) {
       Builder builder = value.newBuilder();
-      if (builder.central_repo != null) builder.central_repo = Warehouse.ADAPTER.redact(builder.central_repo);
+      if (builder.central_repo != null) {
+        builder.central_repo = Warehouse.ADAPTER.redact(builder.central_repo);
+      }
       Internal.redactElements(builder.alternates, Warehouse.ADAPTER);
       Internal.redactElements(builder.robots, Robot.ADAPTER);
       builder.clearUnknownFields();

--- a/misk/src/test/java/helpers/protos/Dinosaur.java
+++ b/misk/src/test/java/helpers/protos/Dinosaur.java
@@ -13,7 +13,8 @@ import static com.squareup.wire.internal.Internal.immutableCopyOf;
 import static com.squareup.wire.internal.Internal.newMutableList;
 
 public final class Dinosaur extends Message<Dinosaur, Dinosaur.Builder> {
-  public static final ProtoAdapter<Dinosaur> ADAPTER = ProtoAdapter.newMessageAdapter(Dinosaur.class);
+  public static final ProtoAdapter<Dinosaur> ADAPTER =
+      ProtoAdapter.newMessageAdapter(Dinosaur.class);
 
   private static final long serialVersionUID = 0L;
 

--- a/misk/src/test/kotlin/misk/MiskApplicationTest.kt
+++ b/misk/src/test/kotlin/misk/MiskApplicationTest.kt
@@ -98,16 +98,15 @@ internal class MiskApplicationTest {
     }
 
     // Error message should be specific to the command
-    assertThat(exception.message).isEqualTo(
-"""
-Expected a value after parameter -f
-
-Usage: with-required-args [options]
- Options:
- * -f, --file
-
-"""
-    )
+    assertThat(exception.message).isEqualTo("""
+        |
+        |Expected a value after parameter -f
+        |
+        |Usage: with-required-args [options]
+        |  Options:
+        |  * -f, --file
+        |
+        |""".trimMargin())
   }
 
   @Test
@@ -118,31 +117,30 @@ Usage: with-required-args [options]
     }
 
     // Error message should include the entire usage
-    assertThat(exception.message).isEqualTo(
-"""
-Expected a command, got unknown
-
-Usage: <main class> [command] [command options]
- Commands:
-  with-required-args      null
-   Usage: with-required-args [options]
-    Options:
-    * -f, --file
-
-
-  with-preconditions      null
-   Usage: with-preconditions [options]
-    Options:
-     -d, --dir
-
-     -f, --file
-
-
-  with-module      null
-   Usage: with-module
-
-"""
-    )
+    assertThat(exception.message).isEqualTo("""
+        |
+        |Expected a command, got unknown
+        |
+        |Usage: <main class> [command] [command options]
+        |  Commands:
+        |    with-required-args      null
+        |      Usage: with-required-args [options]
+        |        Options:
+        |        * -f, --file
+        |
+        |
+        |    with-preconditions      null
+        |      Usage: with-preconditions [options]
+        |        Options:
+        |          -d, --dir
+        |
+        |          -f, --file
+        |
+        |
+        |    with-module      null
+        |      Usage: with-module
+        |
+        |""".trimMargin())
   }
 
   @Test
@@ -153,18 +151,16 @@ Usage: <main class> [command] [command options]
     }
 
     // Error message should be specific to the command
-    assertThat(exception.message).isEqualTo(
-"""
-one of -f or -d must be specified
-
-Usage: with-preconditions [options]
- Options:
-  -d, --dir
-
-  -f, --file
-
-"""
-    )
-
+    assertThat(exception.message).isEqualTo("""
+        |
+        |one of -f or -d must be specified
+        |
+        |Usage: with-preconditions [options]
+        |  Options:
+        |    -d, --dir
+        |
+        |    -f, --file
+        |
+        |""".trimMargin())
   }
 }

--- a/misk/src/test/kotlin/misk/cloud/fake/security/keys/FakeKeyServiceTest.kt
+++ b/misk/src/test/kotlin/misk/cloud/fake/security/keys/FakeKeyServiceTest.kt
@@ -1,7 +1,7 @@
 package misk.cloud.fake.security.keys
 
-import org.assertj.core.api.Assertions.assertThat
 import okio.ByteString
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
 class FakeKeyServiceTest {

--- a/misk/src/test/kotlin/misk/cloud/gcp/environment/GcpInstanceMetadataProviderTest.kt
+++ b/misk/src/test/kotlin/misk/cloud/gcp/environment/GcpInstanceMetadataProviderTest.kt
@@ -1,11 +1,11 @@
 package misk.cloud.gcp.environment
 
-import org.assertj.core.api.Assertions.assertThat
 import misk.cloud.gcp.environment.GcpInstanceMetadataProvider.Companion.GCP_INSTANCE_METADATA_PATH
 import misk.testing.okhttp.RoutingDispatcher
 import misk.testing.okhttp.path
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
 internal class GcpInstanceMetadataProviderTest {

--- a/misk/src/test/kotlin/misk/cloud/gcp/security/keys/GcpKeyServiceTest.kt
+++ b/misk/src/test/kotlin/misk/cloud/gcp/security/keys/GcpKeyServiceTest.kt
@@ -4,11 +4,11 @@ import com.google.api.client.json.jackson2.JacksonFactory
 import com.google.api.services.cloudkms.v1.CloudKMS
 import com.google.api.services.cloudkms.v1.model.DecryptResponse
 import com.google.api.services.cloudkms.v1.model.EncryptResponse
-import org.assertj.core.api.Assertions.assertThat
 import misk.cloud.gcp.testing.FakeHttpRouter
 import misk.cloud.gcp.testing.FakeHttpRouter.Companion.respondWithError
 import misk.cloud.gcp.testing.FakeHttpRouter.Companion.respondWithJson
 import okio.ByteString
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Test
 
@@ -19,7 +19,8 @@ internal class GcpKeyServiceTest {
           "bar" to GcpKeyLocation("system", "other_ring", "key2"),
           "zed" to GcpKeyLocation("system", "main_ring", "key5")))
 
-  private val TARGET_RESOURCE_URL = "https://cloudkms.googleapis.com/v1/projects/my_project/locations/system/keyRings/main_ring/cryptoKeys/key1"
+  private val TARGET_RESOURCE_URL =
+      "https://cloudkms.googleapis.com/v1/projects/my_project/locations/system/keyRings/main_ring/cryptoKeys/key1"
 
   private val transport = FakeHttpRouter {
     when (it.url) {

--- a/misk/src/test/kotlin/misk/cloud/gcp/testing/FakeHttpRequest.kt
+++ b/misk/src/test/kotlin/misk/cloud/gcp/testing/FakeHttpRequest.kt
@@ -6,9 +6,9 @@ import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
 
 class FakeHttpRequest constructor(
-    val method: String,
-    val url: String,
-    private val router: (FakeHttpRequest) -> FakeHttpResponse
+  val method: String,
+  val url: String,
+  private val router: (FakeHttpRequest) -> FakeHttpResponse
 ) : LowLevelHttpRequest() {
   private val headers = LinkedHashMap<String, String>()
   private var contentBytes: ByteArray? = null

--- a/misk/src/test/kotlin/misk/cloud/gcp/testing/FakeHttpResponse.kt
+++ b/misk/src/test/kotlin/misk/cloud/gcp/testing/FakeHttpResponse.kt
@@ -5,6 +5,6 @@ import com.google.api.client.testing.http.MockLowLevelHttpResponse
 
 typealias FakeHttpResponse = MockLowLevelHttpResponse
 
-fun FakeHttpResponse.setJsonContent(item: Any) : FakeHttpResponse =
-  setContent(JacksonFactory.getDefaultInstance().toByteArray(item))
+fun FakeHttpResponse.setJsonContent(item: Any): FakeHttpResponse =
+    setContent(JacksonFactory.getDefaultInstance().toByteArray(item))
 

--- a/misk/src/test/kotlin/misk/cloud/gcp/testing/FakeHttpRouterTest.kt
+++ b/misk/src/test/kotlin/misk/cloud/gcp/testing/FakeHttpRouterTest.kt
@@ -4,9 +4,9 @@ import com.google.api.client.http.GenericUrl
 import com.google.api.client.http.HttpResponseException
 import com.google.api.client.json.jackson2.JacksonFactory
 import com.google.api.client.testing.http.MockHttpContent
-import org.assertj.core.api.Assertions.assertThat
 import misk.cloud.gcp.testing.FakeHttpRouter.Companion.respondWithError
 import misk.cloud.gcp.testing.FakeHttpRouter.Companion.respondWithText
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.fail
 import org.junit.jupiter.api.Test
 import java.io.ByteArrayInputStream

--- a/misk/src/test/kotlin/misk/concurrent/WrappingListeningExecutorServiceTest.kt
+++ b/misk/src/test/kotlin/misk/concurrent/WrappingListeningExecutorServiceTest.kt
@@ -1,8 +1,8 @@
 package misk.concurrent
 
-import org.assertj.core.api.Assertions.assertThat
 import com.google.common.util.concurrent.ListeningExecutorService
 import com.google.common.util.concurrent.MoreExecutors
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import java.util.concurrent.Callable
@@ -42,7 +42,7 @@ internal class WrappingListeningExecutorServiceTest {
   @Test
   fun submitRunnable() {
     val executed = AtomicBoolean()
-    executor.submit({ executed.set(true)}).get()
+    executor.submit({ executed.set(true) }).get()
     assertThat(executed.get()).isTrue()
     assertThat(wrapCounter.get()).isEqualTo(1)
   }
@@ -71,7 +71,7 @@ internal class WrappingListeningExecutorServiceTest {
   @Test
   fun execute() {
     val latch = CountDownLatch(1)
-    executor.execute( { latch.countDown() })
+    executor.execute({ latch.countDown() })
     latch.await()
     assertThat(wrapCounter.get()).isEqualTo(1)
   }

--- a/misk/src/test/kotlin/misk/config/ConfigTest.kt
+++ b/misk/src/test/kotlin/misk/config/ConfigTest.kt
@@ -26,7 +26,6 @@ class ConfigTest {
   @Inject
   private lateinit var testConfig: TestConfig
 
-
   @field:[Inject Named("consumer_a")]
   lateinit var consumerA: ConsumerConfig
 
@@ -72,7 +71,7 @@ class ConfigTest {
     })
 
     assertThat(exception.localizedMessage).contains("could not find configuration files -" +
-      " checked [missing-common.yaml, missing-testing.yaml]")
+        " checked [missing-common.yaml, missing-testing.yaml]")
   }
 
   @Test

--- a/misk/src/test/kotlin/misk/metrics/backends/stackdriver/StackDriverReporterTest.kt
+++ b/misk/src/test/kotlin/misk/metrics/backends/stackdriver/StackDriverReporterTest.kt
@@ -28,14 +28,16 @@ internal class StackDriverReporterTest {
   companion object {
     val APP_NAME = "my_app"
     val INSTANCE_METADATA = InstanceMetadata("165.33.45.25", "us-west2")
-    val METRIC_PREFIX = "custom.googleapis.com/dw/$APP_NAME/${INSTANCE_METADATA.zone}/${INSTANCE_METADATA.instanceName}"
+    val METRIC_PREFIX =
+        "custom.googleapis.com/dw/$APP_NAME/${INSTANCE_METADATA.zone}/${INSTANCE_METADATA.instanceName}"
     val START_TIME = DateTime("2017-11-23T16:46:32Z")
     val NOW = DateTime("2017-11-24T21:56:30Z")
 
     fun assertGauge(timeSeries: TimeSeries, expected: Double) {
       assertThat(timeSeries.metricKind).isEqualTo("GAUGE")
       assertThat(timeSeries.points).hasSize(1)
-      assertThat(timeSeries.points[0].value.doubleValue).isCloseTo(expected, Percentage.withPercentage(0.1))
+      assertThat(timeSeries.points[0].value.doubleValue).isCloseTo(expected,
+          Percentage.withPercentage(0.1))
       assertThat(timeSeries.points[0].interval.startTime).isNull()
       assertThat(timeSeries.points[0].interval.endTime).isEqualTo(NOW.toStringRfc3339())
     }

--- a/misk/src/test/kotlin/misk/moshi/wire/WireMessageAdapterTest.kt
+++ b/misk/src/test/kotlin/misk/moshi/wire/WireMessageAdapterTest.kt
@@ -5,12 +5,12 @@ import com.squareup.moshi.Moshi
 import com.squareup.protos.test.parsing.Robot
 import com.squareup.protos.test.parsing.Shipment
 import com.squareup.protos.test.parsing.Warehouse
-import org.assertj.core.api.isEqualToAsJson
 import misk.moshi.MoshiModule
 import misk.testing.MiskTest
 import misk.testing.MiskTestModule
 import okio.ByteString
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.isEqualToAsJson
 import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Test
 import javax.inject.Inject

--- a/misk/src/test/kotlin/misk/scope/ActionScopePropagationTest.kt
+++ b/misk/src/test/kotlin/misk/scope/ActionScopePropagationTest.kt
@@ -1,11 +1,11 @@
 package misk.scope
 
-import org.assertj.core.api.Assertions.assertThat
 import com.google.inject.Guice
 import com.google.inject.Key
 import com.google.inject.name.Named
 import com.google.inject.name.Names
 import misk.inject.keyOf
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import java.util.concurrent.Callable
 import java.util.concurrent.Executors
@@ -50,7 +50,7 @@ internal class ActionScopePropagationTest {
         keyOf<String>(Names.named("from-seed")) to "my seed data")
 
     // Propagate on the the KCallable directly
-    val f : KFunction<String> = tester::fooValue
+    val f: KFunction<String> = tester::fooValue
     val callable = scope.enter(seedData).use {
       scope.propagate(f)
     }
@@ -73,7 +73,7 @@ internal class ActionScopePropagationTest {
 
     // Propagate on a lambda directly
     val function = scope.enter(seedData).use {
-      scope.propagate( { tester.fooValue() })
+      scope.propagate({ tester.fooValue() })
     }
 
     // Submit to other thread after we've exited the scope

--- a/misk/src/test/kotlin/misk/scope/ActionScopedTest.kt
+++ b/misk/src/test/kotlin/misk/scope/ActionScopedTest.kt
@@ -1,12 +1,12 @@
 package misk.scope
 
-import org.assertj.core.api.Assertions.assertThat
 import com.google.inject.Guice
 import com.google.inject.Key
 import com.google.inject.name.Named
 import com.google.inject.name.Names
 import misk.inject.keyOf
 import misk.inject.uninject
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -14,7 +14,7 @@ import javax.inject.Inject
 
 class ActionScopedTest {
   @Inject @Named("foo")
-  private lateinit var foo : ActionScoped<String>
+  private lateinit var foo: ActionScoped<String>
 
   @Inject private lateinit var scope: ActionScope
 

--- a/misk/src/test/kotlin/misk/scope/TestActionScopedProviderModule.kt
+++ b/misk/src/test/kotlin/misk/scope/TestActionScopedProviderModule.kt
@@ -12,13 +12,13 @@ class TestActionScopedProviderModule : ActionScopedProviderModule() {
   }
 
   class BarProvider @Inject internal constructor(
-      @Named("from-seed") val seedData: ActionScoped<String>
+    @Named("from-seed") val seedData: ActionScoped<String>
   ) : ActionScopedProvider<String> {
     override fun get(): String = "${seedData.get()} and bar"
   }
 
   class FooProvider @Inject internal constructor(
-      @Named("bar") val bar: ActionScoped<String>
+    @Named("bar") val bar: ActionScoped<String>
   ) : ActionScopedProvider<String> {
     override fun get(): String = "${bar.get()} and foo!"
   }

--- a/misk/src/test/kotlin/misk/scope/executor/ActionScopedExecutorServiceTest.kt
+++ b/misk/src/test/kotlin/misk/scope/executor/ActionScopedExecutorServiceTest.kt
@@ -1,6 +1,5 @@
 package misk.scope.executor
 
-import org.assertj.core.api.Assertions.assertThat
 import com.google.inject.Guice
 import com.google.inject.Key
 import com.google.inject.Provides
@@ -11,6 +10,7 @@ import misk.inject.keyOf
 import misk.scope.ActionScope
 import misk.scope.ActionScoped
 import misk.scope.TestActionScopedProviderModule
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 import java.util.concurrent.Callable
@@ -41,7 +41,7 @@ internal class ActionScopedExecutorServiceTest {
         keyOf<String>(Names.named("from-seed")) to "my seed data")
 
     val future = scope.enter(seedData).use {
-      executor.submit( Callable { tester.fooValue() })
+      executor.submit(Callable { tester.fooValue() })
     }
 
     assertThat(future.get()).isEqualTo("my seed data and bar and foo!")

--- a/misk/src/test/kotlin/misk/testing/okhttp/HttpRequestUrl.kt
+++ b/misk/src/test/kotlin/misk/testing/okhttp/HttpRequestUrl.kt
@@ -3,4 +3,4 @@ package misk.testing.okhttp
 import com.google.common.base.Joiner
 import okhttp3.HttpUrl
 
-val HttpUrl.path : String get() = Joiner.on('/').join(pathSegments())
+val HttpUrl.path: String get() = Joiner.on('/').join(pathSegments())

--- a/misk/src/test/kotlin/misk/tracing/TracingConfigTest.kt
+++ b/misk/src/test/kotlin/misk/tracing/TracingConfigTest.kt
@@ -18,39 +18,40 @@ import javax.inject.Inject
 
 @MiskTest
 class TracingConfigTest {
- val defaultEnv = Environment.TESTING
- val config = MiskConfig.load<TestTracingConfig>("test_tracing_app", defaultEnv)
- @MiskTestModule
- val module = Modules.combine(
-   ConfigModule.create<TestTracingConfig>("test_tracing_app", config),
-   TracingModule(config.tracing),
-   EnvironmentModule(defaultEnv)
- )
-
- @Inject
- private lateinit var tracingTestConfig: TestTracingConfig
-
- @Inject
- private lateinit var tracer: Tracer
-
- @Test
- fun tracerProperlyInjected() {
-  assertThat(config.tracing.tracer).isEqualTo(tracingTestConfig.tracing.tracer)
-  assertThat(tracer).isInstanceOf(com.uber.jaeger.Tracer::class.java)
- }
-
- @Test
- fun failsIfTracerNotFound() {
-  val badConfig = MiskConfig.load<TestTracingConfig>(TestTracingConfig::class.java, "test_tracing_app-missing", defaultEnv)
+  val defaultEnv = Environment.TESTING
+  val config = MiskConfig.load<TestTracingConfig>("test_tracing_app", defaultEnv)
+  @MiskTestModule
   val module = Modules.combine(
-    ConfigModule.create<TestTracingConfig>("test_tracing_app-missing", badConfig),
-    TracingModule(badConfig.tracing),
-    EnvironmentModule(defaultEnv)
+      ConfigModule.create<TestTracingConfig>("test_tracing_app", config),
+      TracingModule(config.tracing),
+      EnvironmentModule(defaultEnv)
   )
-  val exception = assertThrows(CreationException::class.java, {
-   Guice.createInjector(module).getInstance<Tracer>()
-  })
 
-  assertThat(exception.localizedMessage).contains("No backend for 'missing_tracer' tracer")
- }
+  @Inject
+  private lateinit var tracingTestConfig: TestTracingConfig
+
+  @Inject
+  private lateinit var tracer: Tracer
+
+  @Test
+  fun tracerProperlyInjected() {
+    assertThat(config.tracing.tracer).isEqualTo(tracingTestConfig.tracing.tracer)
+    assertThat(tracer).isInstanceOf(com.uber.jaeger.Tracer::class.java)
+  }
+
+  @Test
+  fun failsIfTracerNotFound() {
+    val badConfig = MiskConfig.load<TestTracingConfig>(TestTracingConfig::class.java,
+        "test_tracing_app-missing", defaultEnv)
+    val module = Modules.combine(
+        ConfigModule.create<TestTracingConfig>("test_tracing_app-missing", badConfig),
+        TracingModule(badConfig.tracing),
+        EnvironmentModule(defaultEnv)
+    )
+    val exception = assertThrows(CreationException::class.java, {
+      Guice.createInjector(module).getInstance<Tracer>()
+    })
+
+    assertThat(exception.localizedMessage).contains("No backend for 'missing_tracer' tracer")
+  }
 }

--- a/misk/src/test/kotlin/misk/web/ActionScopedWebDispatchTest.kt
+++ b/misk/src/test/kotlin/misk/web/ActionScopedWebDispatchTest.kt
@@ -44,7 +44,7 @@ internal class ActionScopedWebDispatchTest {
 
   @Singleton
   class FakeIdentityActionScopedProvider @Inject internal constructor(
-      private val request: ActionScoped<Request>
+    private val request: ActionScoped<Request>
   ) : ActionScopedProvider<Principal> {
     override fun get(): Principal = Principal {
       request.get().headers["Security-Id"] ?: ""
@@ -53,7 +53,7 @@ internal class ActionScopedWebDispatchTest {
 
   @Singleton
   class Hello @Inject internal constructor(
-      private val principal: @JvmSuppressWildcards ActionScoped<Principal>
+    private val principal: @JvmSuppressWildcards ActionScoped<Principal>
   ) : WebAction {
     @Get("/hello")
     @ResponseContentType(MediaTypes.TEXT_PLAIN_UTF8)

--- a/misk/src/test/kotlin/misk/web/ContentBasedDispatchTest.kt
+++ b/misk/src/test/kotlin/misk/web/ContentBasedDispatchTest.kt
@@ -115,8 +115,10 @@ internal class ContentBasedDispatchTest {
     fun hello(@misk.web.RequestBody message: String) = "*->* $message"
   }
 
-  private fun post(contentType: MediaType, content: String,
-      acceptedMediaType: MediaType? = null): okhttp3.ResponseBody {
+  private fun post(
+    contentType: MediaType, content: String,
+    acceptedMediaType: MediaType? = null
+  ): okhttp3.ResponseBody {
     val httpClient = OkHttpClient()
     val request = Request.Builder()
         .post(RequestBody.create(contentType, content))

--- a/misk/src/test/kotlin/misk/web/actions/LivenessCheckActionTest.kt
+++ b/misk/src/test/kotlin/misk/web/actions/LivenessCheckActionTest.kt
@@ -1,12 +1,12 @@
 package misk.web.actions
 
-import org.assertj.core.api.Assertions.assertThat
 import com.google.common.util.concurrent.ServiceManager
 import com.google.inject.util.Modules
 import misk.MiskModule
 import misk.services.FakeServiceModule
 import misk.testing.MiskTest
 import misk.testing.MiskTestModule
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import javax.inject.Inject
 

--- a/misk/src/test/kotlin/misk/web/actions/NotFoundActionTest.kt
+++ b/misk/src/test/kotlin/misk/web/actions/NotFoundActionTest.kt
@@ -1,8 +1,8 @@
 package misk.web.actions
 
-import org.assertj.core.api.Assertions.assertThat
 import misk.testing.MiskTest
 import misk.web.Response
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import javax.inject.Inject
 
@@ -12,6 +12,7 @@ class NotFoundActionTest {
 
   @Test
   fun test() {
-    assertThat(notFoundAction.notFound("notfound")).isEqualTo(Response("Nothing found at /notfound", statusCode = 404))
+    assertThat(notFoundAction.notFound("notfound")).isEqualTo(
+        Response("Nothing found at /notfound", statusCode = 404))
   }
 }

--- a/misk/src/test/kotlin/misk/web/actions/ReadinessCheckActionTest.kt
+++ b/misk/src/test/kotlin/misk/web/actions/ReadinessCheckActionTest.kt
@@ -1,6 +1,5 @@
 package misk.web.actions
 
-import org.assertj.core.api.Assertions.assertThat
 import com.google.common.util.concurrent.ServiceManager
 import com.google.inject.util.Modules
 import misk.MiskModule
@@ -9,6 +8,7 @@ import misk.healthchecks.FakeHealthCheckModule
 import misk.services.FakeServiceModule
 import misk.testing.MiskTest
 import misk.testing.MiskTestModule
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import javax.inject.Inject
 

--- a/misk/src/test/kotlin/misk/web/exceptions/ExceptionMapperResolverTest.kt
+++ b/misk/src/test/kotlin/misk/web/exceptions/ExceptionMapperResolverTest.kt
@@ -10,51 +10,51 @@ import kotlin.reflect.KClass
 
 internal class ExceptionMapperResolverTest {
 
- val mappers = mutableMapOf<KClass<*>, ExceptionMapper<*>>()
- val resolver = ExceptionMapperResolver(mappers)
+  val mappers = mutableMapOf<KClass<*>, ExceptionMapper<*>>()
+  val resolver = ExceptionMapperResolver(mappers)
 
- @Test
- fun resolvesToSpecificMapper() {
-  mappers[NotFoundException::class] = NotFoundExceptionMapper()
-  mappers[ActionException::class] = ActionExceptionMapper()
+  @Test
+  fun resolvesToSpecificMapper() {
+    mappers[NotFoundException::class] = NotFoundExceptionMapper()
+    mappers[ActionException::class] = ActionExceptionMapper()
 
-  assertThat(resolver.mapperFor(NotFoundException()))
-    .isInstanceOf(NotFoundExceptionMapper::class.java)
- }
-
- @Test
- fun resolvesToSuperClassMapper() {
-  mappers[ActionException::class] = ActionExceptionMapper()
-
-  assertThat(resolver.mapperFor(NotFoundException()))
-    .isInstanceOf(ActionExceptionMapper::class.java)
- }
-
- @Test
- fun noMapperFound() {
-  assertThat(resolver.mapperFor(NotFoundException()))
-    .isNull()
- }
-
- @Test
- fun nonActionException() {
-  mappers[ArithmeticException::class] = ArithmeticExceptionMapper()
-
-  assertThat(resolver.mapperFor(ArithmeticException()))
-    .isInstanceOf(ArithmeticExceptionMapper::class.java)
- }
-
- class NotFoundExceptionMapper : BaseExceptionMapper<NotFoundException>()
- class ActionExceptionMapper : BaseExceptionMapper<ActionException>()
- class ArithmeticExceptionMapper : BaseExceptionMapper<ArithmeticException>()
-
- open class BaseExceptionMapper<in T : Throwable> : ExceptionMapper<T> {
-  override fun toResponse(th: T): Response<ResponseBody> {
-   TODO("")
+    assertThat(resolver.mapperFor(NotFoundException()))
+        .isInstanceOf(NotFoundExceptionMapper::class.java)
   }
 
-  override fun canHandle(th: Throwable): Boolean {
-   TODO("")
+  @Test
+  fun resolvesToSuperClassMapper() {
+    mappers[ActionException::class] = ActionExceptionMapper()
+
+    assertThat(resolver.mapperFor(NotFoundException()))
+        .isInstanceOf(ActionExceptionMapper::class.java)
   }
- }
+
+  @Test
+  fun noMapperFound() {
+    assertThat(resolver.mapperFor(NotFoundException()))
+        .isNull()
+  }
+
+  @Test
+  fun nonActionException() {
+    mappers[ArithmeticException::class] = ArithmeticExceptionMapper()
+
+    assertThat(resolver.mapperFor(ArithmeticException()))
+        .isInstanceOf(ArithmeticExceptionMapper::class.java)
+  }
+
+  class NotFoundExceptionMapper : BaseExceptionMapper<NotFoundException>()
+  class ActionExceptionMapper : BaseExceptionMapper<ActionException>()
+  class ArithmeticExceptionMapper : BaseExceptionMapper<ArithmeticException>()
+
+  open class BaseExceptionMapper<in T : Throwable> : ExceptionMapper<T> {
+    override fun toResponse(th: T): Response<ResponseBody> {
+      TODO("")
+    }
+
+    override fun canHandle(th: Throwable): Boolean {
+      TODO("")
+    }
+  }
 }

--- a/misk/src/test/kotlin/misk/web/extractors/FormValueParameterTest.kt
+++ b/misk/src/test/kotlin/misk/web/extractors/FormValueParameterTest.kt
@@ -110,10 +110,10 @@ internal class FormValueParameterTest {
     fun call(@FormValue basicForm: BasicForm) = "$basicForm"
 
     data class BasicForm(
-        val str: String,
-        val other: String,
-        val int: Int,
-        val testEnum: TestEnum
+      val str: String,
+      val other: String,
+      val int: Int,
+      val testEnum: TestEnum
     )
   }
 
@@ -122,8 +122,8 @@ internal class FormValueParameterTest {
     fun call(@FormValue optionalForm: OptionalForm) = "$optionalForm"
 
     data class OptionalForm(
-        val str: String?,
-        val int: Int?
+      val str: String?,
+      val int: Int?
     )
   }
 
@@ -132,9 +132,9 @@ internal class FormValueParameterTest {
     fun call(@FormValue defaultForm: DefaultForm) = "$defaultForm"
 
     data class DefaultForm(
-        val str: String = "square",
-        val int: Int = 23,
-        val testEnum: TestEnum = TestEnum.TWO
+      val str: String = "square",
+      val int: Int = 23,
+      val testEnum: TestEnum = TestEnum.TWO
     )
   }
 
@@ -143,8 +143,8 @@ internal class FormValueParameterTest {
     fun call(@FormValue listForm: ListForm) = "$listForm"
 
     data class ListForm(
-        val strs: List<String>,
-        val ints: List<Int>
+      val strs: List<String>,
+      val ints: List<Int>
     )
   }
 
@@ -168,8 +168,8 @@ internal class FormValueParameterTest {
   }
 
   private fun post(
-      path: String,
-      body: List<Pair<String, String>>
+    path: String,
+    body: List<Pair<String, String>>
   ): String {
     val url = jettyService.httpServerUrl.newBuilder()
         .encodedPath(path)

--- a/misk/src/test/kotlin/misk/web/extractors/PathParamDispatchTest.kt
+++ b/misk/src/test/kotlin/misk/web/extractors/PathParamDispatchTest.kt
@@ -63,9 +63,9 @@ internal class PathParamDispatchTest {
     @Get("/objects/{objectType}/{name}/{version}")
     @ResponseContentType(MediaTypes.TEXT_PLAIN_UTF8)
     fun getObjectDetails(
-        @PathParam objectType: ObjectType,
-        @PathParam name: String,
-        @PathParam version: Long
+      @PathParam objectType: ObjectType,
+      @PathParam name: String,
+      @PathParam version: Long
     ): String = "(type=$objectType,name=$name,version=$version)"
   }
 
@@ -75,7 +75,7 @@ internal class PathParamDispatchTest {
     fun router(@PathParam("router") routeName: String) = "routing to $routeName"
   }
 
-  fun get(path: String) : okhttp3.Response {
+  fun get(path: String): okhttp3.Response {
     val httpClient = OkHttpClient()
     val request = Request.Builder()
         .get()

--- a/misk/src/test/kotlin/misk/web/extractors/QueryStringParameterProcessorTest.kt
+++ b/misk/src/test/kotlin/misk/web/extractors/QueryStringParameterProcessorTest.kt
@@ -15,7 +15,8 @@ internal class QueryStringParameterProcessorTest {
 
   @Test
   fun optionalStringPresent() {
-    val queryStringProcessor = QueryStringParameterProcessor(TestMemberStore.optionalStringParameter())
+    val queryStringProcessor =
+        QueryStringParameterProcessor(TestMemberStore.optionalStringParameter())
     val extractedResult = queryStringProcessor.extractFunctionArgumentValue(listOf("foo"))
     assertThat(extractedResult).isNotNull()
     assertThat(extractedResult).isEqualTo("foo")
@@ -23,7 +24,8 @@ internal class QueryStringParameterProcessorTest {
 
   @Test
   fun optionalStringNotPresent() {
-    val queryStringProcessor = QueryStringParameterProcessor(TestMemberStore.optionalStringParameter())
+    val queryStringProcessor =
+        QueryStringParameterProcessor(TestMemberStore.optionalStringParameter())
     val extractedResult = queryStringProcessor.extractFunctionArgumentValue(listOf())
     assertThat(extractedResult).isNull()
   }
@@ -70,7 +72,7 @@ internal class QueryStringParameterProcessorTest {
     try {
       queryStringProcessor.extractFunctionArgumentValue(listOf("forty two"))
       assert(false)
-    } catch(e: IllegalArgumentException) {
+    } catch (e: IllegalArgumentException) {
       // expected
     }
   }
@@ -135,7 +137,7 @@ internal class QueryStringParameterProcessorTest {
   @Test
   fun optionalEnumPresent() {
     val queryStringProcessor = QueryStringParameterProcessor(
-      TestMemberStore.optionalEnumParameter())
+        TestMemberStore.optionalEnumParameter())
     val extractedResult = queryStringProcessor.extractFunctionArgumentValue(listOf("ONE"))
     assertThat(extractedResult).isNotNull()
     assertThat(extractedResult).isEqualTo(TestEnum.ONE)
@@ -144,7 +146,7 @@ internal class QueryStringParameterProcessorTest {
   @Test
   fun optionalEnumNotPresent() {
     val queryStringProcessor = QueryStringParameterProcessor(
-      TestMemberStore.optionalEnumParameter())
+        TestMemberStore.optionalEnumParameter())
     val extractedResult = queryStringProcessor.extractFunctionArgumentValue(listOf())
     assertThat(extractedResult).isNull()
   }
@@ -152,7 +154,7 @@ internal class QueryStringParameterProcessorTest {
   @Test
   fun defaultEnumPresent() {
     val queryStringProcessor = QueryStringParameterProcessor(
-      TestMemberStore.defaultEnumParameter())
+        TestMemberStore.defaultEnumParameter())
     val extractedResult = queryStringProcessor.extractFunctionArgumentValue(listOf())
     assertThat(extractedResult).isNull()
   }
@@ -162,7 +164,7 @@ internal class QueryStringParameterProcessorTest {
     try {
       QueryStringParameterProcessor(TestMemberStore.unsupportedParameter())
       assert(false)
-    } catch(e: IllegalArgumentException) {
+    } catch (e: IllegalArgumentException) {
       // should be thrown
     }
   }
@@ -193,8 +195,7 @@ internal class QueryStringParameterProcessorTest {
       fun stringParameter(): KParameter = TestMemberStore::strTest.parameters.get(1)
       fun optionalStringParameter(): KParameter = TestMemberStore::strTest.parameters.get(2)
       fun stringListParameter(): KParameter = TestMemberStore::strTest.parameters.get(3)
-      fun optionalStringListParameter(): KParameter
-          = TestMemberStore::strTest.parameters.get(4)
+      fun optionalStringListParameter(): KParameter = TestMemberStore::strTest.parameters.get(4)
       fun intParameter(): KParameter = TestMemberStore::intTest.parameters.get(1)
       fun optionalIntParameter(): KParameter = TestMemberStore::intTest.parameters.get(2)
       fun intListParameter(): KParameter = TestMemberStore::intTest.parameters.get(3)

--- a/misk/src/test/kotlin/misk/web/extractors/QueryStringRequestTest.kt
+++ b/misk/src/test/kotlin/misk/web/extractors/QueryStringRequestTest.kt
@@ -6,7 +6,11 @@ import misk.inject.KAbstractModule
 import misk.testing.MiskTest
 import misk.testing.MiskTestModule
 import misk.testing.TestWebModule
-import misk.web.*
+import misk.web.Get
+import misk.web.QueryParam
+import misk.web.ResponseContentType
+import misk.web.WebActionModule
+import misk.web.WebModule
 import misk.web.actions.WebAction
 import misk.web.jetty.JettyService
 import misk.web.mediatype.MediaTypes
@@ -63,10 +67,10 @@ internal class QueryStringRequestTest {
   class BasicParamsAction : WebAction {
     @Get("/basic-params")
     fun call(
-        @QueryParam str: String,
-        @QueryParam("something") other: String,
-        @QueryParam int: Int,
-        @QueryParam testEnum: TestEnum
+      @QueryParam str: String,
+      @QueryParam("something") other: String,
+      @QueryParam int: Int,
+      @QueryParam testEnum: TestEnum
     ) = "$str $other $int $testEnum basic-params"
   }
 
@@ -80,15 +84,16 @@ internal class QueryStringRequestTest {
     fun call(
       @QueryParam str: String = "square",
       @QueryParam int: Int = 23,
-      @QueryParam testEnum: TestEnum = TestEnum.TWO) = "$str $int $testEnum default-params"
+      @QueryParam testEnum: TestEnum = TestEnum.TWO
+    ) = "$str $int $testEnum default-params"
   }
 
   class ListParamsAction : WebAction {
     @Get("/list-params")
     @ResponseContentType(MediaTypes.APPLICATION_JSON)
-    fun call(@QueryParam strs: List<String>, @QueryParam ints: List<Int>)
-        = "${strs.joinToString(separator = " ")} " +
-            "${ints.joinToString(separator = " ")} list-params"
+    fun call(@QueryParam strs: List<String>, @QueryParam ints: List<Int>) = "${strs.joinToString(
+        separator = " ")} " +
+        "${ints.joinToString(separator = " ")} list-params"
   }
 
   class TestModule : KAbstractModule() {

--- a/misk/src/test/kotlin/misk/web/interceptors/MetricsInterceptorTest.kt
+++ b/misk/src/test/kotlin/misk/web/interceptors/MetricsInterceptorTest.kt
@@ -1,6 +1,5 @@
 package misk.web.interceptors
 
-import org.assertj.core.api.Assertions.assertThat
 import misk.asAction
 import misk.metrics.Metrics
 import misk.metrics.MetricsModule
@@ -10,6 +9,7 @@ import misk.web.Get
 import misk.web.Response
 import misk.web.actions.WebAction
 import misk.web.actions.asChain
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import javax.inject.Inject

--- a/misk/src/test/kotlin/misk/web/marshal/PlainTextRequestTest.kt
+++ b/misk/src/test/kotlin/misk/web/marshal/PlainTextRequestTest.kt
@@ -54,7 +54,7 @@ internal class PlainTextRequestTest {
     @Post("/as-byte-string")
     @RequestContentType(MediaTypes.TEXT_PLAIN_UTF8)
     @ResponseContentType(MediaTypes.TEXT_PLAIN_UTF8)
-    fun call(@RequestBody messageBytes: ByteString): String  = "${messageBytes.utf8()} as-byte-string"
+    fun call(@RequestBody messageBytes: ByteString): String = "${messageBytes.utf8()} as-byte-string"
   }
 
   class TestModule : KAbstractModule() {

--- a/misk/src/test/kotlin/misk/web/mediatype/MediaRangeTest.kt
+++ b/misk/src/test/kotlin/misk/web/mediatype/MediaRangeTest.kt
@@ -1,8 +1,8 @@
 package misk.web.mediatype
 
-import org.assertj.core.api.containsExactly
 import okhttp3.MediaType
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.containsExactly
 import org.assertj.core.data.Offset
 import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Test

--- a/misk/src/test/kotlin/misk/web/ssl/SslClientServerTest.kt
+++ b/misk/src/test/kotlin/misk/web/ssl/SslClientServerTest.kt
@@ -6,10 +6,10 @@ import com.google.inject.name.Names
 import com.google.inject.util.Modules
 import helpers.protos.Dinosaur
 import misk.MiskModule
-import misk.client.HttpClientsConfig
 import misk.client.HttpClientEndpointConfig
 import misk.client.HttpClientModule
 import misk.client.HttpClientSSLConfig
+import misk.client.HttpClientsConfig
 import misk.client.ProtoMessageHttpClient
 import misk.inject.KAbstractModule
 import misk.inject.getInstance

--- a/misk/src/test/kotlin/org/assertj/core/api/AssertExtensions.kt
+++ b/misk/src/test/kotlin/org/assertj/core/api/AssertExtensions.kt
@@ -3,13 +3,13 @@ package org.assertj.core.api
 import org.assertj.core.data.MapEntry
 
 fun <KEY, VALUE> MapAssert<KEY, VALUE>.containsExactly(
-    vararg p: Pair<KEY, VALUE>
+  vararg p: Pair<KEY, VALUE>
 ): MapAssert<KEY, VALUE> {
   return containsExactly(*p.map { MapEntry.entry(it.first, it.second) }.toTypedArray())
 }
 
 fun <ACTUAL : CharSequence> AbstractCharSequenceAssert<*, ACTUAL>.isEqualToAsJson(
-    expected: CharSequence
+  expected: CharSequence
 ): AbstractCharSequenceAssert<*, ACTUAL> {
   // Normalize whitespace outside of field names and string values
   val regex = Regex("[^\\s\"']+|\"[^\"]*\"|'[^']*'")

--- a/misk/src/test/kotlin/org/assertj/core/api/AssertExtensionsTest.kt
+++ b/misk/src/test/kotlin/org/assertj/core/api/AssertExtensionsTest.kt
@@ -36,7 +36,8 @@ internal class AssertExtensionsTest {
   "my_value"     : "another value"
 }
 """)
-    }).hasMessage("""expected:<"{ "my_structure[]" : [ "this" , 45, "...> but was:<"{ "my_structure[2]" : [ "this" , 45, "...>""")
+    }).hasMessage(
+        """expected:<"{ "my_structure[]" : [ "this" , 45, "...> but was:<"{ "my_structure[2]" : [ "this" , 45, "...>""")
   }
 
   @Test
@@ -53,7 +54,8 @@ internal class AssertExtensionsTest {
   "my_value"     : "another value"
 }
 """)
-    }).hasMessage("""expected:<...structure" : [ "this[]" , 45, "zip" ], "my...> but was:<...structure" : [ "this[isit]" , 45, "zip" ], "my...>""")
+    }).hasMessage(
+        """expected:<...structure" : [ "this[]" , 45, "zip" ], "my...> but was:<...structure" : [ "this[isit]" , 45, "zip" ], "my...>""")
   }
 
   @Test
@@ -70,6 +72,7 @@ internal class AssertExtensionsTest {
   "my_value"     : "another value"
 }
 """)
-    }).hasMessage("""expected:<..._structure" : [ "thi[  ]s" , 45, "zip" ], "m...> but was:<..._structure" : [ "thi[]s" , 45, "zip" ], "m...>""")
+    }).hasMessage(
+        """expected:<..._structure" : [ "thi[  ]s" , 45, "zip" ], "m...> but was:<..._structure" : [ "thi[]s" , 45, "zip" ], "m...>""")
   }
 }

--- a/misk/testing/src/main/kotlin/misk/cloud/fake/environment/FakeInstanceMetadataModule.kt
+++ b/misk/testing/src/main/kotlin/misk/cloud/fake/environment/FakeInstanceMetadataModule.kt
@@ -1,7 +1,7 @@
 package misk.cloud.fake.environment
 
-import misk.inject.KAbstractModule
 import misk.environment.InstanceMetadata
+import misk.inject.KAbstractModule
 
 /** Provides a hard-coded set of instance metadata */
 class FakeInstanceMetadataModule(val metadata: InstanceMetadata) : KAbstractModule() {

--- a/misk/testing/src/main/kotlin/misk/cloud/gcp/datastore/FakeDatastoreModule.kt
+++ b/misk/testing/src/main/kotlin/misk/cloud/gcp/datastore/FakeDatastoreModule.kt
@@ -28,7 +28,7 @@ class FakeDatastoreModule : KAbstractModule() {
 
   @Singleton
   class FakeDatastoreService @Inject constructor(
-      private val datastoreHelper: LocalDatastoreHelper
+    private val datastoreHelper: LocalDatastoreHelper
   ) : AbstractIdleService() {
 
     override fun startUp() {

--- a/misk/testing/src/main/kotlin/misk/cloud/gcp/storage/CustomStorageRpcTestCases.kt
+++ b/misk/testing/src/main/kotlin/misk/cloud/gcp/storage/CustomStorageRpcTestCases.kt
@@ -151,11 +151,11 @@ internal abstract class CustomStorageRpcTestCases<T : StorageRpc> {
 
     val upload = "This is my text".repeat(1024 * 256)
     blob.writer().use {
-          // Use the minimum chunk size, which is smaller than the buffer size, to
-          // ensure that we are sending multiple chunks
-          it.setChunkSize(256 * 1024)
-          it.write(ByteBuffer.wrap(upload.toByteArray()))
-        }
+      // Use the minimum chunk size, which is smaller than the buffer size, to
+      // ensure that we are sending multiple chunks
+      it.setChunkSize(256 * 1024)
+      it.write(ByteBuffer.wrap(upload.toByteArray()))
+    }
 
     val download = blob.getContent()
     assertThat(String(download)).isEqualTo(upload)
@@ -282,10 +282,10 @@ internal abstract class CustomStorageRpcTestCases<T : StorageRpc> {
 
     // Read in smaller chunks
     blob.reader().use {
-          // Use the minimum chunk size, which is smaller than the buffer size, to
-          // ensure that we are retrieving multiple chunks
-          it.forEachChunk(256 * 1024) { buffer, _ -> download.put(buffer) }
-        }
+      // Use the minimum chunk size, which is smaller than the buffer size, to
+      // ensure that we are retrieving multiple chunks
+      it.forEachChunk(256 * 1024) { buffer, _ -> download.put(buffer) }
+    }
 
     download.position(0)
     assertThat(String(download.array())).isEqualTo(upload)

--- a/misk/testing/src/main/kotlin/misk/cloud/gcp/storage/InMemoryStorageRpc.kt
+++ b/misk/testing/src/main/kotlin/misk/cloud/gcp/storage/InMemoryStorageRpc.kt
@@ -23,9 +23,9 @@ class InMemoryStorageRpc : BaseCustomStorageRpc() {
   private val lock = ReentrantReadWriteLock()
 
   override fun create(
-      obj: StorageObject,
-      content: InputStream,
-      options: Map<StorageRpc.Option, *>
+    obj: StorageObject,
+    content: InputStream,
+    options: Map<StorageRpc.Option, *>
   ): StorageObject? = lock.write {
     val existing = options.check(metadata[obj.path])
     val newGeneration = (existing?.generation ?: 0) + 1
@@ -48,8 +48,8 @@ class InMemoryStorageRpc : BaseCustomStorageRpc() {
   }
 
   override fun list(
-      bucket: String,
-      options: Map<StorageRpc.Option, *>
+    bucket: String,
+    options: Map<StorageRpc.Option, *>
   ): Tuple<String, Iterable<StorageObject>> = lock.read {
     val prefix = options[StorageRpc.Option.PREFIX]?.toString()?.trimStart('/') ?: ""
 
@@ -101,10 +101,10 @@ class InMemoryStorageRpc : BaseCustomStorageRpc() {
       }
 
   override fun read(
-      from: StorageObject,
-      options: Map<StorageRpc.Option, *>,
-      zposition: Long,
-      zbytes: Int
+    from: StorageObject,
+    options: Map<StorageRpc.Option, *>,
+    zposition: Long,
+    zbytes: Int
   ): Tuple<String, ByteArray> = lock.read {
     options.check(metadata[from.path])
     val bytes = content[from.path]
@@ -128,12 +128,12 @@ class InMemoryStorageRpc : BaseCustomStorageRpc() {
   }
 
   override fun write(
-      uploadId: String,
-      toWrite: ByteArray,
-      toWriteOffset: Int,
-      destOffset: Long,
-      length: Int,
-      last: Boolean
+    uploadId: String,
+    toWrite: ByteArray,
+    toWriteOffset: Int,
+    destOffset: Long,
+    length: Int,
+    last: Boolean
   ) {
     lock.write {
       val destBytes = pendingContent[uploadId]?.let { currentBytes ->

--- a/misk/testing/src/main/kotlin/misk/testing/AfterEachExtensionModule.kt
+++ b/misk/testing/src/main/kotlin/misk/testing/AfterEachExtensionModule.kt
@@ -4,20 +4,19 @@ import com.google.inject.Module
 import misk.inject.KAbstractModule
 import misk.inject.addMultibinderBinding
 import org.junit.jupiter.api.extension.AfterEachCallback
-import org.junit.jupiter.api.extension.BeforeEachCallback
 import kotlin.reflect.KClass
 
 /** Module registering a callback that fires after each test */
 class AfterEachExtensionModule<T : AfterEachCallback> constructor(
-    private val kclass: KClass<T>
+  private val kclass: KClass<T>
 ) : KAbstractModule() {
 
   override fun configure() {
     binder().addMultibinderBinding<AfterEachCallback>().to(kclass.java)
   }
 
-  companion object{
-    inline fun <reified T: AfterEachCallback> create() : Module =
+  companion object {
+    inline fun <reified T : AfterEachCallback> create(): Module =
         AfterEachExtensionModule(T::class)
   }
 }

--- a/misk/testing/src/main/kotlin/misk/testing/BeforeEachExtensionModule.kt
+++ b/misk/testing/src/main/kotlin/misk/testing/BeforeEachExtensionModule.kt
@@ -8,15 +8,15 @@ import kotlin.reflect.KClass
 
 /** Module registering a callback that fires before each test */
 class BeforeEachExtensionModule<T : BeforeEachCallback> constructor(
-    private val kclass: KClass<T>
+  private val kclass: KClass<T>
 ) : KAbstractModule() {
 
   override fun configure() {
     binder().addMultibinderBinding<BeforeEachCallback>().to(kclass.java)
   }
 
-  companion object{
-    inline fun <reified T: BeforeEachCallback> create() : Module =
+  companion object {
+    inline fun <reified T : BeforeEachCallback> create(): Module =
         BeforeEachExtensionModule(T::class)
   }
 }

--- a/misk/testing/src/main/kotlin/misk/testing/MiskTestExtension.kt
+++ b/misk/testing/src/main/kotlin/misk/testing/MiskTestExtension.kt
@@ -7,8 +7,6 @@ import com.google.inject.Module
 import com.google.inject.util.Modules
 import misk.inject.getInstance
 import misk.inject.uninject
-import misk.testing.store
-import misk.testing.retrieve
 import org.junit.jupiter.api.extension.AfterEachCallback
 import org.junit.jupiter.api.extension.BeforeEachCallback
 import org.junit.jupiter.api.extension.ExtensionContext
@@ -70,7 +68,7 @@ internal class MiskTestExtension : BeforeEachCallback, AfterEachCallback {
 
     @Inject
     @JvmSuppressWildcards
-    lateinit var afterEachCallbacks : Set<AfterEachCallback>
+    lateinit var afterEachCallbacks: Set<AfterEachCallback>
 
     override fun afterEach(context: ExtensionContext) {
       afterEachCallbacks.forEach { it.afterEach(context) }

--- a/misk/testing/src/main/kotlin/misk/testing/TemporaryFolder.kt
+++ b/misk/testing/src/main/kotlin/misk/testing/TemporaryFolder.kt
@@ -3,17 +3,11 @@ package misk.testing
 import com.google.inject.Provides
 import misk.inject.KAbstractModule
 import org.junit.jupiter.api.extension.AfterEachCallback
-import org.junit.jupiter.api.extension.BeforeEachCallback
-import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.api.extension.ExtensionContext
 import java.nio.file.Files
 import java.nio.file.Path
 import javax.inject.Inject
 import javax.inject.Singleton
-import kotlin.reflect.KMutableProperty
-import kotlin.reflect.full.createType
-import kotlin.reflect.full.isSubtypeOf
-import kotlin.reflect.full.memberProperties
 
 /** A temporary folder for use by a given test */
 class TemporaryFolder(val root: Path) {
@@ -42,7 +36,7 @@ class TemporaryFolderModule : KAbstractModule() {
 
   @Provides
   @Singleton
-  fun provideTemporaryFolder() : TemporaryFolder {
+  fun provideTemporaryFolder(): TemporaryFolder {
     val tempDir = Files.createTempDirectory("test-")
     tempDir.toFile().deleteOnExit()
 


### PR DESCRIPTION
This uses IntelliJ's formatter and Square's kotlin style rules.

The biggest difference with what is currently checked in is that
method parameters and constructor parameters are indented +2 instead
of their current +4.