### PR TITLE
Fix NotFoundAction handling

### DIFF
--- a/misk/src/main/kotlin/misk/web/actions/NotFoundAction.kt
+++ b/misk/src/main/kotlin/misk/web/actions/NotFoundAction.kt
@@ -2,18 +2,24 @@ package misk.web.actions
 
 import misk.web.Get
 import misk.web.PathParam
+import misk.web.Post
+import misk.web.RequestContentType
 import misk.web.Response
 import misk.web.ResponseContentType
 import misk.web.mediatype.MediaTypes
+import okhttp3.Headers
 import javax.inject.Singleton
 
 @Singleton
 class NotFoundAction : WebAction {
   @Get("/{path:.*}")
-  @ResponseContentType(MediaTypes.TEXT_PLAIN_UTF8)
+  @Post("/{path:.*}")
+  @RequestContentType(MediaTypes.ALL)
+  @ResponseContentType(MediaTypes.ALL)
   fun notFound(@PathParam path: String): Response<String> {
     return Response(
         body = "Nothing found at /$path",
+        headers = Headers.of("Content-Type", MediaTypes.TEXT_PLAIN_UTF8),
         statusCode = 404
     )
   }

--- a/misk/src/main/kotlin/misk/web/jetty/WebActionsServlet.kt
+++ b/misk/src/main/kotlin/misk/web/jetty/WebActionsServlet.kt
@@ -1,11 +1,13 @@
 package misk.web.jetty
 
+import misk.exceptions.StatusCode
 import misk.inject.keyOf
 import misk.scope.ActionScope
 import misk.web.BoundAction
 import misk.web.Request
 import misk.web.actions.WebAction
 import misk.web.mediatype.MediaRange
+import misk.web.mediatype.MediaTypes
 import okhttp3.Headers
 import okhttp3.HttpUrl
 import okhttp3.MediaType
@@ -47,9 +49,17 @@ internal class WebActionsServlet @Inject constructor(
                 request.accepts(),
                 asRequest.url
             )
+          }.sorted()
+
+          val bestAction = candidateActions.firstOrNull()
+          if (bestAction != null) {
+            bestAction.handle(asRequest, response)
+          } else {
+            response.status = StatusCode.NOT_FOUND.code
+            response.addHeader("Content-Type", MediaTypes.TEXT_PLAIN_UTF8)
+            response.writer.print("Nothing found at /${asRequest.url.encodedPath()}")
+            response.writer.close()
           }
-          val bestAction = candidateActions.sorted().firstOrNull()
-          bestAction?.handle(asRequest, response)
         }
   }
 

--- a/misk/src/test/kotlin/misk/web/actions/NotFoundActionTest.kt
+++ b/misk/src/test/kotlin/misk/web/actions/NotFoundActionTest.kt
@@ -1,18 +1,125 @@
 package misk.web.actions
 
+import com.google.inject.util.Modules
+import com.squareup.moshi.Moshi
+import misk.MiskModule
 import misk.testing.MiskTest
-import misk.web.Response
+import misk.testing.MiskTestModule
+import misk.testing.TestWebModule
+import misk.web.WebActionModule
+import misk.web.WebModule
+import misk.web.jetty.JettyService
+import misk.web.mediatype.MediaTypes
+import misk.web.mediatype.asMediaType
+import okhttp3.MediaType
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import javax.inject.Inject
 
-@MiskTest
+@MiskTest(startService = true)
 class NotFoundActionTest {
-  @Inject lateinit var notFoundAction: NotFoundAction
+  @MiskTestModule
+  val module = Modules.combine(
+      MiskModule(),
+      WebModule(),
+      TestWebModule(),
+      WebActionModule.create<NotFoundAction>())
+
+  val httpClient = OkHttpClient()
+
+  data class Packet(val message: String)
+
+  private val jsonMediaType = MediaTypes.APPLICATION_JSON.asMediaType()
+  private val plainTextMediaType = MediaTypes.TEXT_PLAIN_UTF8.asMediaType()
+  private val weirdMediaType = "application/weird".asMediaType()
+
+  private @Inject
+  lateinit var moshi: Moshi
+
+  private @Inject
+  lateinit var jettyService: JettyService
+
+  private val packetJsonAdapter get() = moshi.adapter(Packet::class.java)
 
   @Test
-  fun test() {
-    assertThat(notFoundAction.notFound("notfound")).isEqualTo(
-        Response("Nothing found at /notfound", statusCode = 404))
+  fun postJsonExpectJsonPathNotFound() {
+    val requestContent = packetJsonAdapter.toJson(Packet("my friend"))
+    val request = post("/unknown", jsonMediaType, requestContent, jsonMediaType)
+    val response = httpClient.newCall(request).execute()
+    assertThat(response.code()).isEqualTo(404)
+  }
+
+  @Test
+  fun postTextExpectTextPathNotFound() {
+    val request = post("/unknown", plainTextMediaType, "my friend", plainTextMediaType)
+    val response = httpClient.newCall(request).execute()
+    assertThat(response.code()).isEqualTo(404)
+  }
+
+  @Test
+  fun postArbitraryExpectArbitraryPathNotFound() {
+    val request = post("/unknown", weirdMediaType, "my friend", weirdMediaType)
+    val response = httpClient.newCall(request).execute()
+    assertThat(response.code()).isEqualTo(404)
+  }
+
+  @Test
+  fun getJsonPathNotFound() {
+    val request = get("/unknown", jsonMediaType)
+    val response = httpClient.newCall(request).execute()
+    assertThat(response.code()).isEqualTo(404)
+  }
+
+  @Test
+  fun getTextPathNotFound() {
+    val request = get("/unknown", plainTextMediaType)
+    val response = httpClient.newCall(request).execute()
+    assertThat(response.code()).isEqualTo(404)
+  }
+
+  @Test
+  fun getArbitraryPathNotFound() {
+    val request = get("/unknown", weirdMediaType)
+    val response = httpClient.newCall(request).execute()
+    assertThat(response.code()).isEqualTo(404)
+  }
+
+  @Test
+  fun headPathNotFound() {
+    val request = head("/unknown", weirdMediaType)
+    val response = httpClient.newCall(request).execute()
+    assertThat(response.code()).isEqualTo(404)
+  }
+
+  private fun head(path: String, acceptedMediaType: MediaType? = null): Request {
+    return Request.Builder()
+        .head()
+        .url(jettyService.httpServerUrl.newBuilder().encodedPath(path).build())
+        .header("Accept", acceptedMediaType.toString())
+        .build()
+  }
+
+  private fun get(path: String, acceptedMediaType: MediaType? = null): Request {
+    return Request.Builder()
+        .get()
+        .url(jettyService.httpServerUrl.newBuilder().encodedPath(path).build())
+        .header("Accept", acceptedMediaType.toString())
+        .build()
+  }
+
+  private fun post(
+    path: String,
+    contentType: MediaType,
+    content: String,
+    acceptedMediaType: MediaType? = null
+  ): Request {
+    return Request.Builder()
+        .post(RequestBody.create(contentType, content))
+        .url(jettyService.httpServerUrl.newBuilder().encodedPath(path).build())
+        .header("Accept", acceptedMediaType.toString())
+        .build()
   }
 }


### PR DESCRIPTION
Previously POSTing to an unknown path would result in a 200 with an
empty response body, instead of the expected 404. Multiple problems:

1. The NotFoundAction was only bound for GET requests
2. The NotFoundAction only supported requests with Accept: text/plain

The NotFoundAction is now bound for both GET and POSTs, and supports
requests for any type of content (but always returns text/plain). Also
added a backstop in the WebActionsServlet to return a 404 if no suitable
action could be found; this handles cases where applications do not
install the NotFoundAction, or when a request arrives with an
unsupported HTTP method.