### PR TITLE
Auto-embed trace information into TypedHttpClient request headers

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,7 @@ ext {
           jCommander           : 'com.beust:jcommander:1.72',
           openTracing          : 'io.opentracing:opentracing-api:0.31.0',
           openTracingMock      : 'io.opentracing:opentracing-mock:0.31.0',
+          openTracingOkHttp    : 'io.opentracing.contrib:opentracing-okhttp3:0.1.0',
           tracingJaeger        : 'com.uber.jaeger:jaeger-core:0.24.0',
           retrofit             : 'com.squareup.retrofit2:retrofit:2.3.0',
           retrofitMoshi        : 'com.squareup.retrofit2:converter-moshi:2.3.0',

--- a/misk/build.gradle
+++ b/misk/build.gradle
@@ -45,6 +45,7 @@ dependencies {
   compile dep.gcpCloudStorage
   compile dep.jCommander
   compile dep.openTracing
+  compile dep.openTracingOkHttp
   compile dep.tracingJaeger
   compile dep.retrofit
   compile dep.retrofitMoshi

--- a/misk/src/main/kotlin/misk/client/TypedHttpClientModule.kt
+++ b/misk/src/main/kotlin/misk/client/TypedHttpClientModule.kt
@@ -1,15 +1,16 @@
 package misk.client
 
+import com.google.inject.Inject
 import com.google.inject.Key
 import com.google.inject.Provider
 import com.squareup.moshi.Moshi
+import io.opentracing.Tracer
 import misk.inject.KAbstractModule
 import misk.inject.newMultibinder
 import okhttp3.OkHttpClient
 import retrofit2.Retrofit
 import retrofit2.converter.moshi.MoshiConverterFactory
 import java.lang.reflect.Proxy
-import javax.inject.Inject
 import kotlin.reflect.KClass
 
 /** Creates a retrofit-backed typed client given an API interface and an HTTP configuration */
@@ -61,6 +62,9 @@ class TypedHttpClientModule<T : Any>(
     @Inject
     private lateinit var moshi: Moshi
 
+    @Inject(optional=true)
+    private val tracer: Tracer? = null
+
     override fun get(): T {
       val okhttp = httpClientProvider.get()
 
@@ -75,7 +79,8 @@ class TypedHttpClientModule<T : Any>(
           retrofit,
           okhttp,
           clientNetworkInterceptorFactories,
-          clientApplicationInterceptorFactories)
+          clientApplicationInterceptorFactories,
+          tracer)
 
       @Suppress("UNCHECKED_CAST")
       return Proxy.newProxyInstance(

--- a/misk/src/main/kotlin/misk/tracing/interceptors/TextMultimapExtractAdapter.kt
+++ b/misk/src/main/kotlin/misk/tracing/interceptors/TextMultimapExtractAdapter.kt
@@ -1,0 +1,31 @@
+package misk.tracing.interceptors
+
+import io.opentracing.propagation.TextMap
+
+/**
+ * Provides an interface for Tracer.extract() to read from a multimap datasource
+ * (i.e. HTTP headers provided via OkHttp)
+ */
+internal class TextMultimapExtractAdapter(
+  private val multimap: Map<String, List<String>>
+) : TextMap {
+  override fun put(key: String, value: String) {
+    throw UnsupportedOperationException("Cannot put into readonly data source")
+  }
+
+  override fun iterator(): MutableIterator<MutableMap.MutableEntry<String, String>> {
+    return multimap.flatMap {
+      it.value.map { mapValue -> ExtractEntry(it.key, mapValue) }
+    }.toMutableList().iterator()
+  }
+
+  private class ExtractEntry(
+    override val key: String,
+    override var value: String
+  ) : MutableMap.MutableEntry<String, String> {
+    override fun setValue(newValue: String): String {
+      value = newValue
+      return value
+    }
+  }
+}

--- a/misk/src/test/kotlin/misk/tracing/ClientServerTraceTest.kt
+++ b/misk/src/test/kotlin/misk/tracing/ClientServerTraceTest.kt
@@ -1,0 +1,202 @@
+package misk.tracing
+
+import com.google.inject.Guice
+import com.google.inject.Injector
+import com.google.inject.Provides
+import com.google.inject.name.Names
+import com.google.inject.util.Modules
+import helpers.protos.Dinosaur
+import io.opentracing.Tracer
+import io.opentracing.mock.MockSpan
+import io.opentracing.mock.MockTracer
+import misk.MiskModule
+import misk.client.HttpClientEndpointConfig
+import misk.client.HttpClientsConfig
+import misk.client.TypedHttpClientModule
+import misk.inject.KAbstractModule
+import misk.inject.getInstance
+import misk.inject.keyOf
+import misk.moshi.MoshiModule
+import misk.testing.MiskTest
+import misk.testing.MiskTestModule
+import misk.testing.MockTracingBackendModule
+import misk.testing.TestWebModule
+import misk.web.Post
+import misk.web.RequestBody
+import misk.web.RequestContentType
+import misk.web.ResponseContentType
+import misk.web.WebActionModule
+import misk.web.WebModule
+import misk.web.actions.WebAction
+import misk.web.jetty.JettyService
+import misk.web.mediatype.MediaTypes
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import retrofit2.Call
+import retrofit2.http.Body
+import retrofit2.http.POST
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@MiskTest(startService = true)
+internal class ClientServerTraceTest {
+  @MiskTestModule
+  val module = Modules.combine(
+      MockTracingBackendModule(),
+      MiskModule(),
+      WebModule(),
+      TestWebModule(),
+      TestModule()
+  )
+
+  @Inject
+  private lateinit var jetty: JettyService
+
+  @Inject
+  private lateinit var tracer: Tracer
+
+  @Inject
+  private lateinit var serverInjector: Injector
+
+  private lateinit var clientInjector: Injector
+
+  private val dinosaurRequest = Dinosaur.Builder().name("trex").build()
+
+  @BeforeEach
+  fun createClient() {
+    clientInjector =
+        Guice.createInjector(MockTracingBackendModule(), MoshiModule(), ClientModule(jetty))
+  }
+
+ @Test
+  fun embedsTrace() {
+    val client = clientInjector.getInstance<ReturnADinosaur>(Names.named("dinosaur"))
+    client.getDinosaur(dinosaurRequest).execute()
+
+    val serverTracer = tracer as MockTracer
+    assertThat(serverTracer.finishedSpans().size).isEqualTo(1)
+
+    val serverSpan = serverTracer.finishedSpans().first()
+    // Parent ID of 0 means there is no parent span
+    assertThat(serverSpan.parentId()).isGreaterThan(0)
+
+    val clientTracer = clientInjector.getInstance(Tracer::class.java) as MockTracer
+    // Two spans here because one is created at the app level and another at the network interceptor
+    // level.
+    assertThat(clientTracer.finishedSpans().size).isEqualTo(2)
+    val clientSpan =
+        clientTracer.finishedSpans().find { it.context().spanId() == serverSpan.parentId() }
+
+    assertThat(clientSpan).isNotNull()
+  }
+
+  @Test
+  fun noTracerNoTracesOrFailures() {
+    val clientInjector = Guice.createInjector(MoshiModule(), ClientModule(jetty))
+    val client = clientInjector.getInstance<ReturnADinosaur>(Names.named("dinosaur"))
+
+    client.getDinosaur(dinosaurRequest).execute()
+
+    val serverTracer = tracer as MockTracer
+    assertThat(serverTracer.finishedSpans().size).isEqualTo(1)
+    assertThat(serverTracer.finishedSpans().first().parentId()).isEqualTo(0)
+
+    assertThat(clientInjector.allBindings.filter { it.key == keyOf<Tracer>() }).isEmpty()
+  }
+
+  @Test
+  fun traceHopsFromClientToServerToServer() {
+    val childServerInjector = serverInjector.createChildInjector(ClientModule(jetty))
+    RoarLikeDinosaurAction.returnADinosaur =
+        childServerInjector.getInstance<ReturnADinosaur>(Names.named("dinosaur"))
+
+    val client = clientInjector.getInstance<RoarLikeDinosaur>(Names.named("roar"))
+    client.doRoar(dinosaurRequest).execute()
+
+    val serverTracer = tracer as MockTracer
+    assertThat(serverTracer.finishedSpans().size).isEqualTo(4)
+
+    val spanIds = serverTracer.finishedSpans().map { it.context().spanId() }.toSet()
+    val traceId = serverTracer.finishedSpans().first().context().traceId()
+
+    var initialServerSpan : MockSpan? = null
+    serverTracer.finishedSpans().forEach {
+      // Parent ID of 0 means there is no parent span
+      assertThat(it.parentId()).isGreaterThan(0)
+
+      // Assert trace IDs are all the same (i.e. no new traces, new spans added as children)
+      assertThat(it.context().traceId()).isEqualTo(traceId)
+
+      if (!spanIds.contains(it.parentId())) initialServerSpan = it
+    }
+
+    assertThat(initialServerSpan).isNotNull()
+
+    val clientTracer = clientInjector.getInstance(Tracer::class.java) as MockTracer
+    // Two spans here because one is created at the app level and another at the network interceptor
+    // level.
+    assertThat(clientTracer.finishedSpans().size).isEqualTo(2)
+    val clientSpan =
+        clientTracer.finishedSpans().find { it.context().spanId() == initialServerSpan!!.parentId() }
+
+    assertThat(clientSpan).isNotNull()
+  }
+
+  interface ReturnADinosaur {
+    @POST("/cooldinos")
+    fun getDinosaur(@Body request: Dinosaur): Call<Dinosaur>
+  }
+
+  class ReturnADinosaurAction : WebAction {
+    @Post("/cooldinos")
+    @RequestContentType(MediaTypes.APPLICATION_JSON)
+    @ResponseContentType(MediaTypes.APPLICATION_JSON)
+    fun getDinosaur(@RequestBody request: Dinosaur):
+        Dinosaur = request.newBuilder().name("super${request.name}").build()
+  }
+
+  interface RoarLikeDinosaur {
+    @POST("/roar")
+    fun doRoar(@Body request: Dinosaur): Call<Dinosaur>
+  }
+
+  @Singleton
+  class RoarLikeDinosaurAction : WebAction {
+    // NOTE(nb): hackily pass in a client because I can't Guice well enough to figure out how to
+    // inject this and I'm exhausted from trying to make it work.
+    companion object {
+      var returnADinosaur: ReturnADinosaur? = null
+    }
+
+    @Post("/roar")
+    @RequestContentType(MediaTypes.APPLICATION_JSON)
+    @ResponseContentType(MediaTypes.APPLICATION_JSON)
+    fun doRoar(@RequestBody request: Dinosaur):
+        Dinosaur = returnADinosaur!!.getDinosaur(request).execute().body()!!
+  }
+
+  class TestModule : KAbstractModule() {
+    override fun configure() {
+      install(WebActionModule.create<ReturnADinosaurAction>())
+      install(WebActionModule.create<RoarLikeDinosaurAction>())
+    }
+  }
+
+  class ClientModule(val jetty: JettyService) : KAbstractModule() {
+    override fun configure() {
+      install(TypedHttpClientModule.create<ReturnADinosaur>("dinosaur", Names.named("dinosaur")))
+      install(TypedHttpClientModule.create<RoarLikeDinosaur>("roar", Names.named("roar")))
+    }
+
+    @Provides
+    @Singleton
+    fun provideHttpClientConfig(): HttpClientsConfig {
+      return HttpClientsConfig(
+          endpoints = mapOf(
+              "dinosaur" to HttpClientEndpointConfig(jetty.httpServerUrl.toString()),
+              "roar" to HttpClientEndpointConfig(jetty.httpServerUrl.toString())
+          ))
+    }
+  }
+}

--- a/misk/src/test/kotlin/misk/tracing/interceptors/TextMultimapExtractAdapterTest.kt
+++ b/misk/src/test/kotlin/misk/tracing/interceptors/TextMultimapExtractAdapterTest.kt
@@ -1,0 +1,31 @@
+package misk.tracing.interceptors
+
+import misk.testing.MiskTest
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+@MiskTest
+class TextMultimapExtractAdapterTest {
+
+  @Test
+  fun flattensMultimap() {
+    val multimap = mapOf(Pair("a", listOf("1", "2")), Pair("b", listOf("3")))
+    val adapter = TextMultimapExtractAdapter(multimap)
+
+    val pairs: MutableList<Pair<String, String>> = mutableListOf()
+    adapter.iterator().forEach { pairs.add(Pair(it.key, it.value)) }
+
+    assertThat(pairs).isEqualTo(listOf(
+        Pair("a", "1"),
+        Pair("a", "2"),
+        Pair("b", "3")))
+  }
+
+  @Test
+  fun emptyMultimap() {
+    val multimap = mapOf<String, List<String>>()
+    val adapter = TextMultimapExtractAdapter(multimap)
+
+    assertThat(adapter.iterator().hasNext()).isFalse()
+  }
+}


### PR DESCRIPTION
Additionally, make TracingInterceptor aware of potential parent
span information in headers and use it to set parent context, if it's
available.