### PR TITLE
Add health checks to the HibernateModule for database connectivity an…

### DIFF
--- a/misk/src/main/kotlin/misk/hibernate/HibernateHealthCheck.kt
+++ b/misk/src/main/kotlin/misk/hibernate/HibernateHealthCheck.kt
@@ -1,0 +1,53 @@
+package misk.hibernate
+
+import misk.healthchecks.HealthCheck
+import misk.healthchecks.HealthStatus
+import misk.jdbc.DataSourceConfig
+import misk.logging.getLogger
+import org.hibernate.SessionFactory
+import java.sql.Timestamp
+import java.time.Clock
+import java.time.Duration
+
+private val logger = getLogger<HibernateHealthCheck>()
+
+/**
+ * HealthCheck to confirm database connectivity and defend against clock skew.
+ */
+class HibernateHealthCheck(
+  private val sessionFactory: SessionFactory,
+  private val config: DataSourceConfig,
+  private val clock: Clock
+) : HealthCheck {
+
+  override fun status(): HealthStatus {
+    val databaseInstant = try {
+      sessionFactory.openSession().use { session ->
+        session.createNativeQuery("SELECT NOW()").uniqueResult() as Timestamp
+      }.toInstant()
+    } catch (e: Exception) {
+      return HealthStatus.unhealthy("Hibernate: failed to query ${config.database} database")
+    }
+
+    val delta = Duration.between(clock.instant(), databaseInstant).abs()
+    val driftMessage = "Hibernate: host and ${config.database} database " +
+        "clocks have drifted ${delta.seconds}s apart"
+
+    return when {
+      delta > CLOCK_SKEW_UNHEALTHY_THRESHOLD -> {
+        HealthStatus.unhealthy(driftMessage)
+      }
+      delta > CLOCK_SKEW_WARN_THRESHOLD -> {
+        logger.warn { driftMessage }
+        HealthStatus.healthy(driftMessage)
+      }
+      else ->
+        HealthStatus.healthy("Hibernate: ${config.database} database")
+    }
+  }
+
+  companion object {
+    val CLOCK_SKEW_WARN_THRESHOLD = Duration.ofSeconds(10)
+    val CLOCK_SKEW_UNHEALTHY_THRESHOLD = Duration.ofSeconds(30)
+  }
+}

--- a/misk/src/main/kotlin/misk/hibernate/HibernateHealthCheckModule.kt
+++ b/misk/src/main/kotlin/misk/hibernate/HibernateHealthCheckModule.kt
@@ -1,0 +1,30 @@
+package misk.hibernate
+
+import misk.healthchecks.HealthCheck
+import misk.inject.KAbstractModule
+import misk.inject.addMultibinderBinding
+import misk.inject.asSingleton
+import misk.jdbc.DataSourceConfig
+import org.hibernate.SessionFactory
+import java.time.Clock
+import javax.inject.Inject
+import javax.inject.Provider
+
+/**
+ * Binds a HealthCheck for Hibernate.
+ */
+class HibernateHealthCheckModule(
+  private val sessionFactoryProvider: Provider<SessionFactory>,
+  private val config: DataSourceConfig
+) : KAbstractModule() {
+
+  override fun configure() {
+    binder().addMultibinderBinding<HealthCheck>()
+      .toProvider(object : Provider<HibernateHealthCheck> {
+        @Inject lateinit var clock: Clock
+
+        override fun get(): HibernateHealthCheck =
+          HibernateHealthCheck(sessionFactoryProvider.get(), config, clock)
+      }).asSingleton()
+  }
+}

--- a/misk/src/main/kotlin/misk/hibernate/HibernateModule.kt
+++ b/misk/src/main/kotlin/misk/hibernate/HibernateModule.kt
@@ -85,5 +85,7 @@ class HibernateModule(
         bindListener(EventType.PRE_UPDATE).to(TimestampListener::class.java)
       }
     })
+
+    install(HibernateHealthCheckModule(sessionFactoryProvider, config))
   }
 }

--- a/misk/src/main/kotlin/misk/time/ClockModule.kt
+++ b/misk/src/main/kotlin/misk/time/ClockModule.kt
@@ -2,9 +2,12 @@ package misk.time
 
 import misk.inject.KAbstractModule
 import java.time.Clock
+import java.time.ZoneOffset
+import java.util.TimeZone
 
 class ClockModule : KAbstractModule() {
   override fun configure() {
     bind<Clock>().toInstance(Clock.systemUTC())
+    TimeZone.setDefault(TimeZone.getTimeZone(ZoneOffset.UTC))
   }
 }

--- a/misk/src/test/kotlin/misk/hibernate/HealthCheckTest.kt
+++ b/misk/src/test/kotlin/misk/hibernate/HealthCheckTest.kt
@@ -1,0 +1,58 @@
+package misk.hibernate
+
+import misk.healthchecks.HealthCheck
+import misk.jdbc.DataSourceConfig
+import misk.testing.MiskTest
+import misk.testing.MiskTestModule
+import misk.time.FakeClock
+import org.assertj.core.api.Assertions.assertThat
+import org.hibernate.SessionFactory
+import org.junit.jupiter.api.Test
+import java.time.Instant
+import javax.inject.Inject
+
+@MiskTest(startService = true)
+class HealthCheckTest {
+  @MiskTestModule
+  val module = MoviesTestModule()
+
+  @Inject lateinit var fakeClock: FakeClock
+  @Inject lateinit var healthChecks: List<HealthCheck>
+  @Inject @Movies lateinit var config: DataSourceConfig
+  @Inject @Movies lateinit var sessionFactory: SessionFactory
+
+  @Test
+  fun healthy() {
+    fakeClock.setNow(Instant.now())
+
+    val status = HibernateHealthCheck(sessionFactory, config, fakeClock).status()
+    assertThat(status.isHealthy).isTrue()
+  }
+
+  @Test
+  fun databaseConnectivityFailure() {
+    // Close the SessionFactory so the health check query fails.
+    sessionFactory.close()
+
+    val status = HibernateHealthCheck(sessionFactory, config, fakeClock).status()
+    assertThat(status.isHealthy).isFalse()
+    assertThat(status.messages).contains("Hibernate: failed to query movies database")
+  }
+
+  @Test
+  fun clockSkew() {
+    val skew = HibernateHealthCheck.CLOCK_SKEW_UNHEALTHY_THRESHOLD.multipliedBy(2)
+    fakeClock.setNow(Instant.now().minus(skew))
+
+    val status = HibernateHealthCheck(sessionFactory, config, fakeClock).status()
+    assertThat(status.isHealthy).isFalse()
+    assertThat(status.messages).anyMatch {
+      it.startsWith("Hibernate: host and movies database clocks have drifted")
+    }
+  }
+
+  @Test
+  fun isInjected() {
+    assertThat(healthChecks).anyMatch { it is HibernateHealthCheck }
+  }
+}

--- a/misk/testing/src/main/kotlin/misk/time/FakeClock.kt
+++ b/misk/testing/src/main/kotlin/misk/time/FakeClock.kt
@@ -22,4 +22,6 @@ class FakeClock(
   fun add(d: Duration) = millis.addAndGet(d.toMillis())
 
   fun add(n: Long, unit: TimeUnit) = millis.addAndGet(TimeUnit.MILLISECONDS.convert(n, unit))
+
+  fun setNow(instant: Instant) = millis.set(instant.toEpochMilli())
 }


### PR DESCRIPTION
…d clock skew.

Health checking queries are performed on-demand rather than periodically in the background and reported when asked.

Closes #227