### PR TITLE
Transacter.inTransaction()

### DIFF
--- a/misk/src/main/kotlin/misk/hibernate/Transacter.kt
+++ b/misk/src/main/kotlin/misk/hibernate/Transacter.kt
@@ -1,5 +1,23 @@
 package misk.hibernate
 
+/**
+ * Provides explicit block-based transaction demarcation.
+ */
 interface Transacter {
+  /**
+   * @returns [true] if the calling thread is currently within a transaction block.
+   */
+  val inTransaction: Boolean
+
+  /**
+   * Executes [lambda] in a transaction. The transaction will be committed once [lambda] completes.
+   * If [lambda] raises an exception the transaction will be rolled back.
+   *
+   * @param lambda a function to execute in a transaction.
+   * @return the result of [lambda] function.
+   *
+   * @throws IllegalStateException if attempting a nested transaction, which is unsupported.
+   * @throws Throwable for various other runtime exceptions.
+   */
   fun <T> transaction(lambda: (session: Session) -> T): T
 }

--- a/misk/src/test/kotlin/misk/hibernate/TransacterTest.kt
+++ b/misk/src/test/kotlin/misk/hibernate/TransacterTest.kt
@@ -92,6 +92,27 @@ class TransacterTest {
     }
   }
 
+  @Test
+  fun inTransaction() {
+    assertThat(transacter.inTransaction).isFalse()
+
+    transacter.transaction {
+      assertThat(transacter.inTransaction).isTrue()
+    }
+
+    assertThat(transacter.inTransaction).isFalse()
+  }
+
+  @Test
+  fun nestedTransactionUnsupported() {
+    val exception = assertThrows(IllegalStateException::class.java) {
+      transacter.transaction {
+        transacter.transaction {}
+      }
+    }
+    assertThat(exception).hasMessage("Attempted to start a nested session")
+  }
+
   interface CharacterQuery : Query<DbCharacter> {
     @Constraint("name")
     fun name(name: String): CharacterQuery


### PR DESCRIPTION
Provide an API to check whether a transaction is in flight (#224).
This is useful for defensive programming such as `require(!transacter.inTransaction())`.

As distinct units of work run in their own threads, the thread-local variable holding on to the Session provides sufficient isolation on the Transacter singleton.