### PR TITLE
Implement support for single-column projections.

### DIFF
--- a/misk/src/main/kotlin/misk/hibernate/Projection.kt
+++ b/misk/src/main/kotlin/misk/hibernate/Projection.kt
@@ -5,9 +5,9 @@ interface Projection {
 }
 
 /**
- * Annotates a parameter of a data class [Projection] to indicate which column (or path of
- * columns) to populate the parameter with.
+ * Annotates a parameter of a [Projection] data class to indicate which column (or path of columns)
+ * to populate the parameter with.
  */
 annotation class Property(
-  val value: String
+  val path: String
 )

--- a/misk/src/main/kotlin/misk/hibernate/Query.kt
+++ b/misk/src/main/kotlin/misk/hibernate/Query.kt
@@ -5,10 +5,8 @@ import kotlin.reflect.KClass
 /** Base class for SQL queries. */
 interface Query<T> {
   fun uniqueResult(session: Session): T?
-  fun <P : Projection> uniqueResultAs(session: Session, projection: KClass<P>): P?
 
   fun list(session: Session): List<T>
-  fun <P : Projection> listAs(session: Session, projection: KClass<P>): List<P>
 
   /** Creates instances of queries. */
   interface Factory {
@@ -16,15 +14,10 @@ interface Query<T> {
   }
 }
 
-inline fun <reified P : Projection> Query<*>.listAs(session: Session) = listAs(session, P::class)
-
-inline fun <reified P : Projection> Query<*>.uniqueResultAs(session: Session) = uniqueResultAs(
-    session, P::class)
-
 inline fun <reified T : Query<*>> Query.Factory.newQuery(): T = newQuery(T::class)
 
 /**
- * Annotations a function on a subinterface of [Query] to indicate which column (or path of columns)
+ * Annotates a function on a subinterface of [Query] to indicate which column (or path of columns)
  * it constrains and using which operator.
  */
 annotation class Constraint(
@@ -60,3 +53,12 @@ enum class Operator {
   /** `a IS NULL` */
   IS_NULL
 }
+
+/**
+ * Annotates a function on a subinterface of [Query] to execute a `SELECT` query. Functions with
+ * this annotation must return a `List` to fetch multiple rows results, or a regular type to fetch
+ * a unique result.
+ */
+annotation class Select(
+  val path: String = ""
+)

--- a/misk/src/test/kotlin/misk/hibernate/ByteStringColumnTest.kt
+++ b/misk/src/test/kotlin/misk/hibernate/ByteStringColumnTest.kt
@@ -60,25 +60,25 @@ class ByteStringColumnTest {
     }
 
     transacter.transaction { session ->
-      assertThat(queryFactory.newQuery(TextHashQuery::class)
+      assertThat(queryFactory.newQuery<TextHashQuery>()
           .hashLessThan(v1.hash)
-          .listAs<TextAndHash>(session))
+          .listAsTextAndHash(session))
           .isEmpty()
-      assertThat(queryFactory.newQuery(TextHashQuery::class)
+      assertThat(queryFactory.newQuery<TextHashQuery>()
           .hashLessThan(v2.hash)
-          .listAs<TextAndHash>(session))
+          .listAsTextAndHash(session))
           .containsExactly(v1)
-      assertThat(queryFactory.newQuery(TextHashQuery::class)
+      assertThat(queryFactory.newQuery<TextHashQuery>()
           .hashLessThan(v3.hash)
-          .listAs<TextAndHash>(session))
+          .listAsTextAndHash(session))
           .containsExactly(v1, v2)
-      assertThat(queryFactory.newQuery(TextHashQuery::class)
+      assertThat(queryFactory.newQuery<TextHashQuery>()
           .hashLessThan(v4.hash)
-          .listAs<TextAndHash>(session))
+          .listAsTextAndHash(session))
           .containsExactly(v1, v2, v3)
-      assertThat(queryFactory.newQuery(TextHashQuery::class)
+      assertThat(queryFactory.newQuery<TextHashQuery>()
           .hashLessThan(ByteString.decodeHex("ff00"))
-          .listAs<TextAndHash>(session))
+          .listAsTextAndHash(session))
           .containsExactly(v1, v2, v3, v4)
     }
   }
@@ -136,5 +136,8 @@ class ByteStringColumnTest {
 
     @Constraint(path = "hash", operator = Operator.LT)
     fun hashLessThan(hash: ByteString): TextHashQuery
+
+    @Select
+    fun listAsTextAndHash(session: Session): List<TextAndHash>
   }
 }

--- a/misk/src/test/kotlin/misk/hibernate/ReflectionQueryFactoryTest.kt
+++ b/misk/src/test/kotlin/misk/hibernate/ReflectionQueryFactoryTest.kt
@@ -36,32 +36,32 @@ class ReflectionQueryFactoryTest {
 
       assertThat(queryFactory.newQuery<OperatorsMovieQuery>()
           .releaseDateLessThan(m3.releaseDate)
-          .listAs<NameAndReleaseDate>(session))
+          .listAsNameAndReleaseDate(session))
           .containsExactly(m1, m2)
 
       assertThat(queryFactory.newQuery<OperatorsMovieQuery>()
           .releaseDateLessThanOrEqualTo(m3.releaseDate)
-          .listAs<NameAndReleaseDate>(session))
+          .listAsNameAndReleaseDate(session))
           .containsExactly(m1, m2, m3)
 
       assertThat(queryFactory.newQuery<OperatorsMovieQuery>()
           .releaseDateEqualTo(m3.releaseDate)
-          .listAs<NameAndReleaseDate>(session))
+          .listAsNameAndReleaseDate(session))
           .containsExactly(m3)
 
       assertThat(queryFactory.newQuery<OperatorsMovieQuery>()
           .releaseDateGreaterThanOrEqualTo(m3.releaseDate)
-          .listAs<NameAndReleaseDate>(session))
+          .listAsNameAndReleaseDate(session))
           .containsExactly(m3, m4, m5)
 
       assertThat(queryFactory.newQuery<OperatorsMovieQuery>()
           .releaseDateGreaterThan(m3.releaseDate)
-          .listAs<NameAndReleaseDate>(session))
+          .listAsNameAndReleaseDate(session))
           .containsExactly(m4, m5)
 
       assertThat(queryFactory.newQuery<OperatorsMovieQuery>()
           .releaseDateNotEqualTo(m3.releaseDate)
-          .listAs<NameAndReleaseDate>(session))
+          .listAsNameAndReleaseDate(session))
           .containsExactly(m1, m2, m4, m5)
     }
   }
@@ -88,32 +88,32 @@ class ReflectionQueryFactoryTest {
 
       assertThat(queryFactory.newQuery<OperatorsMovieQuery>()
           .releaseDateLessThan(null)
-          .listAs<NameAndReleaseDate>(session))
+          .listAsNameAndReleaseDate(session))
           .isEmpty()
 
       assertThat(queryFactory.newQuery<OperatorsMovieQuery>()
           .releaseDateLessThanOrEqualTo(null)
-          .listAs<NameAndReleaseDate>(session))
+          .listAsNameAndReleaseDate(session))
           .isEmpty()
 
       assertThat(queryFactory.newQuery<OperatorsMovieQuery>()
           .releaseDateEqualTo(null)
-          .listAs<NameAndReleaseDate>(session))
+          .listAsNameAndReleaseDate(session))
           .isEmpty()
 
       assertThat(queryFactory.newQuery<OperatorsMovieQuery>()
           .releaseDateGreaterThanOrEqualTo(null)
-          .listAs<NameAndReleaseDate>(session))
+          .listAsNameAndReleaseDate(session))
           .isEmpty()
 
       assertThat(queryFactory.newQuery<OperatorsMovieQuery>()
           .releaseDateGreaterThan(null)
-          .listAs<NameAndReleaseDate>(session))
+          .listAsNameAndReleaseDate(session))
           .isEmpty()
 
       assertThat(queryFactory.newQuery<OperatorsMovieQuery>()
           .releaseDateNotEqualTo(null)
-          .listAs<NameAndReleaseDate>(session))
+          .listAsNameAndReleaseDate(session))
           .isEmpty()
     }
   }
@@ -133,12 +133,12 @@ class ReflectionQueryFactoryTest {
 
       assertThat(queryFactory.newQuery<OperatorsMovieQuery>()
           .releaseDateIsNull()
-          .listAs<NameAndReleaseDate>(session))
+          .listAsNameAndReleaseDate(session))
           .containsExactly(m98, m99)
 
       assertThat(queryFactory.newQuery<OperatorsMovieQuery>()
           .releaseDateIsNotNull()
-          .listAs<NameAndReleaseDate>(session))
+          .listAsNameAndReleaseDate(session))
           .containsExactly(m1, m2)
     }
   }
@@ -156,12 +156,12 @@ class ReflectionQueryFactoryTest {
 
       assertThat(queryFactory.newQuery<OperatorsMovieQuery>()
           .releaseDateInVararg(m1.releaseDate, m3.releaseDate)
-          .listAs<NameAndReleaseDate>(session))
+          .listAsNameAndReleaseDate(session))
           .containsExactly(m1, m3)
 
       assertThat(queryFactory.newQuery<OperatorsMovieQuery>()
           .releaseDateInCollection(listOf(m1.releaseDate, m3.releaseDate))
-          .listAs<NameAndReleaseDate>(session))
+          .listAsNameAndReleaseDate(session))
           .containsExactly(m1, m3)
     }
   }
@@ -177,12 +177,12 @@ class ReflectionQueryFactoryTest {
 
       assertThat(queryFactory.newQuery<OperatorsMovieQuery>()
           .releaseDateInVararg(m1.releaseDate, null)
-          .listAs<NameAndReleaseDate>(session))
+          .listAsNameAndReleaseDate(session))
           .containsExactly(m1)
 
       assertThat(queryFactory.newQuery<OperatorsMovieQuery>()
           .releaseDateInCollection(listOf(m1.releaseDate, null))
-          .listAs<NameAndReleaseDate>(session))
+          .listAsNameAndReleaseDate(session))
           .containsExactly(m1)
     }
   }
@@ -196,12 +196,48 @@ class ReflectionQueryFactoryTest {
 
       assertThat(queryFactory.newQuery<OperatorsMovieQuery>()
           .releaseDateInVararg()
-          .listAs<NameAndReleaseDate>(session))
+          .listAsNameAndReleaseDate(session))
           .isEmpty()
 
       assertThat(queryFactory.newQuery<OperatorsMovieQuery>()
           .releaseDateInCollection(listOf())
-          .listAs<NameAndReleaseDate>(session))
+          .listAsNameAndReleaseDate(session))
+          .isEmpty()
+    }
+  }
+
+  @Test
+  fun singleColumnProjection() {
+    val m1 = NameAndReleaseDate("Rocky 1", LocalDate.of(2018, 1, 1))
+    val m2 = NameAndReleaseDate("Rocky 2", LocalDate.of(2018, 1, 2))
+    val m3 = NameAndReleaseDate("Rocky 3", LocalDate.of(2018, 1, 3))
+
+    transacter.transaction { session ->
+      session.save(DbMovie(m1.name, m1.releaseDate))
+      session.save(DbMovie(m2.name, m2.releaseDate))
+      session.save(DbMovie(m3.name, m3.releaseDate))
+
+      assertThat(queryFactory.newQuery<OperatorsMovieQuery>()
+          .releaseDateEqualTo(m1.releaseDate)
+          .uniqueName(session))
+          .isEqualTo(m1.name)
+
+      assertThat(queryFactory.newQuery<OperatorsMovieQuery>()
+          .releaseDateLessThanOrEqualTo(m2.releaseDate)
+          .listAsNames(session))
+          .containsExactly(m1.name, m2.name)
+    }
+  }
+
+  @Test
+  fun singleColumnProjectionIsEmpty() {
+    transacter.transaction { session ->
+      assertThat(queryFactory.newQuery<OperatorsMovieQuery>()
+          .uniqueName(session))
+          .isNull()
+
+      assertThat(queryFactory.newQuery<OperatorsMovieQuery>()
+          .listAsNames(session))
           .isEmpty()
     }
   }
@@ -236,6 +272,15 @@ class ReflectionQueryFactoryTest {
 
     @Constraint(path = "release_date", operator = Operator.IS_NULL)
     fun releaseDateIsNull(): OperatorsMovieQuery
+
+    @Select
+    fun listAsNameAndReleaseDate(session: Session): List<NameAndReleaseDate>
+
+    @Select("name")
+    fun uniqueName(session: Session): String?
+
+    @Select("name")
+    fun listAsNames(session: Session): List<String>
   }
 
   data class NameAndReleaseDate(

--- a/misk/src/test/kotlin/misk/hibernate/TransacterTest.kt
+++ b/misk/src/test/kotlin/misk/hibernate/TransacterTest.kt
@@ -48,14 +48,14 @@ class TransacterTest {
 
       val lauraDernMovies = queryFactory.newQuery<CharacterQuery>()
           .actorName("Laura Dern")
-          .listAs<MovieNameAndReleaseDate>(session)
+          .listAsMovieNameAndReleaseDate(session)
       assertThat(lauraDernMovies).containsExactly(
-          MovieNameAndReleaseDate("Star Wars", LocalDate.of(1977, 5, 25)),
-          MovieNameAndReleaseDate("Jurassic Park", LocalDate.of(1993, 6, 9)))
+          NameAndReleaseDate("Star Wars", LocalDate.of(1977, 5, 25)),
+          NameAndReleaseDate("Jurassic Park", LocalDate.of(1993, 6, 9)))
 
       val actorsInOldMovies = queryFactory.newQuery<CharacterQuery>()
           .movieReleaseDateBefore(LocalDate.of(1980, 1, 1))
-          .listAs<ActorAndReleaseDate>(session)
+          .listAsActorAndReleaseDate(session)
       assertThat(actorsInOldMovies).containsExactly(
           ActorAndReleaseDate("Laura Dern", LocalDate.of(1977, 5, 25)),
           ActorAndReleaseDate("Carrie Fisher", LocalDate.of(1977, 5, 25)))
@@ -99,16 +99,19 @@ class TransacterTest {
     @Constraint("actor.name")
     fun actorName(name: String): CharacterQuery
 
-    @Constraint("movie.name")
-    fun movieName(name: String): CharacterQuery
-
     @Constraint(path = "movie.release_date", operator = Operator.LT)
     fun movieReleaseDateBefore(upperBound: LocalDate): CharacterQuery
+
+    @Select("movie")
+    fun listAsMovieNameAndReleaseDate(session: Session): List<NameAndReleaseDate>
+
+    @Select
+    fun listAsActorAndReleaseDate(session: Session): List<ActorAndReleaseDate>
   }
 
-  data class MovieNameAndReleaseDate(
-    @Property("movie.name") var movieName: String,
-    @Property("movie.release_date") var movieReleaseDate: LocalDate?
+  data class NameAndReleaseDate(
+    @Property("name") var movieName: String,
+    @Property("release_date") var movieReleaseDate: LocalDate?
   ) : Projection
 
   data class ActorAndReleaseDate(


### PR DESCRIPTION
This changes the way that projections are accessed. Previously we had
generic listAs() and uniqueResultAs() functions that accepted a type
parameter. With this change each query class exposes its supported
projections.

There are two small benefits here:
 - we can reuse projections. Whether we get the movie NameAndReleaseDate
   from a movie query or a character query, both work because we can
   combine paths.
 - Projections are now linked to the query classes, which should make it
   possible to statically check types in an annotation processor.

Closes: https://github.com/square/misk/issues/247