### PR TITLE
Adds a DataSourceModule

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,6 +48,8 @@ ext {
           zipkinBrave          : 'io.zipkin.brave:brave:4.17.2',
           retrofit             : 'com.squareup.retrofit2:retrofit:2.3.0',
           retrofitMoshi        : 'com.squareup.retrofit2:converter-moshi:2.3.0',
+          hikariCp             : 'com.zaxxer:HikariCP:3.1.0',
+          hsqldb               : 'org.hsqldb:hsqldb:2.4.0',
   ]
 
   isCi = "true".equals(System.getenv('CI'))

--- a/misk/build.gradle
+++ b/misk/build.gradle
@@ -54,6 +54,7 @@ dependencies {
   compile dep.zipkinBrave
   compile dep.retrofit
   compile dep.retrofitMoshi
+  compile dep.hikariCp
 
   testCompile project(':misk/testing')
 }

--- a/misk/src/main/kotlin/misk/inject/Guice.kt
+++ b/misk/src/main/kotlin/misk/inject/Guice.kt
@@ -89,6 +89,8 @@ inline fun <reified T : Any> keyOf(a: Annotation): Key<T> = Key.get(T::class.jav
 inline fun <reified T : Any, A : Annotation> keyOf(a: KClass<A>): Key<T> =
     Key.get(T::class.java, a.java)
 
+fun <T : Any, A : Annotation> keyOf(t: KClass<T>, a: KClass<A>): Key<T> = Key.get(t.java, a.java)
+
 fun <T : Any> TypeLiteral<T>.toKey(annotation: Class<out Annotation>? = null): Key<T> {
   return when (annotation) {
     null -> Key.get(this)

--- a/misk/src/main/kotlin/misk/jdbc/DataSourceConfig.kt
+++ b/misk/src/main/kotlin/misk/jdbc/DataSourceConfig.kt
@@ -1,0 +1,39 @@
+package misk.jdbc
+
+import misk.config.Config
+import java.time.Duration
+
+/** Defines a type of datasource */
+enum class DataSourceType(
+  val driverClassName: String,
+  val buildJdbcUrl: (DataSourceConfig) -> String
+) {
+  MYSQL("com.mysql.jdbc.Driver", { config ->
+    val port = config.port ?: 3306
+    val host = config.host ?: "127.0.0.1"
+    val database = config.database ?: ""
+    "jdbc:mysql://${host}:$port/$database"
+
+  }),
+  HSQLDB("org.hsqldb.jdbcDriver", { config ->
+    "jdbc:hsqldb:mem:${config.database!!}"
+  })
+}
+
+/** Configuration element for an individual datasource */
+data class DataSourceConfig(
+  val type: DataSourceType,
+  val host: String? = null,
+  val port: Int? = null,
+  val database: String? = null,
+  val username: String? = null,
+  val password: String? = null,
+  val connection_properties: Map<String, String> = mapOf(),
+  val fixed_pool_size: Int = 10,
+  val connection_timeout: Duration = Duration.ofSeconds(30),
+  val connection_max_lifetime: Duration = Duration.ofMinutes(30),
+  val read_only: Boolean = false
+)
+
+/** Top-level configuration element for all databases */
+data class DataSourcesConfig(val databases: Map<String, DataSourceConfig>) : Config

--- a/misk/src/main/kotlin/misk/jdbc/DataSourceModule.kt
+++ b/misk/src/main/kotlin/misk/jdbc/DataSourceModule.kt
@@ -1,0 +1,60 @@
+package misk.jdbc
+
+import com.google.inject.Key
+import com.zaxxer.hikari.HikariConfig
+import com.zaxxer.hikari.HikariDataSource
+import misk.inject.KAbstractModule
+import misk.inject.asSingleton
+import javax.inject.Inject
+import javax.inject.Provider
+import javax.sql.DataSource
+import kotlin.reflect.KClass
+
+/** Binds a [DataSource] configured from the specific entry in the [DataSourcesConfig] */
+class DataSourceModule constructor(
+  private val datasourceName: String,
+  private val key: Key<DataSource>
+) : KAbstractModule() {
+
+  override fun configure() {
+    bind(key).toProvider(DataSourceProvider(datasourceName)).asEagerSingleton()
+  }
+
+  companion object {
+    fun create(datasourceName: String) =
+        DataSourceModule(datasourceName, Key.get(DataSource::class.java))
+
+    fun create(datasourceName: String, annotatedBy: Annotation) =
+        DataSourceModule(datasourceName, Key.get(DataSource::class.java, annotatedBy))
+
+    fun <A : Annotation> create(datasourceName: String, annotatedBy: Class<A>) =
+        DataSourceModule(datasourceName, Key.get(DataSource::class.java, annotatedBy))
+
+    fun <A : Annotation> create(datasourceName: String, annotatedBy: KClass<A>) =
+        DataSourceModule(datasourceName, Key.get(DataSource::class.java, annotatedBy.java))
+  }
+
+  private class DataSourceProvider(private val datasourceName: String) : Provider<DataSource> {
+    @Inject lateinit var datasourcesConfig: DataSourcesConfig
+
+    override fun get(): DataSource {
+      val config = datasourcesConfig.databases[datasourceName]
+          ?: throw IllegalStateException("no datasource named $datasourceName")
+
+      val hikariConfig = HikariConfig()
+      hikariConfig.driverClassName = config.type.driverClassName
+      hikariConfig.jdbcUrl = config.type.buildJdbcUrl(config)
+      hikariConfig.isReadOnly = config.read_only
+      config.username?.let { hikariConfig.username = it }
+      config.password?.let { hikariConfig.password = it }
+      config.connection_properties.forEach { name, value ->
+        hikariConfig.dataSourceProperties[name] = value
+      }
+      hikariConfig.maximumPoolSize = config.fixed_pool_size
+      hikariConfig.connectionTimeout = config.connection_timeout.toMillis()
+      hikariConfig.maxLifetime = config.connection_max_lifetime.toMillis()
+
+      return HikariDataSource(hikariConfig)
+    }
+  }
+}

--- a/misk/src/test/kotlin/misk/jdbc/DataSourceModuleTest.kt
+++ b/misk/src/test/kotlin/misk/jdbc/DataSourceModuleTest.kt
@@ -1,0 +1,182 @@
+package misk.jdbc
+
+import com.google.inject.CreationException
+import com.google.inject.Guice
+import com.google.inject.name.Names
+import misk.config.Config
+import misk.config.ConfigModule
+import misk.inject.keyOf
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import javax.inject.Qualifier
+import javax.sql.DataSource
+
+internal class DataSourceModuleTest {
+  val username = "snork"
+  val password = "florp"
+  val dbname = "lorfil"
+  val rootConfig = RootConfig(
+      DataSourcesConfig(mapOf(
+          "exemplar" to DataSourceConfig(
+              DataSourceType.HSQLDB,
+              database = dbname,
+              username = username,
+              password = password
+          ))))
+
+  lateinit var baseDataSource: DataSource
+
+  @BeforeEach
+  fun initDatabase() {
+    // Create the datasource by hand
+    Class.forName(DataSourceType.HSQLDB.driverClassName)
+
+    val datasource = org.hsqldb.jdbc.JDBCDataSource()
+    datasource.setURL("jdbc:hsqldb:mem:$dbname")
+    datasource.setUser(username)
+    datasource.setPassword(password)
+    baseDataSource = datasource
+
+    // Add some people that can be retrieved in tests
+    val db = PeopleDatabase(baseDataSource)
+    db.init()
+    db.addPerson(100, "Mary")
+    db.addPerson(101, "Phil")
+  }
+
+  @AfterEach
+  fun destroyDatabase() {
+    baseDataSource.connection.use { conn ->
+      conn.createStatement().use { stmt ->
+            stmt.execute("DROP TABLE people")
+          }
+      conn.commit()
+    }
+  }
+
+  @Test fun bindsDataSourceWithoutAnnotation() {
+    val injector = Guice.createInjector(
+        DataSourceModule.create("exemplar"),
+        ConfigModule.create("my-app", rootConfig))
+
+    val datasource = injector.getInstance(keyOf<DataSource>())
+    val db = PeopleDatabase(datasource)
+    val results = db.listPeople()
+    assertThat(results).containsExactly(100 to "Mary", 101 to "Phil")
+  }
+
+  @Test fun bindsDataSourceWithAnnotationInstance() {
+    val injector = Guice.createInjector(
+        DataSourceModule.create("exemplar", Names.named("exemplar")),
+        ConfigModule.create("my-app", rootConfig))
+
+    val datasource = injector.getInstance(keyOf<DataSource>(Names.named("exemplar")))
+    val db = PeopleDatabase(datasource)
+    val results = db.listPeople()
+    assertThat(results).containsExactly(100 to "Mary", 101 to "Phil")
+  }
+
+  @Test fun bindsDataSourceWithAnnotation() {
+    val injector = Guice.createInjector(
+        DataSourceModule.create("exemplar", ForWrites::class),
+        ConfigModule.create("my-app", rootConfig))
+
+    val datasource = injector.getInstance(keyOf(DataSource::class, ForWrites::class))
+    val db = PeopleDatabase(datasource)
+    val results = db.listPeople()
+    assertThat(results).containsExactly(100 to "Mary", 101 to "Phil")
+  }
+
+  @Test fun usesProperUsername() {
+    assertThrows(CreationException::class.java) {
+      Guice.createInjector(
+          DataSourceModule.create("exemplar"),
+          ConfigModule.create("my-app", RootConfig(
+              DataSourcesConfig(mapOf(
+                  "exemplar" to DataSourceConfig(
+                      DataSourceType.HSQLDB,
+                      database = dbname,
+                      username = username + "INCORRECT",
+                      password = password
+                  )))))
+      )
+    }
+  }
+
+  @Test fun usesProperPassword() {
+    assertThrows(CreationException::class.java) {
+      Guice.createInjector(
+          DataSourceModule.create("exemplar"),
+          ConfigModule.create("my-app", RootConfig(
+              DataSourcesConfig(mapOf(
+                  "exemplar" to DataSourceConfig(
+                      DataSourceType.HSQLDB,
+                      database = dbname,
+                      username = username,
+                      password = password + "INCORRECT"
+                  )))))
+      )
+    }
+  }
+
+  @Test fun failsIfDataSourceNotFound() {
+    assertThrows(CreationException::class.java) {
+      Guice.createInjector(
+          DataSourceModule.create("NOT_EXEMPLAR", ForWrites::class),
+          ConfigModule.create("my-app", RootConfig(
+              DataSourcesConfig(mapOf(
+                  "exemplar" to DataSourceConfig(
+                      DataSourceType.HSQLDB,
+                      database = dbname,
+                      username = username,
+                      password = password
+                  )))))
+      )
+    }
+  }
+
+  class PeopleDatabase(private val datasource: DataSource) {
+    fun init() {
+      datasource.connection.use { conn ->
+        conn.createStatement().use { stmt ->
+              stmt.execute("CREATE TABLE people(id INT NOT NULL, name VARCHAR(256) NOT NULL)")
+            }
+      }
+    }
+
+    fun addPerson(id: Int, name: String) {
+      datasource.connection.use { conn ->
+        conn.prepareStatement("INSERT INTO people(id, name) VALUES(?, ?)").use { stmt ->
+              stmt.setInt(1, id)
+              stmt.setString(2, name)
+              stmt.execute()
+            }
+        conn.commit()
+      }
+    }
+
+    fun listPeople(): List<Pair<Int, String>> {
+      return datasource.connection.use { conn ->
+        conn.createStatement().use { stmt ->
+              stmt.executeQuery("SELECT id, name FROM people ORDER BY id ASC").use { rs ->
+                    val results = mutableListOf<Pair<Int, String>>()
+                    while (rs.next()) {
+                      val id = rs.getInt(1)
+                      val name = rs.getString(2)
+                      results.add(id to name)
+                    }
+                    results.toList()
+                  }
+            }
+      }
+    }
+  }
+
+  @Qualifier
+  annotation class ForWrites
+
+  data class RootConfig(val data_sources: DataSourcesConfig) : Config
+}

--- a/misk/testing/build.gradle
+++ b/misk/testing/build.gradle
@@ -27,6 +27,7 @@ dependencies {
   compile dep.loggingImpl
   compile dep.okHttpMockWebServer
   compile dep.openTracingMock
+  compile dep.hsqldb
 }
 
 apply from: rootProject.file('gradle/gradle-mvn-push.gradle')


### PR DESCRIPTION
Allows binding a qualified or unqualified DataSource based on
configuration. The bound DataSources uses HikariCP for the connection
pool, with a limited set of configuration options.

See https://github.com/square/misk/issues/175