### PR TITLE
Upgrade to the latest Kubernetes API client

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ ext {
           jettyServlet         : 'org.eclipse.jetty:jetty-servlet:9.4.8.v20171121',
           jettyWebsocketServlet: 'org.eclipse.jetty.websocket:websocket-servlet:9.4.8.v20171121',
           jettyWebsocketServer : 'org.eclipse.jetty.websocket:websocket-server:9.4.8.v20171121',
-          kubernetesClient     : 'io.kubernetes:client-java:0.2',
+          kubernetesClient     : 'io.kubernetes:client-java:1.0.0',
           okHttp               : 'com.squareup.okhttp3:okhttp:3.9.1',
           moshi                : 'com.squareup.moshi:moshi-kotlin:1.5.0',
           loggingApi           : 'io.github.microutils:kotlin-logging:1.4.9',

--- a/misk/src/main/kotlin/misk/eventrouter/KubernetesClusterConnector.kt
+++ b/misk/src/main/kotlin/misk/eventrouter/KubernetesClusterConnector.kt
@@ -50,8 +50,20 @@ internal class KubernetesClusterConnector : ClusterConnector {
   private fun subscribeToKubernetes(client: ApiClient, api: CoreV1Api, topicPeer: TopicPeer) {
     val watch = Watch.createWatch<V1Pod>(
         client,
-        api.listNamespacedPodCall(config.my_pod_namespace, null, null, null, null, null, true,
-            null, null),
+        api.listNamespacedPodCall(
+            config.my_pod_namespace, // namespace
+            null, // pretty
+            null, // _continue
+            null, // fieldSelector
+            false, // includeUninitialized
+            null, // labelSelector
+            null, // limit
+            null, // resourceVersion
+            null, // timeoutSeconds
+            true, // watch
+            null, // progressListener
+            null  // progressRequestListener
+        ),
         object : TypeToken<Watch.Response<V1Pod>>() {}.type)
 
     for (item in watch) {


### PR DESCRIPTION
It doesn't have a transitive dependency on Log4J 1.x.