### PR TITLE
Simplify installing tracers

### DIFF
--- a/misk/src/main/kotlin/misk/tracing/TracingConfig.kt
+++ b/misk/src/main/kotlin/misk/tracing/TracingConfig.kt
@@ -3,4 +3,4 @@ package misk.tracing
 import misk.config.Config
 import misk.tracing.backends.TracingBackendConfig
 
-data class TracingConfig(val tracer: String, val backends: TracingBackendConfig) : Config
+data class TracingConfig(val backends: TracingBackendConfig) : Config

--- a/misk/src/main/kotlin/misk/tracing/TracingModule.kt
+++ b/misk/src/main/kotlin/misk/tracing/TracingModule.kt
@@ -5,12 +5,12 @@ import misk.tracing.backends.jaeger.JaegerBackendModule
 
 class TracingModule(val config: TracingConfig) : KAbstractModule() {
   override fun configure() {
-    if (config.tracer.equals("jaeger", true)) {
+    if (config.backends.jaeger != null) {
       install(JaegerBackendModule(config.backends.jaeger))
       return
     }
 
-    throw IllegalArgumentException("No backend for '${config.tracer}' tracer. Ensure that " +
-        "tracer name is spelled correctly and that a backend module exists for that tracer.")
+    throw IllegalStateException("No backends configured for tracing. Please update your yaml "
+      + "configuration.")
   }
 }

--- a/misk/src/main/kotlin/misk/tracing/backends/jaeger/JaegarSamplerConfig.kt
+++ b/misk/src/main/kotlin/misk/tracing/backends/jaeger/JaegarSamplerConfig.kt
@@ -2,6 +2,10 @@ package misk.tracing.backends.jaeger
 
 import misk.config.Config
 
+/**
+ * Configuration for Jaeger's sampler. If values are left null then Jaeger will provide defaults.
+ * See [com.uber.jaeger.Configuration.SamplerConfiguration] for default values.
+ */
 data class JaegerSamplerConfig(
   val type: String?,
   val param: Number?,

--- a/misk/src/main/kotlin/misk/tracing/backends/jaeger/JaegerReporterConfig.kt
+++ b/misk/src/main/kotlin/misk/tracing/backends/jaeger/JaegerReporterConfig.kt
@@ -2,6 +2,10 @@ package misk.tracing.backends.jaeger
 
 import misk.config.Config
 
+/**
+ * Configuration for Jaeger's reporter. If values are left null then Jaeger will provide defaults.
+ * See [com.uber.jaeger.Configuration.ReporterConfiguration] for default values.
+ */
 data class JaegerReporterConfig(
   val log_spans: Boolean?,
   val agent_host: String?,

--- a/misk/src/test/kotlin/misk/tracing/TracingConfigTest.kt
+++ b/misk/src/test/kotlin/misk/tracing/TracingConfigTest.kt
@@ -28,19 +28,15 @@ class TracingConfigTest {
   )
 
   @Inject
-  private lateinit var tracingTestConfig: TestTracingConfig
-
-  @Inject
   private lateinit var tracer: Tracer
 
   @Test
   fun tracerProperlyInjected() {
-    assertThat(config.tracing.tracer).isEqualTo(tracingTestConfig.tracing.tracer)
     assertThat(tracer).isInstanceOf(com.uber.jaeger.Tracer::class.java)
   }
 
   @Test
-  fun failsIfTracerNotFound() {
+  fun failsIfInstalledWithNoBackendConfigured() {
     val badConfig = MiskConfig.load<TestTracingConfig>(TestTracingConfig::class.java,
         "test_tracing_app-missing", defaultEnv)
     val module = Modules.combine(
@@ -52,6 +48,6 @@ class TracingConfigTest {
       Guice.createInjector(module).getInstance<Tracer>()
     })
 
-    assertThat(exception.localizedMessage).contains("No backend for 'missing_tracer' tracer")
+    assertThat(exception.localizedMessage).contains("No backends configured for tracing.")
   }
 }

--- a/misk/src/test/resources/test_tracing_app-common.yaml
+++ b/misk/src/test/resources/test_tracing_app-common.yaml
@@ -1,5 +1,4 @@
 tracing:
-  tracer: jaeger
   backends:
     jaeger:
       reporter:

--- a/misk/src/test/resources/test_tracing_app-missing-common.yaml
+++ b/misk/src/test/resources/test_tracing_app-missing-common.yaml
@@ -1,3 +1,2 @@
 tracing:
-  tracer: missing_tracer
   backends: {}


### PR DESCRIPTION
Removes a superfluous tracer field and adds documentation to Jaeger configuration classes.