### PR TITLE
MiskCaller and authz support

### DIFF
--- a/misk/src/main/kotlin/misk/MiskCaller.kt
+++ b/misk/src/main/kotlin/misk/MiskCaller.kt
@@ -1,0 +1,21 @@
+package misk
+
+/** Information about the authenticated caller of a given action */
+data class MiskCaller(
+  /** Present if the caller is an authenticated peer service */
+  val service: String? = null,
+
+  /** Present if the caller is a human user, typically from an SSO proxy */
+  val user: String? = null,
+
+  /** Set of roles to which the human user belongs, typically provided by the SSO infrastructure */
+  val roles: Set<String> = setOf()
+) {
+  init {
+    require(service != null || user != null) { "one of service or user is required" }
+    require(service == null || user == null) { "only one of service or user is allowed" }
+  }
+
+  /** The identity of the calling principal, regardless of whether they are a service or a user */
+  val principal: String get() = service ?: user!!
+}

--- a/misk/src/main/kotlin/misk/scope/ActionScope.kt
+++ b/misk/src/main/kotlin/misk/scope/ActionScope.kt
@@ -20,11 +20,11 @@ class ActionScope @Inject internal constructor(
   private val providers: @JvmSuppressWildcards Map<Key<*>, Provider<ActionScopedProvider<*>>>
 ) : AutoCloseable {
   companion object {
-    private val tls = ThreadLocal<LinkedHashMap<Key<*>, Any>>()
+    private val tls = ThreadLocal<LinkedHashMap<Key<*>, Any?>>()
   }
 
   /** Starts the scope on a thread with the provided seed data */
-  fun enter(seedData: Map<Key<*>, Any>): ActionScope {
+  fun enter(seedData: Map<Key<*>, Any?>): ActionScope {
     check(tls.get() == null) {
       "cannot begin an ActionScope on a thread that is already running in an action scope"
     }
@@ -96,10 +96,11 @@ class ActionScope @Inject internal constructor(
       return cachedValue as T
     }
 
+    val value = providerFor(key as Key<*>).get()
+    threadState[key] = value
+
     @Suppress("UNCHECKED_CAST")
-    val value = providerFor(key as Key<Any>).get() as T
-    threadState[key] = value as Any
-    return value
+    return value as T
   }
 
   @Suppress("UNCHECKED_CAST")
@@ -110,7 +111,7 @@ class ActionScope @Inject internal constructor(
   }
 
   private class WrappedKFunction<T>(
-    val seedData: Map<Key<*>, Any>,
+    val seedData: Map<Key<*>, Any?>,
     val scope: ActionScope,
     val wrapped: KFunction<T>
   ) : KFunction<T> {

--- a/misk/src/main/kotlin/misk/scope/ActionScopedProviderModule.kt
+++ b/misk/src/main/kotlin/misk/scope/ActionScopedProviderModule.kt
@@ -63,7 +63,7 @@ abstract class ActionScopedProviderModule : KAbstractModule() {
   }
 
   /** Binds an annotation qualified [ActionScoped] along with its provider */
-  fun <T, A : Annotation> bindProvider(
+  fun <T> bindProvider(
     type: TypeLiteral<T>,
     providerType: KClass<out ActionScopedProvider<T>>,
     annotatedBy: Annotation? = null

--- a/misk/src/main/kotlin/misk/security/authz/AccessControlModule.kt
+++ b/misk/src/main/kotlin/misk/security/authz/AccessControlModule.kt
@@ -1,0 +1,49 @@
+package misk.security.authz
+
+import com.google.inject.TypeLiteral
+import misk.ApplicationInterceptor
+import misk.MiskCaller
+import misk.inject.addMultibinderBinding
+import misk.inject.newMultibinder
+import misk.inject.to
+import misk.scope.ActionScoped
+import misk.scope.ActionScopedProvider
+import misk.scope.ActionScopedProviderModule
+import javax.inject.Inject
+import kotlin.reflect.KClass
+
+/**
+ * Installs a binding for the [ActionScoped] [MiskCaller]?, along with support for
+ * perform access control checks for actions based on the incoming caller
+ */
+class AccessControlModule(
+  private val authenticators: List<KClass<out MiskCallerAuthenticator>>
+) : ActionScopedProviderModule() {
+
+  constructor(vararg authenticators: KClass<out MiskCallerAuthenticator>) :
+      this(authenticators.toList())
+
+  override fun configureProviders() {
+    bindProvider(miskCallerType, MiskCallerProvider::class)
+    binder().newMultibinder<MiskCallerAuthenticator>() // In case no authenticators are registered
+    authenticators.forEach { authenticator ->
+      binder().newMultibinder<MiskCallerAuthenticator>().addBinding().to(authenticator.java)
+    }
+    binder().addMultibinderBinding<ApplicationInterceptor.Factory>().to<AccessInterceptor.Factory>()
+  }
+
+  class MiskCallerProvider : ActionScopedProvider<MiskCaller?> {
+    @Inject lateinit
+    var authenticators: @JvmSuppressWildcards MutableList<out MiskCallerAuthenticator>
+
+    override fun get(): MiskCaller? {
+      return authenticators.mapNotNull {
+        it.getAuthenticatedCaller()
+      }.firstOrNull()
+    }
+  }
+
+  private companion object {
+    val miskCallerType = object : TypeLiteral<MiskCaller?>() {}
+  }
+}

--- a/misk/src/main/kotlin/misk/security/authz/AccessInterceptor.kt
+++ b/misk/src/main/kotlin/misk/security/authz/AccessInterceptor.kt
@@ -1,0 +1,56 @@
+package misk.security.authz
+
+import misk.Action
+import misk.ApplicationInterceptor
+import misk.Chain
+import misk.MiskCaller
+import misk.exceptions.UnauthenticatedException
+import misk.exceptions.UnauthorizedException
+import misk.scope.ActionScoped
+import javax.inject.Inject
+import kotlin.reflect.full.findAnnotation
+
+class AccessInterceptor private constructor(
+  private val allowedServices: Set<String>,
+  private val allowedRoles: Set<String>,
+  private val caller: ActionScoped<MiskCaller?>
+) : ApplicationInterceptor {
+
+  override fun intercept(chain: Chain): Any {
+    val caller = caller.get() ?: throw UnauthenticatedException()
+    if (!isAllowed(caller)) {
+      throw UnauthorizedException()
+    }
+
+    return chain.proceed(chain.args)
+  }
+
+  private fun isAllowed(caller: MiskCaller): Boolean {
+    // Allow if we don't have any requirements on service or role
+    if (allowedServices.isEmpty() && allowedRoles.isEmpty()) return true
+
+    // Allow if the caller has provided an allowed service
+    if (caller.service != null && allowedServices.contains(caller.service)) return true
+
+    // Allow if the caller has provided an allowed role
+    return caller.roles.any { allowedRoles.contains(it) }
+  }
+
+  class Factory @Inject internal constructor(
+    private val caller: @JvmSuppressWildcards ActionScoped<MiskCaller?>
+  ) : ApplicationInterceptor.Factory {
+    override fun create(action: Action): ApplicationInterceptor? {
+      val authenticated = action.function.findAnnotation<Authenticated>()
+      if (authenticated == null) {
+        // One of Authenticated or Unauthenticated must be specified
+        check(action.function.findAnnotation<Unauthenticated>() != null) {
+          "invalid action ${action.name}: one of @Authenticated or @Unauthenticated must be provided"
+        }
+        return null
+      }
+
+      return AccessInterceptor(authenticated.services.toSet(), authenticated.roles.toSet(), caller)
+    }
+  }
+}
+

--- a/misk/src/main/kotlin/misk/security/authz/Authenticated.kt
+++ b/misk/src/main/kotlin/misk/security/authz/Authenticated.kt
@@ -1,0 +1,21 @@
+package misk.security.authz
+
+import javax.inject.Qualifier
+
+/**
+ * Annotation indicating that a given action requires an authenticated caller - either a human
+ * in a specific role, or one of a set of services
+ */
+@Qualifier
+@Retention(AnnotationRetention.RUNTIME)
+@Target(AnnotationTarget.FUNCTION)
+annotation class Authenticated(val services: Array<String> = [], val roles: Array<String> = [])
+
+/**
+ * Annotation indicating that a given action supports unauthenticated access
+ */
+@Qualifier
+@Retention(AnnotationRetention.RUNTIME)
+@Target(AnnotationTarget.FUNCTION)
+annotation class Unauthenticated
+

--- a/misk/src/main/kotlin/misk/security/authz/MiskCallerAuthenticator.kt
+++ b/misk/src/main/kotlin/misk/security/authz/MiskCallerAuthenticator.kt
@@ -1,0 +1,12 @@
+package misk.security.authz
+
+import misk.MiskCaller
+
+/**
+ * Interface for determining the current [MiskCaller]. Typically use an [ActionScoped] [Request],
+ * [ActionScoped] [ClientCertSubject], etc to determine the caller based on request headers
+ * or client certificate information. The [ActionScoped] [MiskCaller]
+ */
+interface MiskCallerAuthenticator {
+  fun getAuthenticatedCaller() : MiskCaller?
+}

--- a/misk/src/main/kotlin/misk/security/authz/PeerServiceClientCertAuthenticator.kt
+++ b/misk/src/main/kotlin/misk/security/authz/PeerServiceClientCertAuthenticator.kt
@@ -1,0 +1,22 @@
+package misk.security.authz
+
+import misk.MiskCaller
+import misk.scope.ActionScoped
+import misk.security.ssl.ClientCertSubject
+import misk.security.x509.X500Name
+import javax.inject.Inject
+
+/**
+ * Derives authentication information for peer services from the OU of the client provided
+ * certificate.
+ *
+ * TODO(mmihic): Potentially allow configuration for which part of the X500 name defines
+ * the service name
+ */
+class PeerServiceClientCertAuthenticator @Inject internal constructor(
+  private @ClientCertSubject val clientCertSubject: @JvmSuppressWildcards ActionScoped<X500Name?>
+) : MiskCallerAuthenticator {
+  override fun getAuthenticatedCaller(): MiskCaller? {
+    return clientCertSubject.get()?.organizationalUnit?.let { MiskCaller(service = it) }
+  }
+}

--- a/misk/src/main/kotlin/misk/security/authz/ProxyUserAuthenticator.kt
+++ b/misk/src/main/kotlin/misk/security/authz/ProxyUserAuthenticator.kt
@@ -1,0 +1,31 @@
+package misk.security.authz
+
+import misk.MiskCaller
+import misk.scope.ActionScoped
+import misk.web.Request
+import javax.inject.Inject
+
+/**
+ * Derives authentication for end users coming in through a proxy fronted by SSO
+ *
+ * TODO(mmihic): Potentially allow configuration of which headers contain the user
+ * and which headers contain the role information
+ */
+class ProxyUserAuthenticator @Inject internal constructor(
+  private val currentRequest: ActionScoped<Request>
+) : MiskCallerAuthenticator {
+  override fun getAuthenticatedCaller(): MiskCaller? {
+    val request = currentRequest.get()
+    val user = request.headers[HEADER_FORWARDED_USER] ?: return null
+    val roles = request.headers[HEADER_FORWARDED_CAPABILITIES]
+        ?.split(',')
+        ?.map { it.trim() }
+        ?.toSet() ?: setOf()
+    return MiskCaller(user = user, roles = roles)
+  }
+
+  companion object {
+    const val HEADER_FORWARDED_USER = "HTTP_X_FORWARDED_USER"
+    const val HEADER_FORWARDED_CAPABILITIES = "HTTP_X_FORWARDED_CAPABILITIES"
+  }
+}

--- a/misk/src/test/kotlin/misk/scope/TestActionScopedProviderModule.kt
+++ b/misk/src/test/kotlin/misk/scope/TestActionScopedProviderModule.kt
@@ -1,7 +1,9 @@
 package misk.scope
 
+import com.google.inject.TypeLiteral
 import com.google.inject.name.Named
 import com.google.inject.name.Names
+import misk.exceptions.UnauthenticatedException
 import javax.inject.Inject
 
 class TestActionScopedProviderModule : ActionScopedProviderModule() {
@@ -9,17 +11,52 @@ class TestActionScopedProviderModule : ActionScopedProviderModule() {
     bindSeedData(String::class, Names.named("from-seed"))
     bindProvider(String::class, FooProvider::class, Names.named("foo"))
     bindProvider(String::class, BarProvider::class, Names.named("bar"))
+    bindProvider(String::class, ZedProvider::class, Names.named("zed"))
+    bindProvider(nullableStringTypeLiteral, NullableFooProvider::class, Names.named("nullable-foo"))
+    bindProvider(nullableStringTypeLiteral, NullableBasedOnFooProvider::class,
+        Names.named("nullable-based-on-foo"))
   }
 
   class BarProvider @Inject internal constructor(
-    @Named("from-seed") val seedData: ActionScoped<String>
+    @Named("from-seed") private val seedData: ActionScoped<String>
   ) : ActionScopedProvider<String> {
     override fun get(): String = "${seedData.get()} and bar"
   }
 
   class FooProvider @Inject internal constructor(
-    @Named("bar") val bar: ActionScoped<String>
+    @Named("bar") private val bar: ActionScoped<String>
   ) : ActionScopedProvider<String> {
     override fun get(): String = "${bar.get()} and foo!"
+  }
+
+  class ZedProvider @Inject internal constructor(
+    @Named("from-seed") private val seedData: ActionScoped<String>
+  ) : ActionScopedProvider<String> {
+    override fun get(): String {
+      val seedData = seedData.get()
+      if (seedData == "unauthenticated") throw UnauthenticatedException()
+      return "$seedData and zed*"
+    }
+  }
+
+  class NullableFooProvider @Inject internal constructor(
+    @Named("from-seed") private val seedData: ActionScoped<String>
+  ) : ActionScopedProvider<String?> {
+    override fun get(): String? {
+      val seedData = seedData.get()
+      return if (seedData == "null") return null else "$seedData and foo"
+    }
+  }
+
+  class NullableBasedOnFooProvider @Inject internal constructor(
+    @Named("nullable-foo") private val nullableFoo: ActionScoped<String?>
+  ) : ActionScopedProvider<String?> {
+    override fun get(): String? {
+      return nullableFoo.get()?.let { "from foo $it" }
+    }
+  }
+
+  companion object {
+    val nullableStringTypeLiteral = object : TypeLiteral<String?>() {}
   }
 }

--- a/misk/src/test/kotlin/misk/web/authz/AccessControlTest.kt
+++ b/misk/src/test/kotlin/misk/web/authz/AccessControlTest.kt
@@ -1,0 +1,260 @@
+package misk.web.authz
+
+import com.google.inject.Guice
+import com.google.inject.Provides
+import com.google.inject.name.Names
+import misk.MiskCaller
+import misk.MiskModule
+import misk.client.HttpClientEndpointConfig
+import misk.client.HttpClientModule
+import misk.client.HttpClientSSLConfig
+import misk.client.HttpClientsConfig
+import misk.inject.KAbstractModule
+import misk.inject.getInstance
+import misk.moshi.MoshiModule
+import misk.scope.ActionScoped
+import misk.security.authz.AccessControlModule
+import misk.security.authz.Authenticated
+import misk.security.authz.PeerServiceClientCertAuthenticator
+import misk.security.authz.ProxyUserAuthenticator
+import misk.security.authz.Unauthenticated
+import misk.security.ssl.CertStoreConfig
+import misk.security.ssl.Keystores
+import misk.security.ssl.TrustStoreConfig
+import misk.testing.MiskTest
+import misk.testing.MiskTestModule
+import misk.testing.TestWebModule
+import misk.web.Get
+import misk.web.WebActionModule
+import misk.web.WebModule
+import misk.web.WebSslConfig
+import misk.web.actions.WebAction
+import misk.web.jetty.JettyService
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@MiskTest(startService = true)
+internal class AccessControlTest {
+  @MiskTestModule
+  private val module = ServerModule()
+
+  @Inject
+  private lateinit var jetty: JettyService
+
+  private lateinit var httpClient: OkHttpClient
+  private lateinit var httpsClient: OkHttpClient
+
+  @BeforeEach
+  fun init() {
+    val clientInjector = Guice.createInjector(MoshiModule(), ClientModule(jetty))
+    httpClient = clientInjector.getInstance(Names.named("http"))
+    httpsClient = clientInjector.getInstance(Names.named("https"))
+  }
+
+  @Test fun allowUnauthenticated() {
+    val request = Request.Builder()
+        .url(jetty.httpServerUrl.newBuilder().encodedPath("/hello/anyone").build())
+        .get()
+        .build()
+
+    val response = httpClient.newCall(request).execute()
+    assertThat(response.code()).isEqualTo(200)
+    assertThat(response.body()?.string()!!).isEqualTo("hello (you are anonymous)")
+  }
+
+  @Test fun canAccessCallerIfAuthenticatedEventIfMethodUnauthenticated() {
+    val request = Request.Builder()
+        .url(jetty.httpsServerUrl!!.newBuilder().encodedPath("/hello/anyone").build())
+        .get()
+        .build()
+
+    val response = httpsClient.newCall(request).execute()
+    assertThat(response.code()).isEqualTo(200)
+    assertThat(response.body()?.string()!!).isEqualTo("hello (you are Client)")
+  }
+
+  @Test fun allowsServiceAuthenticationIfServiceInAllowedSet() {
+    val request = Request.Builder()
+        .url(jetty.httpsServerUrl!!.newBuilder().encodedPath("/hello/misk-client").build())
+        .get()
+        .build()
+
+    val response = httpsClient.newCall(request).execute()
+    assertThat(response.code()).isEqualTo(200)
+    assertThat(response.body()?.string()!!).isEqualTo("hello peer service Client")
+  }
+
+  @Test fun failServiceAuthenticationIfNoCallerProvided() {
+    val request = Request.Builder()
+        .url(jetty.httpServerUrl.newBuilder().encodedPath("/hello/misk-client").build())
+        .get()
+        .build()
+
+    val response = httpClient.newCall(request).execute()
+    assertThat(response.code()).isEqualTo(401)
+  }
+
+  @Test fun failServiceAuthenticationIfCallerIsUserOnly() {
+    val request = Request.Builder()
+        .url(jetty.httpServerUrl.newBuilder().encodedPath("/hello/misk-client").build())
+        .addHeader(ProxyUserAuthenticator.HEADER_FORWARDED_USER, "marge")
+        .addHeader(ProxyUserAuthenticator.HEADER_FORWARDED_CAPABILITIES, "eng,admin")
+        .get()
+        .build()
+
+    val response = httpClient.newCall(request).execute()
+    assertThat(response.code()).isEqualTo(403)
+  }
+
+  @Test fun failServiceAuthenticationIfServiceNotInAllowedSet() {
+    val request = Request.Builder()
+        .url(jetty.httpsServerUrl!!.newBuilder().encodedPath("/hello/not-misk-client").build())
+        .get()
+        .build()
+
+    val response = httpsClient.newCall(request).execute()
+    assertThat(response.code()).isEqualTo(403)
+  }
+
+  @Test fun allowsUserAuthenticationIfRoleInAllowedSet() {
+    val request = Request.Builder()
+        .url(jetty.httpServerUrl.newBuilder().encodedPath("/hello/admin").build())
+        .addHeader(ProxyUserAuthenticator.HEADER_FORWARDED_USER, "marge")
+        .addHeader(ProxyUserAuthenticator.HEADER_FORWARDED_CAPABILITIES, "eng,admin")
+        .get()
+        .build()
+
+    val response = httpClient.newCall(request).execute()
+    assertThat(response.code()).isEqualTo(200)
+    assertThat(response.body()!!.string()).isEqualTo("hello admin marge")
+  }
+
+  @Test fun failUserAuthenticationIfNoCallerProvided() {
+    val request = Request.Builder()
+        .url(jetty.httpServerUrl.newBuilder().encodedPath("/hello/admin").build())
+        .get()
+        .build()
+
+    val response = httpClient.newCall(request).execute()
+    assertThat(response.code()).isEqualTo(401)
+  }
+
+  @Test fun failUserAuthenticationIfCallerIsServiceOnly() {
+    val request = Request.Builder()
+        .url(jetty.httpsServerUrl!!.newBuilder().encodedPath("/hello/admin").build())
+        .get()
+        .build()
+
+    val response = httpsClient.newCall(request).execute()
+    assertThat(response.code()).isEqualTo(403)
+  }
+
+  @Test fun failUserAuthenticationIfRoleNotInAllowedSet() {
+    val request = Request.Builder()
+        .url(jetty.httpServerUrl.newBuilder().encodedPath("/hello/admin").build())
+        .addHeader(ProxyUserAuthenticator.HEADER_FORWARDED_USER, "marge")
+        .addHeader(ProxyUserAuthenticator.HEADER_FORWARDED_CAPABILITIES, "eng,operator")
+        .get()
+        .build()
+
+    val response = httpClient.newCall(request).execute()
+    assertThat(response.code()).isEqualTo(403)
+  }
+
+  /** Action that can be invoked without an authenticated caller */
+  class UnauthenticatedAction : WebAction {
+    @Inject lateinit var caller: @JvmSuppressWildcards ActionScoped<MiskCaller?>
+
+    @Get("/hello/anyone")
+    @Unauthenticated
+    fun get(): String = "hello (you are ${caller.get()?.principal ?: "anonymous"})"
+  }
+
+  /** Action that can only be invoked by the misk-client service */
+  class ClientServiceOnlyAction : WebAction {
+    @Inject lateinit var caller: @JvmSuppressWildcards ActionScoped<MiskCaller?>
+
+    @Get("/hello/misk-client")
+    @Authenticated(services = ["Client"])
+    fun get(): String = "hello peer service ${caller.get()?.service}"
+  }
+
+  /** Action that can be invoked by any service _other_ than misk-client */
+  class OtherServiceOnlyAction : WebAction {
+    @Inject lateinit var caller: @JvmSuppressWildcards ActionScoped<MiskCaller?>
+
+    @Get("/hello/not-misk-client")
+    @Authenticated(services = ["not-misk-client"])
+    fun get(): String = "hello peer service ${caller.get()?.service}"
+  }
+
+  /** Action that can be invoked by an admin user */
+  class AdminOnlyAction : WebAction {
+    @Inject lateinit var caller: @JvmSuppressWildcards ActionScoped<MiskCaller?>
+
+    @Get("/hello/admin")
+    @Authenticated(roles = ["admin"])
+    fun get(): String = "hello admin ${caller.get()?.user}"
+  }
+
+  class ClientModule(val jetty: JettyService) : KAbstractModule() {
+    override fun configure() {
+      install(HttpClientModule("https", Names.named("https")))
+      install(HttpClientModule("http", Names.named("http")))
+    }
+
+    @Provides
+    @Singleton
+    fun provideHttpClientConfig(): HttpClientsConfig {
+      return HttpClientsConfig(
+          endpoints = mapOf(
+              "https" to HttpClientEndpointConfig(
+                  jetty.httpsServerUrl!!.toString(),
+                  ssl = HttpClientSSLConfig(
+                      cert_store = CertStoreConfig(
+                          path = "src/test/resources/ssl/client_cert_key_combo.pem",
+                          passphrase = "clientpassword",
+                          type = Keystores.TYPE_PEM
+                      ),
+                      trust_store = TrustStoreConfig(
+                          path = "src/test/resources/ssl/server_cert.pem",
+                          type = Keystores.TYPE_PEM
+                      )
+                  )),
+              "http" to HttpClientEndpointConfig(jetty.httpServerUrl.toString())
+          ))
+
+    }
+  }
+
+  class ServerModule : KAbstractModule() {
+    override fun configure() {
+      install(MiskModule())
+      install(WebModule())
+      install(AccessControlModule(PeerServiceClientCertAuthenticator::class, ProxyUserAuthenticator::class))
+      install(WebActionModule.create<UnauthenticatedAction>())
+      install(WebActionModule.create<ClientServiceOnlyAction>())
+      install(WebActionModule.create<OtherServiceOnlyAction>())
+      install(WebActionModule.create<AdminOnlyAction>())
+      install(TestWebModule(
+          ssl = WebSslConfig(0,
+              cert_store = CertStoreConfig(
+                  path = "src/test/resources/ssl/server_cert_key_combo.pem",
+                  passphrase = "serverpassword",
+                  type = Keystores.TYPE_PEM
+              ),
+              trust_store = TrustStoreConfig(
+                  path = "src/test/resources/ssl/client_cert.pem",
+                  type = Keystores.TYPE_PEM
+              ),
+              mutual_auth = WebSslConfig.MutualAuth.REQUIRED)
+      ))
+    }
+  }
+
+}


### PR DESCRIPTION
Exposes an ActionScoped<MiskCaller> representing the service or user
calling into the current action. Provides authenticators which identify
the service via the OU of a client cert (if specified) or the user via
headers forwarded from trogdor. Provides an AccessInterceptor which
enforces annotation based authentication rules, only allowing calls into
actions from a designated set of allowed services or allowed roles.