### PR TITLE
Expose client certificates as action scoped vars

### DIFF
--- a/misk/src/main/kotlin/misk/security/ssl/CertificatesModule.kt
+++ b/misk/src/main/kotlin/misk/security/ssl/CertificatesModule.kt
@@ -1,0 +1,61 @@
+package misk.security.ssl
+
+import com.google.inject.TypeLiteral
+import misk.scope.ActionScoped
+import misk.scope.ActionScopedProvider
+import misk.scope.ActionScopedProviderModule
+import misk.security.x509.X500Name
+import java.security.cert.X509Certificate
+import javax.inject.Inject
+import javax.servlet.http.HttpServletRequest
+
+/** Installs support for accessing client certificates */
+internal class CertificatesModule : ActionScopedProviderModule() {
+  override fun configureProviders() {
+    bindProvider(
+        type = certificateArrayType,
+        providerType = ClientCertProvider::class,
+        annotatedBy = ClientCertChain::class.java)
+    bindProvider(
+        type = x500NameType,
+        providerType = ClientCertSubjectDNProvider::class,
+        annotatedBy = ClientCertSubject::class.java)
+    bindProvider(
+        type = x500NameType,
+        providerType = ClientCertIssuerDNProvider::class,
+        annotatedBy = ClientCertIssuer::class.java)
+  }
+
+  private class ClientCertProvider : ActionScopedProvider<Array<X509Certificate>?> {
+    @Inject lateinit @JvmSuppressWildcards var request: ActionScoped<HttpServletRequest>
+
+    override fun get(): Array<X509Certificate>? {
+      @Suppress("UNCHECKED_CAST")
+      return request.get().getAttribute("javax.servlet.request.X509Certificate")
+          as? Array<X509Certificate>
+    }
+  }
+
+  private class ClientCertSubjectDNProvider : ActionScopedProvider<X500Name?> {
+    @Inject @JvmSuppressWildcards @ClientCertChain
+    lateinit var clientCert: ActionScoped<Array<X509Certificate>?>
+
+    override fun get(): X500Name? {
+      return clientCert.get()?.get(0)?.subjectX500Principal?.name?.let { X500Name.parse(it) }
+    }
+  }
+
+  private class ClientCertIssuerDNProvider : ActionScopedProvider<X500Name?> {
+    @Inject @JvmSuppressWildcards @ClientCertChain
+    lateinit var clientCert: ActionScoped<Array<X509Certificate>?>
+
+    override fun get(): X500Name? {
+      return clientCert.get()?.get(0)?.issuerX500Principal?.name?.let { X500Name.parse(it) }
+    }
+  }
+
+  private companion object {
+    val certificateArrayType = object : TypeLiteral<Array<X509Certificate>?>() {}
+    val x500NameType = object : TypeLiteral<X500Name?>() {}
+  }
+}

--- a/misk/src/main/kotlin/misk/security/ssl/ClientCertAnnotations.kt
+++ b/misk/src/main/kotlin/misk/security/ssl/ClientCertAnnotations.kt
@@ -1,0 +1,43 @@
+package misk.security.ssl
+
+import javax.inject.Qualifier
+import misk.scope.ActionScoped
+import misk.security.x509.X500Name
+import javax.security.cert.X509Certificate
+
+/**
+ * Qualifier annotation for an [ActionScoped] array of [X509Certificate]s containing the
+ * certificate chain provided by the client (if any)
+ */
+@Qualifier
+@Retention(AnnotationRetention.RUNTIME)
+@Target(
+    AnnotationTarget.CLASS,
+    AnnotationTarget.VALUE_PARAMETER,
+    AnnotationTarget.FIELD,
+    AnnotationTarget.TYPE)
+annotation class ClientCertChain
+
+/**
+ * Qualifier annotation for an [ActionScoped] [X500Name] containing the subject of the client cert
+ */
+@Qualifier
+@Retention(AnnotationRetention.RUNTIME)
+@Target(
+    AnnotationTarget.CLASS,
+    AnnotationTarget.VALUE_PARAMETER,
+    AnnotationTarget.FIELD,
+    AnnotationTarget.TYPE)
+annotation class ClientCertSubject
+
+/**
+ * Qualifier annotation for an [ActionScoped] [X500Name] containing the issuer of the client cert
+ */
+@Qualifier
+@Retention(AnnotationRetention.RUNTIME)
+@Target(
+    AnnotationTarget.CLASS,
+    AnnotationTarget.VALUE_PARAMETER,
+    AnnotationTarget.FIELD,
+    AnnotationTarget.TYPE)
+annotation class ClientCertIssuer

--- a/misk/src/main/kotlin/misk/security/x509/X500Name.kt
+++ b/misk/src/main/kotlin/misk/security/x509/X500Name.kt
@@ -1,0 +1,97 @@
+package misk.security.x509
+
+class X500Name(private val components: Map<String, String>) {
+  val commonName = get("CN")
+  val organization = get("O")
+  val organizationalUnit = get("OU")
+  val state = get("ST")
+  val locality = get("L")
+  val country = get("C")
+
+  operator fun get(componentName: String) = components[componentName.toUpperCase()]
+
+  fun asMap() = components
+
+  companion object {
+    fun parse(dnString: String): X500Name {
+      val components = mutableMapOf<String, String>()
+
+      val dn = dnString.toCharArray()
+
+      var index = 0
+      var escaped = false
+      var quoteEscaped = false
+      var openNameOrValue = StringBuilder()
+      var inAttributeName = true
+      var attributeName: String? = null
+
+      while (index < dn.size) {
+        val c = dn[index]
+
+        when {
+        // Current character is being escaped, so should be added as-is to the open name or value
+          escaped -> {
+            openNameOrValue.append(c)
+            escaped = false
+          }
+
+        // Either starts or ends a quoted string
+          c == '"' -> quoteEscaped = !quoteEscaped
+
+        // Currently in a quoted string, so add the character as-is to the open name or value
+          quoteEscaped -> openNameOrValue.append(c)
+
+        // Next character will be escaped
+          c == '\\' -> escaped = true
+
+        // Ends the attribute entirely. An error if we never encountered a value, otherwise
+        // trim the current value and add to the component map
+          c == ',' || c == ';' -> {
+            require(!inAttributeName) {
+              "invalid X.500 name '$dnString'; no attribute value for $openNameOrValue"
+            }
+
+            components[attributeName!!] = openNameOrValue.toString().trim()
+
+            attributeName = null
+            openNameOrValue = StringBuilder()
+            inAttributeName = true
+          }
+
+        // Ends the attribute name. An error if we are parsing an attribute value, otherwise
+        // trim and save off the attribute name, and begin parsing the attribute value
+          c == '=' -> {
+            require(inAttributeName) {
+              "invalid X.500 name '$dnString'; illegal character '=' in attribute value $attributeName"
+            }
+            inAttributeName = false
+            attributeName = openNameOrValue.toString().trim()
+            require(attributeName.isNotBlank()) {
+              "invalid X.500 name '$dnString'; attribute name is blank"
+            }
+            openNameOrValue = StringBuilder()
+          }
+
+        // Not a special character, add directly to the open name or value
+          else -> openNameOrValue.append(c)
+        }
+
+        index++
+      }
+
+      // We need to end with either having completed an attribute name + value, or without
+      // having started an attribute
+      require(openNameOrValue.isBlank() || !inAttributeName) {
+        "invalid X.500 name '$dnString'; unfinished attribute $openNameOrValue"
+      }
+
+      if (!inAttributeName) {
+        components[attributeName!!] = openNameOrValue.toString().trim()
+      }
+
+      require(!components.isEmpty()) { "invalid X.500 name '$dnString'; no attributes" }
+
+      return X500Name(components.toMap())
+    }
+  }
+}

--- a/misk/src/main/kotlin/misk/web/WebModule.kt
+++ b/misk/src/main/kotlin/misk/web/WebModule.kt
@@ -12,6 +12,7 @@ import misk.inject.addMultibinderBindingWithAnnotation
 import misk.inject.newMultibinder
 import misk.inject.to
 import misk.scope.ActionScopedProviderModule
+import misk.security.ssl.CertificatesModule
 import misk.web.exceptions.ActionExceptionMapper
 import misk.web.exceptions.ExceptionHandlingInterceptor
 import misk.web.exceptions.ExceptionMapperModule
@@ -98,5 +99,8 @@ class WebModule : KAbstractModule() {
         .toInstance(WebSocketParameterExtractorFactory)
     binder().addMultibinderBinding<ParameterExtractor.Factory>()
         .to<RequestBodyParameterExtractor.Factory>()
+
+    // Install infrastructure support
+    install(CertificatesModule())
   }
 }

--- a/misk/src/test/kotlin/misk/scope/TestActionScopedProviderModule.kt
+++ b/misk/src/test/kotlin/misk/scope/TestActionScopedProviderModule.kt
@@ -7,8 +7,8 @@ import javax.inject.Inject
 class TestActionScopedProviderModule : ActionScopedProviderModule() {
   override fun configureProviders() {
     bindSeedData(String::class, Names.named("from-seed"))
-    bindProvider(String::class, Names.named("foo"), FooProvider::class)
-    bindProvider(String::class, Names.named("bar"), BarProvider::class)
+    bindProvider(String::class, FooProvider::class, Names.named("foo"))
+    bindProvider(String::class, BarProvider::class, Names.named("bar"))
   }
 
   class BarProvider @Inject internal constructor(


### PR DESCRIPTION
Allows interceptors and actions to make decisions based on the subject
of the authenticated client