### PR TITLE
Change DataSourcesConfig to inherit from LinkedHashMap

### DIFF
--- a/misk/src/main/kotlin/misk/jdbc/DataSourceConfig.kt
+++ b/misk/src/main/kotlin/misk/jdbc/DataSourceConfig.kt
@@ -36,4 +36,7 @@ data class DataSourceConfig(
 )
 
 /** Top-level configuration element for all databases */
-data class DataSourcesConfig(val databases: Map<String, DataSourceConfig>) : Config
+class DataSourcesConfig : LinkedHashMap<String, DataSourceConfig>, Config {
+  constructor() : super()
+  constructor(m : Map<String, DataSourceConfig>) : super(m)
+}

--- a/misk/src/main/kotlin/misk/jdbc/DataSourceModule.kt
+++ b/misk/src/main/kotlin/misk/jdbc/DataSourceModule.kt
@@ -38,7 +38,7 @@ class DataSourceModule constructor(
     @Inject lateinit var datasourcesConfig: DataSourcesConfig
 
     override fun get(): DataSource {
-      val config = datasourcesConfig.databases[datasourceName]
+      val config = datasourcesConfig[datasourceName]
           ?: throw IllegalStateException("no datasource named $datasourceName")
 
       val hikariConfig = HikariConfig()

--- a/misk/src/test/resources/test_data_source_app-common.yaml
+++ b/misk/src/test/resources/test_data_source_app-common.yaml
@@ -1,25 +1,24 @@
 data_sources:
-  databases:
-    exemplar:
-      type: HSQLDB
-      username: snork
-      password: florp
-      database: lorfil
+  exemplar:
+    type: HSQLDB
+    username: snork
+    password: florp
+    database: lorfil
 
-    exemplar-incorrect-username:
-      type: HSQLDB
-      username: INCORRECT_USERNAME
-      password: florp
-      database: lorfil
+  exemplar-incorrect-username:
+    type: HSQLDB
+    username: INCORRECT_USERNAME
+    password: florp
+    database: lorfil
 
-    exemplar-incorrect-password:
-      type: HSQLDB
-      username: snork
-      password: INCORRECT_PASSWORD
-      database: lorfil
+  exemplar-incorrect-password:
+    type: HSQLDB
+    username: snork
+    password: INCORRECT_PASSWORD
+    database: lorfil
 
-    exemplar-mysql:
-      type: MYSQL
-      username: snork
-      password: florp
-      database: lorfil
+  exemplar-mysql:
+    type: MYSQL
+    username: snork
+    password: florp
+    database: lorfil


### PR DESCRIPTION
As a data class with a Map property, the DataSourcesConfig class
adds an additional level of nesting to configuration.

Eg:
```
data_sources:
  databases:
    exemplar:
      ...
    exemplar-readonly:
      ...
```

Rather than:
```
data_sources:
  exemplar:
    ...
  exemplar-readonly:
    ...
```

To achieve this DataSourcesConfig now implements the Map interface
such that when the Config object is being built from yaml the key-value
pairs within data_sources are interpreted as a Map on the root config.
(Jackson needs a concrete implementation of Map, which is why this is
done by inheriting from LinkedHashMap.)

The result is Config.data_sources is a Map<String, DataSourceConfig>,
but will still be bound by Guice as DataSourcesConfig.