### PR TITLE
Add a JPAEntityModule for binding entities for a DataSource

### DIFF
--- a/misk/src/main/kotlin/misk/inject/Guice.kt
+++ b/misk/src/main/kotlin/misk/inject/Guice.kt
@@ -84,10 +84,21 @@ inline fun <reified T : Any> Injector.getInstance(annotation: Annotation? = null
   return getInstance(key)
 }
 
+@Suppress("UNCHECKED_CAST")
+fun <T : Any> Injector.getSetOf(
+  type: KClass<T>,
+  annotation: KClass<out Annotation>? = null
+) : Set<T> = getInstance(parameterizedKeyOf<Set<*>>(type, annotation)) as Set<T>
+
 inline fun <reified T : Any> keyOf(): Key<T> = Key.get(T::class.java)
 inline fun <reified T : Any> keyOf(a: Annotation): Key<T> = Key.get(T::class.java, a)
 inline fun <reified T : Any, A : Annotation> keyOf(a: KClass<A>): Key<T> =
     Key.get(T::class.java, a.java)
+
+inline fun <reified T : Any> parameterizedKeyOf(
+  type: KClass<*>,
+  annotation: KClass<out Annotation>? = null
+) = parameterizedType<T>(type.java).typeLiteral().toKey(annotation?.java)
 
 fun <T : Any, A : Annotation> keyOf(t: KClass<T>, a: KClass<A>): Key<T> = Key.get(t.java, a.java)
 

--- a/misk/src/main/kotlin/misk/jdbc/JPAEntity.kt
+++ b/misk/src/main/kotlin/misk/jdbc/JPAEntity.kt
@@ -1,0 +1,7 @@
+package misk.jdbc
+
+/**
+ * [JPAEntity] is a wrapper class that allows for unqualified
+ * binding of JPA entity classes without collision.
+ */
+data class JPAEntity(val entity: Class<*>)

--- a/misk/src/main/kotlin/misk/jdbc/JPAEntityModule.kt
+++ b/misk/src/main/kotlin/misk/jdbc/JPAEntityModule.kt
@@ -1,0 +1,43 @@
+package misk.jdbc
+
+import misk.inject.KAbstractModule
+import misk.inject.addMultibinderBinding
+import misk.inject.newMultibinder
+import kotlin.reflect.KClass
+
+/**
+ * Binds a Set<[JPAEntity]> intended for the [DataSource] annotated by [annotatedBy].
+ */
+class JPAEntityModule (
+  private val annotatedBy: Class<out Annotation>? = null,
+  private val entities: Set<Class<*>>
+) : KAbstractModule() {
+
+  override fun configure() {
+    binder().newMultibinder<JPAEntity>(annotatedBy)
+
+    for (entity in entities) {
+      binder().addMultibinderBinding<JPAEntity>(annotatedBy).toInstance(JPAEntity(entity))
+    }
+  }
+
+  companion object {
+    fun create(entities: Set<Class<*>>) = create(null, entities)
+
+    fun create(annotatedBy: Annotation?, entities: Set<Class<*>>) =
+      create(annotatedBy?.let { it::class.java }, entities)
+
+    fun <A : Annotation> create(annotatedBy: Class<A>?, entities: Set<Class<*>>) =
+      JPAEntityModule(annotatedBy, entities.toSet())
+
+    @JvmName("-createKClass")
+    fun create(entities: Set<KClass<*>>) = create(null, entities)
+
+    @JvmName("-createKClass")
+    fun create(annotatedBy: Annotation?, entities: Set<KClass<*>>) =
+      create(annotatedBy?.let { it::class }, entities)
+
+    fun <A : Annotation> create(annotatedBy: KClass<A>?, entities: Set<KClass<*>>) =
+      JPAEntityModule(annotatedBy?.java, entities.map { it.java }.toSet())
+  }
+}

--- a/misk/src/test/kotlin/misk/jdbc/JPAEntityModuleTest.kt
+++ b/misk/src/test/kotlin/misk/jdbc/JPAEntityModuleTest.kt
@@ -1,0 +1,51 @@
+package misk.jdbc
+
+import com.google.inject.Guice
+import misk.inject.getSetOf
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import javax.inject.Qualifier
+import kotlin.reflect.KClass
+
+internal class JPAEntityModuleTest {
+
+  @Test fun multipleDataSources() {
+    val dinosaurs = setOf(Triceratops::class, Stegosaurus::class)
+    val shapes = setOf(Square::class, Circle::class)
+
+    val injector = Guice.createInjector(
+      JPAEntityModule.create(dinosaurs),
+      JPAEntityModule.create(annotatedBy = Shapes::class, entities = shapes)
+    )
+
+    assertEntities(injector.getSetOf(JPAEntity::class), dinosaurs)
+    assertEntities(injector.getSetOf(JPAEntity::class, Shapes::class), shapes)
+  }
+
+  @Test fun multipleModulesSameDataSource() {
+    val injector = Guice.createInjector(
+      JPAEntityModule.create(setOf(Triceratops::class)),
+      JPAEntityModule.create(setOf(Stegosaurus::class)),
+      JPAEntityModule.create(annotatedBy = Shapes::class, entities = setOf(Square::class)),
+      JPAEntityModule.create(annotatedBy = Shapes::class, entities = setOf(Circle::class))
+    )
+
+    val dinosaurs = setOf(Triceratops::class, Stegosaurus::class)
+    val shapes = setOf(Square::class, Circle::class)
+
+    assertEntities(injector.getSetOf(JPAEntity::class), dinosaurs)
+    assertEntities(injector.getSetOf(JPAEntity::class, Shapes::class), shapes)
+  }
+
+  fun assertEntities(actual: Set<JPAEntity>, expected: Set<KClass<*>>) =
+    assertThat(actual.map { it.entity }).containsExactlyElementsOf(expected.map { it.java })
+}
+
+@Qualifier
+annotation class Shapes
+
+class Square
+class Circle
+
+class Triceratops
+class Stegosaurus


### PR DESCRIPTION
JPA entities can be bound for a DataSource with the JPAEntityModule.
Multiple modules can contribute entities for a particular DataSource
using its qualifying annotation (or lack thereof).

Higher-level abstractions such as Hibernate can use the entities bound
for a particular DataSource as part of its relational mapping.

The annotation `@JvmName("-createKClass")` prevents declaration clashes
on the JVM due to type erasure. Declarations such as `fun create(entities: Set<KClass<*>>)`
and `fun create(entities: Set<Class<*>>)` will have the same signature.

The "-" prefix in the above annotation also "hides" the method from Java developers
as Java does not allow the hyphen even though the JVM does. Discussion here:
https://discuss.kotlinlang.org/t/more-characters-allowed-for-identifiers-than-grammar-specifies-what-is-supported/2359/2