### PR TITLE
Remove unnecessary check from uploadArchives task

### DIFF
--- a/gradle/gradle-mvn-push.gradle
+++ b/gradle/gradle-mvn-push.gradle
@@ -91,7 +91,7 @@ afterEvaluate { project ->
   }
 
   signing {
-    required { isReleaseBuild() && gradle.taskGraph.hasTask("uploadArchives") }
+    required { isReleaseBuild() }
     sign configurations.archives
   }
 


### PR DESCRIPTION
The uploadArchives task is where this check is occurring, rendering it unnecessary. Additionally, it wasn't working properly and was preventing signing by failing.