### PR TITLE
LogCollector for testing

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,6 @@ ext {
           moshi                : 'com.squareup.moshi:moshi-kotlin:1.5.0',
           loggingApi           : 'io.github.microutils:kotlin-logging:1.4.9',
           wireRuntime          : 'com.squareup.wire:wire-runtime:2.3.0-RC1',
-          loggingImpl          : 'org.apache.logging.log4j:log4j-slf4j-impl:2.10.0',
           jacksonDatabind      : 'com.fasterxml.jackson.core:jackson-databind:2.9.3',
           jacksonDataformatYaml: 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.9.3',
           jacksonKotlin        : 'com.fasterxml.jackson.module:jackson-module-kotlin:2.9.3',

--- a/misk/testing/build.gradle
+++ b/misk/testing/build.gradle
@@ -32,7 +32,7 @@ dependencies {
   compile dep.junitParams
   compile dep.junitEngine
   compile dep.assertj
-  compile dep.loggingImpl
+  compile dep.logbackClassic
   compile dep.okHttpMockWebServer
   compile dep.openTracingMock
   compile dep.hsqldb

--- a/misk/testing/src/main/kotlin/misk/logging/LogCollector.kt
+++ b/misk/testing/src/main/kotlin/misk/logging/LogCollector.kt
@@ -1,0 +1,56 @@
+package misk.logging
+
+import ch.qos.logback.classic.Level
+import ch.qos.logback.classic.spi.ILoggingEvent
+import kotlin.reflect.KClass
+
+/**
+ * Collects log messages so they may be asserted on for testing.
+ *
+ * To use it, add the [LogCollectorModule] to your test. You’ll need `@MiskTest` with services
+ * started because this uses a service to install a log appender for the duration of the test.
+ *
+ * In your test method you should perform some action that logs, then use an injected `logCollector`
+ * to verify that the expected logs were emitted:
+ *
+ * ```
+ * @MiskTest(startService = true)
+ * class MyTest {
+ *   @MiskTestModule
+ *   val module = Modules.combine(
+ *       MiskModule(),
+ *       LogCollectorModule(),
+ *       ...
+ *   )
+ *
+ *   @Inject lateinit var logCollector: LogCollector
+ *
+ *   @Test
+ *   fun test() {
+ *     someMethodThatLogs()
+ *     assertThat(logCollector.takeMessages()).containsExactly("this is the only logged message!")
+ *   }
+ * }
+ * ```
+ *
+ * Use the optional parameters of [takeMessages] to constrain which log messages are returned.
+ */
+interface LogCollector {
+  /**
+   * Removes all collected log messages and returns those that match the requested criteria.
+   */
+  fun takeMessages(
+    loggerClass: KClass<*>? = null,
+    minLevel: Level = Level.INFO,
+    pattern: Regex? = null
+  ): List<String>
+
+  /**
+   * Removes all collected log events and returns those that match the requested criteria.
+   */
+  fun takeEvents(
+    loggerClass: KClass<*>? = null,
+    minLevel: Level = Level.INFO,
+    pattern: Regex? = null
+  ): List<ILoggingEvent>
+}

--- a/misk/testing/src/main/kotlin/misk/logging/LogCollectorModule.kt
+++ b/misk/testing/src/main/kotlin/misk/logging/LogCollectorModule.kt
@@ -1,0 +1,12 @@
+package misk.logging
+
+import com.google.common.util.concurrent.Service
+import misk.inject.KAbstractModule
+import misk.inject.addMultibinderBinding
+
+class LogCollectorModule : KAbstractModule() {
+  override fun configure() {
+    bind(LogCollector::class.java).to(RealLogCollector::class.java)
+    binder().addMultibinderBinding<Service>().to(RealLogCollector::class.java)
+  }
+}

--- a/misk/testing/src/main/kotlin/misk/logging/RealLogCollector.kt
+++ b/misk/testing/src/main/kotlin/misk/logging/RealLogCollector.kt
@@ -1,0 +1,62 @@
+package misk.logging
+
+import ch.qos.logback.classic.Level
+import ch.qos.logback.classic.Logger
+import ch.qos.logback.classic.spi.ILoggingEvent
+import ch.qos.logback.core.UnsynchronizedAppenderBase
+import com.google.common.util.concurrent.AbstractIdleService
+import com.google.common.util.concurrent.Service.State.NEW
+import org.slf4j.LoggerFactory
+import javax.inject.Singleton
+import kotlin.reflect.KClass
+
+@Singleton
+internal class RealLogCollector : AbstractIdleService(), LogCollector {
+  private val events = mutableListOf<ILoggingEvent>()
+
+  private val appender = object : UnsynchronizedAppenderBase<ILoggingEvent>() {
+    override fun append(event: ILoggingEvent) {
+      synchronized(this@RealLogCollector) {
+        events.add(event)
+      }
+    }
+  }
+
+  override fun takeMessages(
+    loggerClass: KClass<*>?,
+    minLevel: Level,
+    pattern: Regex?
+  ): List<String> {
+    return takeEvents(loggerClass, minLevel, pattern).map { it.message.toString() }
+  }
+
+  override fun takeEvents(
+    loggerClass: KClass<*>?,
+    minLevel: Level,
+    pattern: Regex?
+  ): List<ILoggingEvent> {
+    require(state() != NEW) { "not collecting logs: did you forget to start the service?" }
+
+    synchronized(this@RealLogCollector) {
+      val result = events.filter {
+        (loggerClass == null || loggerClass.qualifiedName == it.loggerName) &&
+            it.level.toInt() >= minLevel.toInt() &&
+            (pattern == null || pattern.containsMatchIn(it.message.toString()))
+      }
+
+      events.clear()
+
+      return result
+    }
+  }
+
+  override fun startUp() {
+    appender.start()
+    (LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME) as Logger).addAppender(appender)
+  }
+
+  override fun shutDown() {
+    (LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME) as Logger).detachAppender(appender)
+    appender.stop()
+  }
+}

--- a/misk/testing/src/test/kotlin/misk/logging/LogCollectorTest.kt
+++ b/misk/testing/src/test/kotlin/misk/logging/LogCollectorTest.kt
@@ -1,0 +1,74 @@
+package misk.logging
+
+import ch.qos.logback.classic.Level
+import com.google.inject.util.Modules
+import misk.MiskModule
+import misk.testing.MiskTest
+import misk.testing.MiskTestModule
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import javax.inject.Inject
+
+@MiskTest(startService = true)
+class LogCollectorTest {
+  @MiskTestModule
+  val module = Modules.combine(
+      MiskModule(),
+      LogCollectorModule()
+  )
+
+  @Inject lateinit var logCollector: LogCollector
+
+  @Test
+  fun happyPath() {
+    val logger = getLogger<LogCollectorTest>()
+
+    logger.info("this is a log message!")
+    assertThat(logCollector.takeMessages()).containsExactly("this is a log message!")
+
+    logger.info("another log message")
+    logger.info("and a third!")
+    assertThat(logCollector.takeMessages()).containsExactly("another log message", "and a third!")
+  }
+
+  @Test
+  fun filterByLevel() {
+    val logger = getLogger<LogCollectorTest>()
+
+    logger.debug("this is DEBUG.")
+    logger.info("this is INFO.")
+    logger.warn("this is WARN!")
+    assertThat(logCollector.takeMessages(minLevel = Level.INFO))
+        .containsExactly("this is INFO.", "this is WARN!")
+  }
+
+  @Test
+  fun filterByLogger() {
+    val testLogger = getLogger<LogCollectorTest>()
+    val realLogger = getLogger<RealLogCollector>()
+
+    testLogger.info("this is from the test logger")
+    realLogger.info("this is from the real logger")
+    assertThat(logCollector.takeMessages(loggerClass = RealLogCollector::class))
+        .containsExactly("this is from the real logger")
+  }
+
+  @Test
+  fun filterByPattern() {
+    val logger = getLogger<LogCollectorTest>()
+
+    logger.info("this matches the pattern")
+    logger.info("this does not match the pattern")
+    assertThat(logCollector.takeMessages(pattern = Regex("m[a-z]tch[a-z]s")))
+        .containsExactly("this matches the pattern")
+  }
+
+  @Test
+  fun takeConsumesUnmatched() {
+    val logger = getLogger<LogCollectorTest>()
+
+    logger.info("this is a log message!")
+    assertThat(logCollector.takeMessages(minLevel = Level.ERROR)).isEmpty()
+    assertThat(logCollector.takeMessages()).isEmpty()
+  }
+}

--- a/samples/exemplar/build.gradle
+++ b/samples/exemplar/build.gradle
@@ -18,7 +18,7 @@ dependencies {
   compile dep.kotlinStdLib
   compile dep.guava
   compile dep.guice
-  compile dep.loggingImpl
+  compile dep.logbackClassic
 
   compile project(':misk')
 

--- a/samples/exemplarchat/build.gradle
+++ b/samples/exemplarchat/build.gradle
@@ -18,7 +18,7 @@ dependencies {
   compile dep.kotlinStdLib
   compile dep.guava
   compile dep.guice
-  compile dep.loggingImpl
+  compile dep.logbackClassic
 
   compile project(':misk')
 

--- a/samples/urlshortener/build.gradle
+++ b/samples/urlshortener/build.gradle
@@ -18,7 +18,7 @@ dependencies {
   compile dep.kotlinStdLib
   compile dep.guava
   compile dep.guice
-  compile dep.loggingImpl
+  compile dep.logbackClassic
   compile dep.hsqldb
 
   compile project(':misk')


### PR DESCRIPTION
This requires Logback as the SLF4J backend. That's what we're using
elsewhere (ie. CloudwatchLogAppender) and having multiple is bad news.
