### PR TITLE
Add typed websockets

### DIFF
--- a/misk/src/main/kotlin/misk/web/Request.kt
+++ b/misk/src/main/kotlin/misk/web/Request.kt
@@ -11,5 +11,5 @@ data class Request(
   val method: HttpMethod,
   val headers: Headers = Headers.of(),
   val body: BufferedSource,
-  val websocket: WebSocket? = null
+  var websocket: WebSocket<Any>? = null
 )

--- a/misk/src/main/kotlin/misk/web/Response.kt
+++ b/misk/src/main/kotlin/misk/web/Response.kt
@@ -14,6 +14,7 @@ data class Response<out T>(
 
 interface ResponseBody {
   fun writeTo(sink: BufferedSink)
+  fun get(): Any = Unit
 }
 
 fun Response<ResponseBody>.writeToJettyResponse(jettyResponse: HttpServletResponse) {

--- a/misk/src/main/kotlin/misk/web/WebModule.kt
+++ b/misk/src/main/kotlin/misk/web/WebModule.kt
@@ -1,8 +1,6 @@
 package misk.web
 
-import misk.Action
 import misk.ApplicationInterceptor
-import misk.Chain
 import misk.MiskDefault
 import misk.NetworkInterceptor
 import misk.exceptions.ActionException
@@ -21,7 +19,7 @@ import misk.web.extractors.ParameterExtractor
 import misk.web.extractors.PathPatternParameterExtractorFactory
 import misk.web.extractors.QueryStringParameterExtractorFactory
 import misk.web.extractors.RequestBodyParameterExtractor
-import misk.web.extractors.WebSocketParameterExtractorFactory
+import misk.web.extractors.WebSocketParameterExtractor
 import misk.web.interceptors.InternalErrorInterceptorFactory
 import misk.web.interceptors.MarshallerInterceptor
 import misk.web.interceptors.MetricsInterceptor
@@ -33,6 +31,7 @@ import misk.web.marshal.JsonUnmarshaller
 import misk.web.marshal.MarshallerModule
 import misk.web.marshal.PlainTextMarshaller
 import misk.web.marshal.UnmarshallerModule
+import misk.web.marshal.WebSocketMarshaller
 import javax.servlet.http.HttpServletRequest
 
 class WebModule : KAbstractModule() {
@@ -48,6 +47,7 @@ class WebModule : KAbstractModule() {
     // Register built-in marshallers and unmarshallers
     install(MarshallerModule.create<PlainTextMarshaller.Factory>())
     install(MarshallerModule.create<JsonMarshaller.Factory>())
+    install(MarshallerModule.create<WebSocketMarshaller.Factory>())
     install(UnmarshallerModule.create<JsonUnmarshaller.Factory>())
 
     // Create empty set binders of interceptor factories that can be added to by users.
@@ -95,7 +95,7 @@ class WebModule : KAbstractModule() {
     binder().addMultibinderBinding<ParameterExtractor.Factory>()
         .toInstance(HeadersParameterExtractorFactory)
     binder().addMultibinderBinding<ParameterExtractor.Factory>()
-        .toInstance(WebSocketParameterExtractorFactory)
+        .to<WebSocketParameterExtractor.Factory>()
     binder().addMultibinderBinding<ParameterExtractor.Factory>()
         .to<RequestBodyParameterExtractor.Factory>()
   }

--- a/misk/src/main/kotlin/misk/web/actions/WebSocket.kt
+++ b/misk/src/main/kotlin/misk/web/actions/WebSocket.kt
@@ -34,7 +34,7 @@ import okio.ByteString
  * incoming messages. But it does not guarantee that the other peer will successfully receive all of
  * its incoming messages.
  */
-interface WebSocket {
+interface WebSocket<in T> {
   /**
    * Returns the size in bytes of all messages enqueued to be transmitted to the server. This
    * doesn't include framing overhead. It also doesn't include any bytes buffered by the operating
@@ -45,8 +45,8 @@ interface WebSocket {
   fun queueSize(): Long
 
   /**
-   * Attempts to enqueue {@code text} to be UTF-8 encoded and sent as a the data of a text (type
-   * {@code 0x1}) message.
+   * Attempts to enqueue {@code content} to be UTF-8 encoded and sent as a the marshaled form of the
+   * content.
    *
    * <p>This method returns true if the message was enqueued. Messages that would overflow the
    * outgoing message buffer will be rejected and trigger a {@linkplain #close graceful shutdown} of
@@ -55,20 +55,7 @@ interface WebSocket {
    *
    * <p>This method returns immediately.
    */
-  fun send(bytes: ByteString): Boolean
-
-  /**
-   * Attempts to enqueue {@code bytes} to be sent as a the data of a binary (type {@code 0x2})
-   * message.
-   *
-   * <p>This method returns true if the message was enqueued. Messages that would overflow the
-   * outgoing message buffer will be rejected and trigger a {@linkplain #close graceful shutdown} of
-   * this web socket. This method returns false in that case, and in any other case where this
-   * web socket is closing, closed, or canceled.
-   *
-   * <p>This method returns immediately.
-   */
-  fun send(text: String): Boolean
+  fun send(content: T): Boolean
 
   /**
    * Attempts to initiate a graceful shutdown of this web socket. Any already-enqueued messages will

--- a/misk/src/main/kotlin/misk/web/actions/WebSocketListener.kt
+++ b/misk/src/main/kotlin/misk/web/actions/WebSocketListener.kt
@@ -1,30 +1,25 @@
 package misk.web.actions
 
-import okio.ByteString
-
-open class WebSocketListener {
+open class WebSocketListener<T> {
   /** Invoked when a text (type {@code 0x1}) message has been received. */
-  open fun onMessage(webSocket: WebSocket, text: String) = Unit
-
-  /** Invoked when a binary (type {@code 0x2}) message has been received. */
-  open fun onMessage(webSocket: WebSocket, bytes: ByteString) = Unit
+  open fun onMessage(webSocket: WebSocket<T>, content: T) = Unit
 
   /**
    * Invoked when the remote peer has indicated that no more incoming messages will be
    * transmitted.
    */
-  open fun onClosing(webSocket: WebSocket, code: Int, reason: String?) = Unit
+  open fun onClosing(webSocket: WebSocket<T>, code: Int, reason: String?) = Unit
 
   /**
    * Invoked when both peers have indicated that no more messages will be transmitted and the
    * connection has been successfully released. No further calls to this listener will be made.
    */
-  open fun onClosed(webSocket: WebSocket, code: Int, reason: String) = Unit
+  open fun onClosed(webSocket: WebSocket<T>, code: Int, reason: String) = Unit
 
   /**
    * Invoked when a web socket has been closed due to an error reading from or writing to the
    * network. Both outgoing and incoming messages may have been lost. No further calls to this
    * listener will be made.
    */
-  open fun onFailure(webSocket: WebSocket, t: Throwable) = Unit
+  open fun onFailure(webSocket: WebSocket<T>, t: Throwable) = Unit
 }

--- a/misk/src/main/kotlin/misk/web/extractors/RequestBodyParameterExtractor.kt
+++ b/misk/src/main/kotlin/misk/web/extractors/RequestBodyParameterExtractor.kt
@@ -25,8 +25,8 @@ internal class RequestBodyParameterExtractor(
   ): Any? {
     val mediaType = request.headers["Content-Type"]?.let { MediaType.parse(it) }
     val unmarshaller = mediaType?.let { type ->
-      unmarshallerFactories.map { it.create(type, parameter.type) }.firstOrNull()
-    } ?: GenericUnmarshallers.into(parameter)
+      unmarshallerFactories.map { it.create<Any>(type, parameter.type) }.firstOrNull()
+    } ?: GenericUnmarshallers.into(parameter.type)
     ?: throw IllegalArgumentException("no generic unmarshaller for ${parameter.type}")
 
     return unmarshaller.unmarshal(request.body)

--- a/misk/src/main/kotlin/misk/web/extractors/WebSocketParameterExtractorFactory.kt
+++ b/misk/src/main/kotlin/misk/web/extractors/WebSocketParameterExtractorFactory.kt
@@ -2,28 +2,79 @@ package misk.web.extractors
 
 import misk.web.PathPattern
 import misk.web.Request
+import misk.web.ResponseContentType
 import misk.web.actions.WebAction
 import misk.web.actions.WebSocket
+import misk.web.marshal.GenericMarshallers
+import misk.web.marshal.Marshaller
+import misk.web.mediatype.MediaTypes
+import misk.web.mediatype.asMediaType
+import okhttp3.MediaType
+import okio.Buffer
 import java.util.regex.Matcher
+import javax.inject.Inject
 import kotlin.reflect.KFunction
 import kotlin.reflect.KParameter
+import kotlin.reflect.KType
+import kotlin.reflect.full.findAnnotation
 
-object WebSocketParameterExtractorFactory : ParameterExtractor.Factory {
-  override fun create(
-    function: KFunction<*>,
-    parameter: KParameter,
-    pathPattern: PathPattern
-  ): ParameterExtractor? {
-    if (parameter.type.classifier != WebSocket::class) return null
-
-    return object : ParameterExtractor {
-      override fun extract(
-        webAction: WebAction,
-        request: Request,
-        pathMatcher: Matcher
-      ): Any? {
-        return request.websocket
+class WebSocketParameterExtractor(private val marshaller: Marshaller<Any>) : ParameterExtractor {
+  override fun extract(
+    webAction: WebAction,
+    request: Request,
+    pathMatcher: Matcher
+  ): Any? {
+    val ws = request.websocket!!
+    request.websocket = object : WebSocket<Any> {
+      override fun queueSize(): Long {
+        return ws.queueSize()
       }
+
+      override fun send(content: Any): Boolean {
+        val buffer = Buffer()
+        marshaller.responseBody(content).writeTo(buffer)
+        val utf8 = buffer.readUtf8()
+        return ws.send(utf8)
+      }
+
+      override fun close(code: Int, reason: String?): Boolean {
+        return ws.close(code, reason)
+      }
+
+      override fun cancel() {
+        ws.cancel()
+      }
+    }
+
+    return request.websocket
+  }
+
+  class Factory @Inject internal constructor(
+    @JvmSuppressWildcards private val marshallerFactories: List<Marshaller.Factory>
+  ) : ParameterExtractor.Factory {
+    override fun create(
+      function: KFunction<*>,
+      parameter: KParameter,
+      pathPattern: PathPattern
+    ): ParameterExtractor? {
+      if (parameter.type.classifier != WebSocket::class) return null
+
+      val responseMediaType =
+          function.findAnnotation<ResponseContentType>()?.value?.asMediaType()
+              ?: MediaTypes.TEXT_PLAIN_UTF8.asMediaType()
+
+      val webSocketType = parameter.type.arguments[0].type!!
+
+      val marshaller = marshallerFactories.mapNotNull {
+        it.create(responseMediaType, webSocketType, marshallerFactories)
+      }.firstOrNull() ?: genericMarshallerFor(responseMediaType, webSocketType)
+
+      return WebSocketParameterExtractor(marshaller)
+    }
+
+    private fun genericMarshallerFor(mediaType: MediaType?, type: KType): Marshaller<Any> {
+      return GenericMarshallers.from(mediaType, type) ?: throw IllegalArgumentException(
+          "no marshaller for $mediaType as $type")
     }
   }
 }

--- a/misk/src/main/kotlin/misk/web/interceptors/MarshallerInterceptor.kt
+++ b/misk/src/main/kotlin/misk/web/interceptors/MarshallerInterceptor.kt
@@ -5,7 +5,6 @@ import misk.NetworkChain
 import misk.NetworkInterceptor
 import misk.web.Response
 import misk.web.ResponseContentType
-import misk.web.actions.WebSocketListener
 import misk.web.marshal.GenericMarshallers
 import misk.web.marshal.Marshaller
 import misk.web.mediatype.MediaTypes
@@ -36,9 +35,6 @@ internal class MarshallerInterceptor constructor(private val marshaller: Marshal
     @JvmSuppressWildcards private val marshallerFactories: List<Marshaller.Factory>
   ) : NetworkInterceptor.Factory {
     override fun create(action: Action): NetworkInterceptor? {
-      if (action.returnType.classifier == WebSocketListener::class) {
-        return null
-      }
       return findMarshaller(action)?.let { MarshallerInterceptor(it) }
     }
 
@@ -52,7 +48,7 @@ internal class MarshallerInterceptor constructor(private val marshaller: Marshal
       }
 
       val contentTypeMarshaller = marshallerFactories.mapNotNull {
-        it.create(responseMediaType, action.returnType)
+        it.create(responseMediaType, action.returnType, marshallerFactories)
       }.firstOrNull()
 
       return contentTypeMarshaller

--- a/misk/src/main/kotlin/misk/web/marshal/Generic.kt
+++ b/misk/src/main/kotlin/misk/web/marshal/Generic.kt
@@ -8,7 +8,6 @@ import okio.BufferedSink
 import okio.BufferedSource
 import okio.ByteString
 import java.lang.reflect.Type
-import kotlin.reflect.KParameter
 import kotlin.reflect.KType
 import kotlin.reflect.jvm.javaType
 
@@ -23,21 +22,20 @@ object GenericUnmarshallers {
       ByteString::class.java
   )
 
-  private object ToString : Unmarshaller {
+  private object ToString : Unmarshaller<Any> {
     override fun unmarshal(source: BufferedSource): Any? = source.readUtf8()
   }
 
-  private object ToBufferedSource : Unmarshaller {
+  private object ToBufferedSource : Unmarshaller<Any> {
     override fun unmarshal(source: BufferedSource): Any? = source
   }
 
-  private object ToByteString : Unmarshaller {
+  private object ToByteString : Unmarshaller<Any> {
     override fun unmarshal(source: BufferedSource): Any? = source.readByteString()
   }
 
-  fun into(parameter: KParameter): Unmarshaller? {
-    val paramType = parameter.type
-    return when (paramType.typeLiteral().rawType) {
+  fun into(type: KType): Unmarshaller<Any>? {
+    return when (type.typeLiteral().rawType) {
       String::class.java -> ToString
       BufferedSource::class.java -> ToBufferedSource
       ByteString::class.java -> ToByteString

--- a/misk/src/main/kotlin/misk/web/marshal/Marshaller.kt
+++ b/misk/src/main/kotlin/misk/web/marshal/Marshaller.kt
@@ -17,7 +17,7 @@ interface Marshaller<in T> {
   fun responseBody(o: T): ResponseBody
 
   interface Factory {
-    fun create(mediaType: MediaType, type: KType): Marshaller<Any>?
+    fun create(mediaType: MediaType, type: KType, factories: List<Marshaller.Factory>): Marshaller<Any>?
   }
 
   companion object {

--- a/misk/src/main/kotlin/misk/web/marshal/PlainText.kt
+++ b/misk/src/main/kotlin/misk/web/marshal/PlainText.kt
@@ -1,12 +1,11 @@
 package misk.web.marshal
 
 import misk.web.ResponseBody
+import misk.web.actions.WebSocketListener
 import misk.web.marshal.Marshaller.Companion.actualResponseType
 import misk.web.mediatype.MediaTypes
 import okhttp3.MediaType
 import okio.BufferedSink
-import okio.BufferedSource
-import okio.ByteString
 import kotlin.reflect.KType
 
 object PlainTextMarshaller : Marshaller<Any> {
@@ -18,39 +17,19 @@ object PlainTextMarshaller : Marshaller<Any> {
   }
 
   class Factory : Marshaller.Factory {
-    override fun create(mediaType: MediaType, type: KType): Marshaller<Any>? {
+    override fun create(
+      mediaType: MediaType,
+      type: KType,
+      factories: List<Marshaller.Factory>
+    ): Marshaller<Any>? {
       if (mediaType.type() != MediaTypes.TEXT_PLAIN_UTF8_MEDIA_TYPE.type() ||
-          mediaType.subtype() != MediaTypes.TEXT_PLAIN_UTF8_MEDIA_TYPE.subtype()) {
+          mediaType.subtype() != MediaTypes.TEXT_PLAIN_UTF8_MEDIA_TYPE.subtype() ||
+          type.classifier == WebSocketListener::class) {
         return null
       }
 
       if (GenericMarshallers.canHandle(actualResponseType(type))) return null
       return PlainTextMarshaller
-    }
-  }
-}
-
-object PlainTextUnmarshaller {
-  object ToString : Unmarshaller {
-    override fun unmarshal(source: BufferedSource) = source.readUtf8()
-  }
-
-  object ToByteString : Unmarshaller {
-    override fun unmarshal(source: BufferedSource) = source.readByteString()
-  }
-
-  class Factory : Unmarshaller.Factory {
-    override fun create(mediaType: MediaType, type: KType): Unmarshaller? {
-      if (mediaType.type() != MediaTypes.TEXT_PLAIN_UTF8_MEDIA_TYPE.type() ||
-          mediaType.subtype() != MediaTypes.TEXT_PLAIN_UTF8_MEDIA_TYPE.subtype()) return null
-
-      if (GenericUnmarshallers.canHandle(type)) return null
-
-      return when (type) {
-        String::class -> ToString
-        ByteString::class -> ToByteString
-        else -> throw IllegalArgumentException("no plain/text unmarshaller for $type")
-      }
     }
   }
 }

--- a/misk/src/main/kotlin/misk/web/marshal/Unmarshaller.kt
+++ b/misk/src/main/kotlin/misk/web/marshal/Unmarshaller.kt
@@ -5,10 +5,10 @@ import okio.BufferedSource
 import kotlin.reflect.KType
 
 /** Unmarshalls a typed object from an incoming source */
-interface Unmarshaller {
-  fun unmarshal(source: BufferedSource): Any?
+interface Unmarshaller<out T> {
+  fun unmarshal(source: BufferedSource): T?
 
   interface Factory {
-    fun create(mediaType: MediaType, type: KType): Unmarshaller?
+    fun <T> create(mediaType: MediaType, type: KType): Unmarshaller<T>?
   }
 }

--- a/misk/src/main/kotlin/misk/web/marshal/WebSocketMarshaller.kt
+++ b/misk/src/main/kotlin/misk/web/marshal/WebSocketMarshaller.kt
@@ -1,0 +1,72 @@
+package misk.web.marshal
+
+import misk.web.ResponseBody
+import misk.web.actions.WebSocket
+import misk.web.actions.WebSocketListener
+import okhttp3.MediaType
+import okio.Buffer
+import okio.BufferedSink
+import javax.inject.Inject
+import kotlin.reflect.KType
+
+class WebSocketMarshaller<R, in T>(val delegate: Unmarshaller<R>) : Marshaller<T> {
+  override fun contentType(): MediaType? {
+    return null
+  }
+
+  override fun responseBody(o: T): ResponseBody {
+    val webSocketListener = o as WebSocketListener<R>
+
+    val marshallingWebSocketListener = object : WebSocketListener<R>() {
+      override fun onMessage(webSocket: WebSocket<R>, content: R) {
+        val source = Buffer().writeUtf8(content.toString())
+        val t = delegate.unmarshal(source)!!
+        webSocketListener.onMessage(webSocket, t)
+      }
+
+      override fun onClosing(webSocket: WebSocket<R>, code: Int, reason: String?) {
+        webSocketListener.onClosing(webSocket, code, reason)
+      }
+
+      override fun onClosed(webSocket: WebSocket<R>, code: Int, reason: String) {
+        webSocketListener.onClosed(webSocket, code, reason)
+      }
+
+      override fun onFailure(webSocket: WebSocket<R>, t: Throwable) {
+        webSocketListener.onFailure(webSocket, t)
+      }
+    }
+
+    return object : ResponseBody {
+      override fun writeTo(sink: BufferedSink) {
+      }
+
+      override fun get(): Any {
+        return marshallingWebSocketListener
+      }
+    }
+  }
+
+  class Factory @Inject internal constructor(
+    @JvmSuppressWildcards private val unmarshallerFactories: List<Unmarshaller.Factory>
+  ) : Marshaller.Factory {
+    override fun create(
+      mediaType: MediaType,
+      type: KType,
+      factories: List<Marshaller.Factory>
+    ): Marshaller<Any>? {
+      // TODO(tso): the mediaType passed in here is the reverse of what we want, which
+      // is fine since the response and request content types for websockets must be
+      // equal for now.
+      if (type.classifier != WebSocketListener::class) return null
+      val webSocketType = type.arguments[0].type!!
+
+      val unmarshaller =
+          unmarshallerFactories.map { it.create<Any>(mediaType, webSocketType) }.firstOrNull()
+              ?: GenericUnmarshallers.into(webSocketType)
+              ?: throw IllegalArgumentException("no unmarshaller for $webSocketType")
+
+      return WebSocketMarshaller(unmarshaller)
+    }
+  }
+}


### PR DESCRIPTION
This commmit adds the ability to define a type on a WebSocketListener
which is marshalled and unmarshalled per websocket message using the
request/response content type annotation.