### PR TITLE
Don't treat assembly as a release when running in CI

### DIFF
--- a/gradle/gradle-mvn-push.gradle
+++ b/gradle/gradle-mvn-push.gradle
@@ -21,7 +21,7 @@ version = VERSION_NAME
 group = GROUP
 
 def isReleaseBuild() {
-  return VERSION_NAME.contains("SNAPSHOT") == false
+  return !isCi && VERSION_NAME.contains("SNAPSHOT") == false
 }
 
 def getReleaseRepositoryUrl() {


### PR DESCRIPTION
This hinges on adding "CI=true" to Travis, which I've already done.