### PR TITLE
Implement row counts.

### DIFF
--- a/misk/src/main/kotlin/misk/hibernate/Query.kt
+++ b/misk/src/main/kotlin/misk/hibernate/Query.kt
@@ -4,6 +4,9 @@ import kotlin.reflect.KClass
 
 /** Base class for SQL queries. */
 interface Query<T> {
+  /** How many rows to return. Must be -1 or in range 1..10_000. */
+  var maxRows: Int
+
   fun uniqueResult(session: Session): T?
 
   fun list(session: Session): List<T>

--- a/misk/src/test/kotlin/misk/hibernate/MoviesTestModule.kt
+++ b/misk/src/test/kotlin/misk/hibernate/MoviesTestModule.kt
@@ -8,12 +8,14 @@ import misk.environment.Environment
 import misk.environment.EnvironmentModule
 import misk.inject.KAbstractModule
 import misk.jdbc.DataSourceConfig
+import misk.logging.LogCollectorModule
 import misk.resources.ResourceLoaderModule
 import misk.time.FakeClockModule
 
 /** This module creates movies, actors, and characters tables for several Hibernate tests. */
 class MoviesTestModule : KAbstractModule() {
   override fun configure() {
+    install(LogCollectorModule())
     install(ResourceLoaderModule())
     install(Modules.override(MiskModule()).with(FakeClockModule()))
     install(EnvironmentModule(Environment.TESTING))


### PR DESCRIPTION
We're opinionated here. If you don't specify a row count you get warnings at 2000
rows and errors at 3000 rows.

Whether or not you specify a row count you get hard errors at 10,000 rows.