### PR TITLE
Replace class literals with reified methods

### DIFF
--- a/misk/src/main/kotlin/misk/eventrouter/EventRouterTestingModule.kt
+++ b/misk/src/main/kotlin/misk/eventrouter/EventRouterTestingModule.kt
@@ -6,6 +6,7 @@ import com.google.inject.Provides
 import com.squareup.moshi.Moshi
 import misk.inject.KAbstractModule
 import misk.inject.addMultibinderBinding
+import misk.inject.asSingleton
 import misk.moshi.MoshiAdapterModule
 import misk.moshi.adapter
 import java.util.concurrent.ExecutorService
@@ -26,8 +27,8 @@ class EventRouterTestingModule internal constructor(val distributed: Boolean) : 
     if (distributed) {
       bind<EventRouter>().to<RealEventRouter>()
     } else {
-      bind<EventRouter>().to<RealEventRouter>().`in`(Singleton::class.java)
-      bind<RealEventRouter>().`in`(Singleton::class.java)
+      bind<EventRouter>().to<RealEventRouter>().asSingleton()
+      bind<RealEventRouter>().asSingleton()
       binder().addMultibinderBinding<Service>().toInstance(object: AbstractIdleService() {
         @Inject private lateinit var eventRouter: RealEventRouter
         @Inject private lateinit var eventRouterTester: EventRouterTester

--- a/misk/src/main/kotlin/misk/eventrouter/RealEventRouterModule.kt
+++ b/misk/src/main/kotlin/misk/eventrouter/RealEventRouterModule.kt
@@ -7,6 +7,7 @@ import misk.environment.Environment
 import misk.healthchecks.HealthCheck
 import misk.inject.KAbstractModule
 import misk.inject.addMultibinderBinding
+import misk.inject.asSingleton
 import misk.inject.to
 import misk.moshi.MoshiAdapterModule
 import misk.moshi.adapter
@@ -20,8 +21,8 @@ import javax.inject.Singleton
 
 class RealEventRouterModule(val environment: Environment) : KAbstractModule() {
   override fun configure() {
-    bind<EventRouter>().to<RealEventRouter>().`in`(Singleton::class.java)
-    bind<RealEventRouter>().`in`(Singleton::class.java)
+    bind<EventRouter>().to<RealEventRouter>().asSingleton()
+    bind<RealEventRouter>().asSingleton()
     binder().addMultibinderBinding<Service>().to<EventRouterService>()
     if (environment == Environment.DEVELOPMENT) {
       bind<ClusterConnector>().to<LocalClusterConnector>()

--- a/misk/src/main/kotlin/misk/hibernate/HibernateModule.kt
+++ b/misk/src/main/kotlin/misk/hibernate/HibernateModule.kt
@@ -6,6 +6,7 @@ import misk.inject.KAbstractModule
 import misk.inject.addMultibinderBinding
 import misk.inject.asSingleton
 import misk.inject.setOfType
+import misk.inject.to
 import misk.inject.toKey
 import misk.jdbc.DataSourceConfig
 import misk.resources.ResourceLoader
@@ -77,13 +78,12 @@ class HibernateModule(
           qualifier, environment, schemaMigratorProvider)
     }).asSingleton()
 
-
-    bind(Query.Factory::class.java).to(ReflectionQuery.Factory::class.java)
+    bind<Query.Factory>().to<ReflectionQuery.Factory>()
 
     install(object : HibernateEntityModule(qualifier) {
       override fun configureHibernate() {
-        bindListener(EventType.PRE_INSERT).to(TimestampListener::class.java)
-        bindListener(EventType.PRE_UPDATE).to(TimestampListener::class.java)
+        bindListener(EventType.PRE_INSERT).to<TimestampListener>()
+        bindListener(EventType.PRE_UPDATE).to<TimestampListener>()
       }
     })
 

--- a/misk/src/main/kotlin/misk/moshi/MoshiModule.kt
+++ b/misk/src/main/kotlin/misk/moshi/MoshiModule.kt
@@ -5,6 +5,7 @@ import com.squareup.moshi.JsonAdapter
 import com.squareup.moshi.Moshi
 import misk.inject.KAbstractModule
 import misk.inject.newMultibinder
+import misk.inject.to
 import misk.moshi.okio.ByteStringAdapter
 import misk.moshi.wire.WireMessageAdapter
 import javax.inject.Singleton
@@ -12,7 +13,7 @@ import javax.inject.Singleton
 class MoshiModule : KAbstractModule() {
   override fun configure() {
     val factoryBinder = binder().newMultibinder<JsonAdapter.Factory>(MoshiJsonAdapter::class)
-    factoryBinder.addBinding().to(WireMessageAdapter.Factory::class.java)
+    factoryBinder.addBinding().to<WireMessageAdapter.Factory>()
 
     val adapterBinder = binder().newMultibinder<Any>(MoshiJsonAdapter::class)
     adapterBinder.addBinding().toInstance(ByteStringAdapter)

--- a/misk/src/main/kotlin/misk/resources/FakeResourceLoaderModule.kt
+++ b/misk/src/main/kotlin/misk/resources/FakeResourceLoaderModule.kt
@@ -4,6 +4,6 @@ import misk.inject.KAbstractModule
 
 class FakeResourceLoaderModule : KAbstractModule() {
   override fun configure() {
-    bind<ResourceLoader>().to(FakeResourceLoader::class.java)
+    bind<ResourceLoader>().to<FakeResourceLoader>()
   }
 }

--- a/misk/src/main/kotlin/misk/time/ClockModule.kt
+++ b/misk/src/main/kotlin/misk/time/ClockModule.kt
@@ -3,11 +3,12 @@ package misk.time
 import com.google.common.util.concurrent.Service
 import misk.inject.KAbstractModule
 import misk.inject.addMultibinderBinding
+import misk.inject.to
 import java.time.Clock
 
 class ClockModule : KAbstractModule() {
   override fun configure() {
-    binder().addMultibinderBinding<Service>().to(ForceUtcTimeZoneService::class.java)
+    binder().addMultibinderBinding<Service>().to<ForceUtcTimeZoneService>()
 
     bind<Clock>().toInstance(Clock.systemUTC())
   }

--- a/misk/src/test/kotlin/misk/ActionsTest.kt
+++ b/misk/src/test/kotlin/misk/ActionsTest.kt
@@ -1,7 +1,7 @@
 package misk
 
+import misk.testing.assertThrows
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Test
 import kotlin.reflect.full.createType
 
@@ -17,7 +17,7 @@ internal class ActionsTest {
 
   @Test
   fun methodReferenceNotAllowedAsAction() {
-    assertThrows(IllegalArgumentException::class.java) {
+    assertThrows<IllegalArgumentException> {
       val t = TestAction()
       t::myActionMethod.asAction()
     }
@@ -25,7 +25,7 @@ internal class ActionsTest {
 
   @Test
   fun freeStandingFunctionNotAllowedAsAction() {
-    assertThrows(IllegalArgumentException::class.java) {
+    assertThrows<IllegalArgumentException> {
       ::myActionHandler.asAction()
     }
   }

--- a/misk/src/test/kotlin/misk/CoordinatedServiceTest.kt
+++ b/misk/src/test/kotlin/misk/CoordinatedServiceTest.kt
@@ -3,8 +3,8 @@ package misk
 import com.google.common.util.concurrent.AbstractService
 import com.google.inject.Key
 import com.google.inject.name.Names
+import misk.testing.assertThrows
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Test
 
 class CoordinatedServiceTest {
@@ -101,7 +101,7 @@ class CoordinatedServiceTest {
     val a = AppendingService(target, "Service A", produced = setOf("a"))
     val c = AppendingService(target, "Service C", consumed = setOf("a", "b"))
 
-    assertThat(assertThrows(IllegalArgumentException::class.java) {
+    assertThat(assertThrows<IllegalArgumentException> {
       CoordinatedService.coordinate(listOf(a, c))
     }).hasMessage("""
         |Service dependency graph has problems:
@@ -115,7 +115,7 @@ class CoordinatedServiceTest {
     val c = AppendingService(target, "Service C", consumed = setOf("a"))
     val b = AppendingService(target, "Service B", produced = setOf("a"))
 
-    assertThat(assertThrows(IllegalArgumentException::class.java) {
+    assertThat(assertThrows<IllegalArgumentException> {
       CoordinatedService.coordinate(listOf(a, b, c))
     }).hasMessage("""
         |Service dependency graph has problems:
@@ -130,7 +130,7 @@ class CoordinatedServiceTest {
     val c = AppendingService(target, "Service C", produced = setOf("c"), consumed = setOf("a"))
     val d = AppendingService(target, "Service D", produced = setOf("d"), consumed = setOf("c"))
 
-    assertThat(assertThrows(IllegalArgumentException::class.java) {
+    assertThat(assertThrows<IllegalArgumentException> {
       CoordinatedService.coordinate(listOf(a, b, c, d))
     }).hasMessage("""
         |Service dependency graph has problems:
@@ -152,9 +152,9 @@ class CoordinatedServiceTest {
 
     val serviceManager = CoordinatedService.coordinate(listOf(a, b))
     serviceManager.startAsync()
-    assertThat(assertThrows(IllegalStateException::class.java) {
+    assertThrows<IllegalStateException> {
       serviceManager.awaitHealthy()
-    })
+    }
   }
 
   /** Appends messages to `target` on start up and shut down. */

--- a/misk/src/test/kotlin/misk/MiskApplicationTest.kt
+++ b/misk/src/test/kotlin/misk/MiskApplicationTest.kt
@@ -2,8 +2,8 @@ package misk
 
 import com.beust.jcommander.Parameter
 import misk.inject.KAbstractModule
+import misk.testing.assertThrows
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Test
 import javax.inject.Inject
 
@@ -90,7 +90,7 @@ internal class MiskApplicationTest {
 
   @Test
   fun missingRequiredArgument() {
-    val exception = assertThrows(MiskApplication.CliException::class.java) {
+    val exception = assertThrows<MiskApplication.CliException> {
       val commands = Commands()
       MiskApplication(*commands.all).doRun(arrayOf("with-required-args", "-f"))
     }
@@ -109,7 +109,7 @@ internal class MiskApplicationTest {
 
   @Test
   fun unknownCommand() {
-    val exception = assertThrows(MiskApplication.CliException::class.java) {
+    val exception = assertThrows<MiskApplication.CliException> {
       val commands = Commands()
       MiskApplication(*commands.all).doRun(arrayOf("unknown"))
     }
@@ -143,7 +143,7 @@ internal class MiskApplicationTest {
 
   @Test
   fun commandPreconditionsNotMet() {
-    val exception = assertThrows(MiskApplication.CliException::class.java) {
+    val exception = assertThrows<MiskApplication.CliException> {
       val commands = Commands()
       MiskApplication(*commands.all).doRun(arrayOf("with-preconditions"))
     }

--- a/misk/src/test/kotlin/misk/backoff/RetryTest.kt
+++ b/misk/src/test/kotlin/misk/backoff/RetryTest.kt
@@ -1,7 +1,7 @@
 package misk.backoff
 
+import misk.testing.assertThrows
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Test
 import java.time.Duration
 
@@ -20,7 +20,7 @@ internal class RetryTest {
   @Test fun failsIfExceedsMaxRetries() {
     val backoff = ExponentialBackoff(Duration.ofMillis(10), Duration.ofMillis(100))
 
-    assertThrows(IllegalStateException::class.java) {
+    assertThrows<IllegalStateException> {
       retry(3, backoff) { throw IllegalStateException("this failed") }
     }
   }
@@ -28,7 +28,7 @@ internal class RetryTest {
   @Test fun honorsBackoff() {
     val backoff = ExponentialBackoff(Duration.ofMillis(10), Duration.ofMillis(100))
 
-    assertThrows(IllegalStateException::class.java) {
+    assertThrows<IllegalStateException> {
       retry(3, backoff) { throw IllegalStateException("this failed") }
     }
 
@@ -44,7 +44,7 @@ internal class RetryTest {
     backoff.nextRetry()
     backoff.nextRetry()
 
-    assertThrows(IllegalStateException::class.java) {
+    assertThrows<IllegalStateException> {
       retry(3, backoff) { throw IllegalStateException("this failed") }
     }
 

--- a/misk/src/test/kotlin/misk/cloud/gcp/security/keys/GcpKeyServiceTest.kt
+++ b/misk/src/test/kotlin/misk/cloud/gcp/security/keys/GcpKeyServiceTest.kt
@@ -7,9 +7,9 @@ import com.google.api.services.cloudkms.v1.model.EncryptResponse
 import misk.cloud.gcp.testing.FakeHttpRouter
 import misk.cloud.gcp.testing.FakeHttpRouter.Companion.respondWithError
 import misk.cloud.gcp.testing.FakeHttpRouter.Companion.respondWithJson
+import misk.testing.assertThrows
 import okio.ByteString
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Test
 
 internal class GcpKeyServiceTest {
@@ -49,14 +49,14 @@ internal class GcpKeyServiceTest {
 
   @Test
   fun invalidEncryptKey() {
-    assertThrows(IllegalArgumentException::class.java) {
+    assertThrows<IllegalArgumentException> {
       keyManager.encrypt("unknown_key", ByteString.encodeUtf8("should fail"))
     }
   }
 
   @Test
   fun invalidDecryptKey() {
-    assertThrows(IllegalArgumentException::class.java) {
+    assertThrows<IllegalArgumentException> {
       keyManager.decrypt("unknown_key", ByteString.encodeUtf8("should fail"))
     }
   }

--- a/misk/src/test/kotlin/misk/cloud/gcp/testing/FakeHttpRouterTest.kt
+++ b/misk/src/test/kotlin/misk/cloud/gcp/testing/FakeHttpRouterTest.kt
@@ -6,8 +6,8 @@ import com.google.api.client.json.jackson2.JacksonFactory
 import com.google.api.client.testing.http.MockHttpContent
 import misk.cloud.gcp.testing.FakeHttpRouter.Companion.respondWithError
 import misk.cloud.gcp.testing.FakeHttpRouter.Companion.respondWithText
+import misk.testing.assertThrows
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Test
 import java.io.ByteArrayInputStream
 
@@ -38,7 +38,7 @@ internal class FakeHttpRouterTest {
 
   @Test
   fun matchOnUrl() {
-    assertThat(assertThrows(HttpResponseException::class.java) {
+    assertThat(assertThrows<HttpResponseException> {
       transport.createRequestFactory()
           .buildGetRequest(GenericUrl("https://something.com/second"))
           .setContent(MockHttpContent().setContent(
@@ -49,7 +49,7 @@ internal class FakeHttpRouterTest {
 
   @Test
   fun noMatch() {
-    assertThat(assertThrows(HttpResponseException::class.java) {
+    assertThat(assertThrows<HttpResponseException> {
       transport.createRequestFactory()
           .buildGetRequest(GenericUrl("https://something.com/unknown"))
           .execute()

--- a/misk/src/test/kotlin/misk/config/ConfigTest.kt
+++ b/misk/src/test/kotlin/misk/config/ConfigTest.kt
@@ -5,10 +5,10 @@ import misk.environment.Environment
 import misk.environment.EnvironmentModule
 import misk.testing.MiskTest
 import misk.testing.MiskTestModule
+import misk.testing.assertThrows
 import misk.web.WebConfig
 import misk.web.exceptions.ActionExceptionLogLevelConfig
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Test
 import org.slf4j.event.Level
 import java.time.Duration
@@ -72,7 +72,7 @@ class ConfigTest {
 
   @Test
   fun friendlyErrorMessagesWhenFilesNotFound() {
-    val exception = assertThrows(IllegalStateException::class.java) {
+    val exception = assertThrows<IllegalStateException> {
       MiskConfig.load<TestConfig>(TestConfig::class.java, "missing", defaultEnv)
     }
 
@@ -82,7 +82,7 @@ class ConfigTest {
 
   @Test
   fun friendlyErrorMessageWhenConfigPropertyMissing() {
-    val exception = assertThrows(IllegalStateException::class.java) {
+    val exception = assertThrows<IllegalStateException> {
       MiskConfig.load<TestConfig>(TestConfig::class.java, "partial_test_app", defaultEnv)
     }
 
@@ -92,7 +92,7 @@ class ConfigTest {
 
   @Test
   fun friendlyErrorMessagesWhenFileUnparseable() {
-    val exception = assertThrows(IllegalStateException::class.java) {
+    val exception = assertThrows<IllegalStateException> {
       MiskConfig.load<TestConfig>(TestConfig::class.java, "unparsable", defaultEnv)
     }
 
@@ -101,7 +101,7 @@ class ConfigTest {
 
   @Test
   fun friendlyErrorMessagesWhenPropertiesNotFound() {
-    val exception = assertThrows(IllegalStateException::class.java) {
+    val exception = assertThrows<IllegalStateException> {
       MiskConfig.load<TestConfig>(TestConfig::class.java, "unknownproperty", defaultEnv)
     }
 

--- a/misk/src/test/kotlin/misk/hibernate/EventListenersTest.kt
+++ b/misk/src/test/kotlin/misk/hibernate/EventListenersTest.kt
@@ -1,6 +1,7 @@
 package misk.hibernate
 
 import com.google.inject.util.Modules
+import misk.inject.to
 import misk.testing.MiskTest
 import misk.testing.MiskTestModule
 import org.assertj.core.api.Assertions.assertThat
@@ -16,10 +17,10 @@ class EventListenersTest {
       MoviesTestModule(),
       object : HibernateEntityModule(Movies::class) {
         override fun configureHibernate() {
-          bindListener(EventType.PRE_LOAD).to(FakeEventListener::class.java)
-          bindListener(EventType.PRE_INSERT).to(FakeEventListener::class.java)
-          bindListener(EventType.PRE_UPDATE).to(FakeEventListener::class.java)
-          bindListener(EventType.PRE_DELETE).to(FakeEventListener::class.java)
+          bindListener(EventType.PRE_LOAD).to<FakeEventListener>()
+          bindListener(EventType.PRE_INSERT).to<FakeEventListener>()
+          bindListener(EventType.PRE_UPDATE).to<FakeEventListener>()
+          bindListener(EventType.PRE_DELETE).to<FakeEventListener>()
         }
       })
 

--- a/misk/src/test/kotlin/misk/hibernate/ReflectionQueryFactoryTest.kt
+++ b/misk/src/test/kotlin/misk/hibernate/ReflectionQueryFactoryTest.kt
@@ -5,8 +5,8 @@ import com.google.common.collect.Iterables.getOnlyElement
 import misk.logging.LogCollector
 import misk.testing.MiskTest
 import misk.testing.MiskTestModule
+import misk.testing.assertThrows
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Test
 import java.time.LocalDate
 import javax.inject.Inject
@@ -305,7 +305,7 @@ class ReflectionQueryFactoryTest {
         session.save(DbMovie("Rocky $i", null))
       }
     }
-    assertThat(assertThrows(IllegalStateException::class.java) {
+    assertThat(assertThrows<IllegalStateException> {
       transacter.transaction { session ->
         queryFactory.newQuery<OperatorsMovieQuery>().list(session)
       }
@@ -331,7 +331,7 @@ class ReflectionQueryFactoryTest {
   @Test
   fun maxMaxRowCountEnforced() {
     val query = queryFactory.newQuery<OperatorsMovieQuery>()
-    assertThat(assertThrows(IllegalArgumentException::class.java) {
+    assertThat(assertThrows<IllegalArgumentException> {
       query.maxRows = 10_001
     }).hasMessage("out of range: 10001")
   }
@@ -371,14 +371,14 @@ class ReflectionQueryFactoryTest {
     }
 
     // Unique result.
-    assertThat(assertThrows(IllegalStateException::class.java) {
+    assertThat(assertThrows<IllegalStateException> {
       transacter.transaction { session ->
         queryFactory.newQuery<OperatorsMovieQuery>().uniqueResult(session)
       }
     }).hasMessageContaining("query expected a unique result but was")
 
     // Unique result projection.
-    assertThat(assertThrows(IllegalStateException::class.java) {
+    assertThat(assertThrows<IllegalStateException> {
       transacter.transaction { session ->
         queryFactory.newQuery<OperatorsMovieQuery>().uniqueName(session)
       }

--- a/misk/src/test/kotlin/misk/hibernate/ReflectionQueryFactoryValidationTest.kt
+++ b/misk/src/test/kotlin/misk/hibernate/ReflectionQueryFactoryValidationTest.kt
@@ -3,8 +3,8 @@ package misk.hibernate
 import com.google.common.util.concurrent.UncheckedExecutionException
 import misk.testing.MiskTest
 import misk.testing.MiskTestModule
+import misk.testing.assertThrows
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Test
 import javax.inject.Inject
 
@@ -18,7 +18,7 @@ class ReflectionQueryFactoryValidationTest {
 
   @Test
   fun returnTypeMustBeThis() {
-    assertThat(assertThrows(UncheckedExecutionException::class.java) {
+    assertThat(assertThrows<UncheckedExecutionException> {
       queryFactory.newQuery<ReturnTypeMustBeThis>()
     }.cause).hasMessage("""
         |Query class ${ReturnTypeMustBeThis::class.java.name} has problems:
@@ -32,7 +32,7 @@ class ReflectionQueryFactoryValidationTest {
 
   @Test
   fun parameterCountMustMatchOperator() {
-    assertThat(assertThrows(UncheckedExecutionException::class.java) {
+    assertThat(assertThrows<UncheckedExecutionException> {
       queryFactory.newQuery<ParameterCountMustMatchOperator>()
     }.cause).hasMessage("""
         |Query class ${ParameterCountMustMatchOperator::class.java.name} has problems:
@@ -46,7 +46,7 @@ class ReflectionQueryFactoryValidationTest {
 
   @Test
   fun annotationRequiredOnQuery() {
-    assertThat(assertThrows(UncheckedExecutionException::class.java) {
+    assertThat(assertThrows<UncheckedExecutionException> {
       queryFactory.newQuery<AnnotationRequiredOnQuery>()
     }.cause).hasMessage("""
         |Query class ${AnnotationRequiredOnQuery::class.java.name} has problems:
@@ -59,7 +59,7 @@ class ReflectionQueryFactoryValidationTest {
 
   @Test
   fun malformedPathOnQuery() {
-    assertThat(assertThrows(UncheckedExecutionException::class.java) {
+    assertThat(assertThrows<UncheckedExecutionException> {
       queryFactory.newQuery<MalformedPathOnQuery>()
     }.cause).hasMessage("""
         |Query class ${MalformedPathOnQuery::class.java.name} has problems:
@@ -73,7 +73,7 @@ class ReflectionQueryFactoryValidationTest {
 
   @Test
   fun parameterAnnotationRequiredOnProjection() {
-    assertThat(assertThrows(UncheckedExecutionException::class.java) {
+    assertThat(assertThrows<UncheckedExecutionException> {
       transacter.transaction {
         queryFactory.newQuery<ParameterAnnotationRequiredOnProjectionQuery>()
       }
@@ -91,7 +91,7 @@ class ReflectionQueryFactoryValidationTest {
 
   @Test
   fun missingPrimaryConstructor() {
-    assertThat(assertThrows(UncheckedExecutionException::class.java) {
+    assertThat(assertThrows<UncheckedExecutionException> {
       transacter.transaction {
         queryFactory.newQuery<MissingPrimaryConstructorQuery>()
       }
@@ -109,7 +109,7 @@ class ReflectionQueryFactoryValidationTest {
 
   @Test
   fun malformedPathOnParameter() {
-    assertThat(assertThrows(UncheckedExecutionException::class.java) {
+    assertThat(assertThrows<UncheckedExecutionException> {
       transacter.transaction {
         queryFactory.newQuery<MalformedPathOnParameterQuery>()
       }
@@ -129,7 +129,7 @@ class ReflectionQueryFactoryValidationTest {
 
   @Test
   fun inParameterIsNotVarargOrCollection() {
-    assertThat(assertThrows(UncheckedExecutionException::class.java) {
+    assertThat(assertThrows<UncheckedExecutionException> {
       queryFactory.newQuery<InParameterIsNotVarargOrCollection>()
     }.cause).hasMessage("""
         |Query class ${InParameterIsNotVarargOrCollection::class.java.name} has problems:
@@ -143,7 +143,7 @@ class ReflectionQueryFactoryValidationTest {
 
   @Test
   fun selectDoesNotAcceptSession() {
-    assertThat(assertThrows(UncheckedExecutionException::class.java) {
+    assertThat(assertThrows<UncheckedExecutionException> {
       transacter.transaction {
         queryFactory.newQuery<SelectDoesNotAcceptSessionQuery>()
       }
@@ -159,7 +159,7 @@ class ReflectionQueryFactoryValidationTest {
 
   @Test
   fun selectNonProjectionPathIsEmpty() {
-    assertThat(assertThrows(UncheckedExecutionException::class.java) {
+    assertThat(assertThrows<UncheckedExecutionException> {
       transacter.transaction {
         queryFactory.newQuery<SelectNonProjectionPathIsEmpty>()
       }
@@ -175,7 +175,7 @@ class ReflectionQueryFactoryValidationTest {
 
   @Test
   fun selectUniqueReturnTypeNullability() {
-    assertThat(assertThrows(UncheckedExecutionException::class.java) {
+    assertThat(assertThrows<UncheckedExecutionException> {
       transacter.transaction {
         queryFactory.newQuery<SelectUniqueReturnTypeNullability>()
       }
@@ -195,7 +195,7 @@ class ReflectionQueryFactoryValidationTest {
 
   @Test
   fun tooManyAnnotations() {
-    assertThat(assertThrows(UncheckedExecutionException::class.java) {
+    assertThat(assertThrows<UncheckedExecutionException> {
       transacter.transaction {
         queryFactory.newQuery<TooManyAnnotations>()
       }

--- a/misk/src/test/kotlin/misk/hibernate/SchemaMigratorTest.kt
+++ b/misk/src/test/kotlin/misk/hibernate/SchemaMigratorTest.kt
@@ -16,9 +16,9 @@ import misk.resources.FakeResourceLoader
 import misk.resources.FakeResourceLoaderModule
 import misk.testing.MiskTest
 import misk.testing.MiskTestModule
+import misk.testing.assertThrows
 import org.assertj.core.api.Assertions.assertThat
 import org.hibernate.SessionFactory
-import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Test
 import javax.inject.Inject
 import javax.inject.Provider
@@ -63,9 +63,7 @@ internal class SchemaMigratorTest {
           SessionFactoryService(Movies::class, config.data_source, defaultEnv)
       binder().addMultibinderBinding<Service>().toInstance(sessionFactoryService)
       binder().addMultibinderBinding<Service>().toInstance(dropTablesService)
-      bind(SessionFactory::class.java)
-          .annotatedWith(Movies::class.java)
-          .toProvider(sessionFactoryService)
+      bind<SessionFactory>().annotatedWith<Movies>().toProvider(sessionFactoryService)
     }
   }
 
@@ -88,7 +86,7 @@ internal class SchemaMigratorTest {
     assertThat(tableExists("table_2")).isFalse()
     assertThat(tableExists("table_3")).isFalse()
     assertThat(tableExists("table_4")).isFalse()
-    assertThrows(PersistenceException::class.java) {
+    assertThrows<PersistenceException> {
       schemaMigrator.appliedMigrations()
     }
 
@@ -139,7 +137,7 @@ internal class SchemaMigratorTest {
         |CREATE TABLE table_1 (name varchar(255))
         |""".trimMargin())
 
-    assertThat(assertThrows(IllegalStateException::class.java) {
+    assertThat(assertThrows<IllegalStateException> {
       schemaMigrator.requireAll()
     }).hasMessage("""
           |schemamigrator is missing migrations:

--- a/misk/src/test/kotlin/misk/hibernate/TransacterTest.kt
+++ b/misk/src/test/kotlin/misk/hibernate/TransacterTest.kt
@@ -3,9 +3,9 @@ package misk.hibernate
 import misk.exceptions.UnauthorizedException
 import misk.testing.MiskTest
 import misk.testing.MiskTestModule
+import misk.testing.assertThrows
 import org.assertj.core.api.Assertions.assertThat
 import org.hibernate.exception.ConstraintViolationException
-import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Test
 import java.time.LocalDate
 import javax.inject.Inject
@@ -64,7 +64,7 @@ class TransacterTest {
 
   @Test
   fun exceptionCausesTransactionToRollback() {
-    assertThrows(UnauthorizedException::class.java) {
+    assertThrows<UnauthorizedException> {
       transacter.transaction { session ->
         session.save(DbMovie("Star Wars", LocalDate.of(1977, 5, 25)))
         assertThat(queryFactory.newQuery<MovieQuery>().list(session)).isNotEmpty()
@@ -81,7 +81,7 @@ class TransacterTest {
     transacter.transaction { session ->
       session.save(DbMovie("Cinderella", LocalDate.of(1950, 3, 4)))
     }
-    assertThrows(ConstraintViolationException::class.java) {
+    assertThrows<ConstraintViolationException> {
       transacter.transaction { session ->
         session.save(DbMovie("Beauty and the Beast", LocalDate.of(1991, 11, 22)))
         session.save(DbMovie("Cinderella", LocalDate.of(2015, 3, 13)))
@@ -105,9 +105,10 @@ class TransacterTest {
 
   @Test
   fun nestedTransactionUnsupported() {
-    val exception = assertThrows(IllegalStateException::class.java) {
+    val exception = assertThrows<IllegalStateException> {
       transacter.transaction {
-        transacter.transaction {}
+        transacter.transaction {
+        }
       }
     }
     assertThat(exception).hasMessage("Attempted to start a nested session")

--- a/misk/src/test/kotlin/misk/moshi/wire/WireMessageAdapterTest.kt
+++ b/misk/src/test/kotlin/misk/moshi/wire/WireMessageAdapterTest.kt
@@ -8,10 +8,10 @@ import com.squareup.protos.test.parsing.Warehouse
 import misk.moshi.MoshiModule
 import misk.testing.MiskTest
 import misk.testing.MiskTestModule
+import misk.testing.assertThrows
 import okio.ByteString
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.isEqualToAsJson
-import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Test
 import javax.inject.Inject
 
@@ -210,7 +210,7 @@ internal class WireMessageAdapterTest {
   @Test
   fun detectsAndFailsOnMultipleOneOfs() {
     val shipmentAdapter = moshi.adapter(Shipment::class.java)
-    assertThat(assertThrows(IllegalArgumentException::class.java) {
+    assertThat(assertThrows<IllegalArgumentException> {
       shipmentAdapter.fromJson("""
         |{
         | "shipment_id": 100075,

--- a/misk/src/test/kotlin/misk/scope/ActionScopedTest.kt
+++ b/misk/src/test/kotlin/misk/scope/ActionScopedTest.kt
@@ -7,8 +7,8 @@ import com.google.inject.name.Names
 import misk.exceptions.UnauthenticatedException
 import misk.inject.keyOf
 import misk.inject.uninject
+import misk.testing.assertThrows
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import javax.inject.Inject
@@ -47,7 +47,7 @@ class ActionScopedTest {
 
   @Test
   fun doubleEnterScopeFails() {
-    assertThrows(IllegalStateException::class.java) {
+    assertThrows<IllegalStateException> {
       val injector = Guice.createInjector(TestActionScopedProviderModule())
       injector.injectMembers(this)
 
@@ -57,7 +57,7 @@ class ActionScopedTest {
 
   @Test
   fun resolveOutsideOfScopeFails() {
-    assertThrows(IllegalStateException::class.java) {
+    assertThrows<IllegalStateException> {
       val injector = Guice.createInjector(TestActionScopedProviderModule())
       injector.injectMembers(this)
 
@@ -67,7 +67,7 @@ class ActionScopedTest {
 
   @Test
   fun seedDataNotFoundFails() {
-    assertThrows(IllegalStateException::class.java) {
+    assertThrows<IllegalStateException> {
       val injector = Guice.createInjector(TestActionScopedProviderModule())
       injector.injectMembers(this)
 
@@ -98,7 +98,7 @@ class ActionScopedTest {
 
   @Test
   fun providerExceptionsPropagate() {
-    assertThrows(UnauthenticatedException::class.java) {
+    assertThrows<UnauthenticatedException> {
       val injector = Guice.createInjector(TestActionScopedProviderModule())
       injector.injectMembers(this)
 

--- a/misk/src/test/kotlin/misk/scope/executor/ActionScopedExecutorServiceTest.kt
+++ b/misk/src/test/kotlin/misk/scope/executor/ActionScopedExecutorServiceTest.kt
@@ -10,8 +10,8 @@ import misk.inject.keyOf
 import misk.scope.ActionScope
 import misk.scope.ActionScoped
 import misk.scope.TestActionScopedProviderModule
+import misk.testing.assertThrows
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Test
 import java.util.concurrent.Callable
 import java.util.concurrent.ExecutorService
@@ -49,7 +49,7 @@ internal class ActionScopedExecutorServiceTest {
 
   @Test
   fun doesNotPropagateScopeIfNotInScope() {
-    assertThrows(IllegalStateException::class.java) {
+    assertThrows<IllegalStateException> {
       val injector = Guice.createInjector(
           TestActionScopedProviderModule(),
           ActionScopedExecutorServiceModule())

--- a/misk/src/test/kotlin/misk/security/x509/X500NameTest.kt
+++ b/misk/src/test/kotlin/misk/security/x509/X500NameTest.kt
@@ -1,7 +1,7 @@
 package misk.security.x509
 
+import misk.testing.assertThrows
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Test
 
 internal class X500NameTest {
@@ -39,7 +39,7 @@ internal class X500NameTest {
   }
 
   @Test fun endsInAttributeName() {
-    val e = assertThrows(IllegalArgumentException::class.java) {
+    val e = assertThrows<IllegalArgumentException> {
       X500Name.parse("CN")
     }
 
@@ -47,7 +47,7 @@ internal class X500NameTest {
   }
 
   @Test fun noAttributes() {
-    val e = assertThrows(IllegalArgumentException::class.java) {
+    val e = assertThrows<IllegalArgumentException> {
       X500Name.parse("    \n")
     }
 
@@ -55,7 +55,7 @@ internal class X500NameTest {
   }
 
   @Test fun blankAttributeName() {
-    val e = assertThrows(IllegalArgumentException::class.java) {
+    val e = assertThrows<IllegalArgumentException> {
       X500Name.parse("=Marshall T. Rose")
     }
 
@@ -63,7 +63,7 @@ internal class X500NameTest {
   }
 
   @Test fun nakedAttributeName() {
-    val e = assertThrows(IllegalArgumentException::class.java) {
+    val e = assertThrows<IllegalArgumentException> {
       X500Name.parse("CN,")
     }
 
@@ -71,7 +71,7 @@ internal class X500NameTest {
   }
 
   @Test fun unescapedEqualsInAttributeValue() {
-    val e = assertThrows(IllegalArgumentException::class.java) {
+    val e = assertThrows<IllegalArgumentException> {
       X500Name.parse("CN=Marshall = ")
     }
 

--- a/misk/src/test/kotlin/misk/testing/JUnitTest.kt
+++ b/misk/src/test/kotlin/misk/testing/JUnitTest.kt
@@ -1,0 +1,57 @@
+package misk.testing
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+internal class JUnitTest {
+  @Test
+  internal fun assertThrows() {
+    val thrown = assertThrows<IllegalStateException> {
+      throw IllegalStateException("boom")
+    }
+    assertThat(thrown).hasMessage("boom")
+  }
+
+  /**
+   * Identical to the test above, but [AssertionError] is a special case because it's also what we
+   * throw when things don't work.
+   */
+  @Test
+  internal fun assertThrowsAssertionError() {
+    val thrown = assertThrows<AssertionError> {
+      throw AssertionError("boom")
+    }
+    assertThat(thrown).hasMessage("boom")
+  }
+
+  @Test
+  internal fun assertThrowsFailsWithNoException() {
+    var exceptionThrown: Throwable? = null
+    try {
+      assertThrows<IllegalStateException> {
+        // Throw nothing!
+      }
+    } catch (e: Throwable) {
+      exceptionThrown = e
+    }
+
+    assertThat(exceptionThrown).isInstanceOf(AssertionError::class.java)
+    assertThat(exceptionThrown).hasMessage("expected IllegalStateException was not thrown")
+  }
+
+  @Test
+  internal fun assertThrowsFailsWithWrongException() {
+    var exceptionThrown: Throwable? = null
+    try {
+      assertThrows<IllegalStateException> {
+        throw UnsupportedOperationException()
+      }
+    } catch (e: Throwable) {
+      exceptionThrown = e
+    }
+
+    assertThat(exceptionThrown).isInstanceOf(AssertionError::class.java)
+    assertThat(exceptionThrown)
+        .hasMessage("expected IllegalStateException but was UnsupportedOperationException")
+  }
+}

--- a/misk/src/test/kotlin/misk/tracing/MiskTracerTest.kt
+++ b/misk/src/test/kotlin/misk/tracing/MiskTracerTest.kt
@@ -5,14 +5,12 @@ import io.opentracing.Tracer
 import io.opentracing.mock.MockTracer
 import io.opentracing.tag.Tags
 import misk.exceptions.ActionException
-import misk.exceptions.BadRequestException
 import misk.exceptions.StatusCode
 import misk.testing.MiskTest
 import misk.testing.MiskTestModule
 import misk.testing.MockTracingBackendModule
+import misk.testing.assertThrows
 import org.assertj.core.api.Assertions.assertThat
-import org.assertj.core.api.Assertions.assertThatThrownBy
-import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Test
 import javax.inject.Inject
 
@@ -39,7 +37,7 @@ class MiskTracerTest {
     val mockTracer = tracer as MockTracer
 
     assertThat(mockTracer.finishedSpans().size).isEqualTo(0)
-    assertThrows(ActionException::class.java, { miskTracer.trace("failedTrace", ::failedTrace) })
+    assertThrows<ActionException> { miskTracer.trace("failedTrace", ::failedTrace) }
     assertThat(mockTracer.finishedSpans().size).isEqualTo(1)
     assertThat(mockTracer.finishedSpans().get(0).tags().get(Tags.ERROR.key)).isEqualTo(true)
   }

--- a/misk/src/test/kotlin/misk/tracing/TracingConfigTest.kt
+++ b/misk/src/test/kotlin/misk/tracing/TracingConfigTest.kt
@@ -10,8 +10,8 @@ import misk.environment.Environment
 import misk.environment.EnvironmentModule
 import misk.testing.MiskTest
 import misk.testing.MiskTestModule
+import misk.testing.assertThrows
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Test
 import javax.inject.Inject
 
@@ -39,9 +39,9 @@ class TracingConfigTest {
     val config = MiskConfig.load<TestTracingConfig>(
         TestTracingConfig::class.java, "multiple-tracers", defaultEnv)
 
-    val exception = assertThrows(CreationException::class.java, {
+    val exception = assertThrows<CreationException> {
       Guice.createInjector(ConfigModule.create("test_app", config), TracingModule(config.tracing))
-    })
+    }
 
     assertThat(exception.cause).isInstanceOf(IllegalStateException::class.java)
     assertThat(exception.localizedMessage).contains("More than one tracer has been configured." +

--- a/misk/src/test/kotlin/misk/web/extractors/QueryStringParameterProcessorTest.kt
+++ b/misk/src/test/kotlin/misk/web/extractors/QueryStringParameterProcessorTest.kt
@@ -1,7 +1,7 @@
 package misk.web.extractors
 
+import misk.testing.assertThrows
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Test
 import kotlin.reflect.KParameter
 
@@ -70,7 +70,7 @@ internal class QueryStringParameterProcessorTest {
   @Test
   fun invalidInt() {
     val queryStringProcessor = QueryStringParameterProcessor(TestMemberStore.intParameter())
-    assertThrows(IllegalArgumentException::class.java) {
+    assertThrows<IllegalArgumentException> {
       queryStringProcessor.extractFunctionArgumentValue(listOf("forty two"))
     }
   }
@@ -159,7 +159,7 @@ internal class QueryStringParameterProcessorTest {
 
   @Test
   fun unsupportedClass() {
-    assertThrows(IllegalArgumentException::class.java) {
+    assertThrows<IllegalArgumentException> {
       QueryStringParameterProcessor(TestMemberStore.unsupportedParameter())
     }
   }

--- a/misk/src/test/kotlin/misk/web/mediatype/MediaRangeTest.kt
+++ b/misk/src/test/kotlin/misk/web/mediatype/MediaRangeTest.kt
@@ -1,10 +1,10 @@
 package misk.web.mediatype
 
+import misk.testing.assertThrows
 import okhttp3.MediaType
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.containsExactly
 import org.assertj.core.data.Offset
-import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Test
 import java.util.Collections.shuffle
 
@@ -90,56 +90,56 @@ internal class MediaRangeTest {
 
   @Test
   fun wildcardTypeWithSpecificSubType() {
-    assertThrows(IllegalArgumentException::class.java) {
+    assertThrows<IllegalArgumentException> {
       MediaRange.parse("*/html")
     }
   }
 
   @Test
   fun blankType() {
-    assertThrows(IllegalArgumentException::class.java) {
+    assertThrows<IllegalArgumentException> {
       MediaRange.parse("/html")
     }
   }
 
   @Test
   fun blankSubType() {
-    assertThrows(IllegalArgumentException::class.java) {
+    assertThrows<IllegalArgumentException> {
       MediaRange.parse("text/")
     }
   }
 
   @Test
   fun noTypeSubType() {
-    assertThrows(IllegalArgumentException::class.java) {
+    assertThrows<IllegalArgumentException> {
       MediaRange.parse("*")
     }
   }
 
   @Test
   fun blankNameToken() {
-    assertThrows(IllegalArgumentException::class.java) {
+    assertThrows<IllegalArgumentException> {
       MediaRange.parse("text/html;=foo")
     }
   }
 
   @Test
   fun blankValueToken() {
-    assertThrows(IllegalArgumentException::class.java) {
+    assertThrows<IllegalArgumentException> {
       MediaRange.parse("text/html;bar=")
     }
   }
 
   @Test
   fun multipleQualityFactors() {
-    assertThrows(IllegalArgumentException::class.java) {
+    assertThrows<IllegalArgumentException> {
       MediaRange.parse("text/html;q=0.4;q=0.56")
     }
   }
 
   @Test
   fun charsetInExtensions() {
-    assertThrows(IllegalArgumentException::class.java) {
+    assertThrows<IllegalArgumentException> {
       MediaRange.parse("text/html;q=0.4;charset=utf-8")
     }
   }

--- a/misk/src/test/kotlin/misk/web/ssl/JceksSslClientServerTest.kt
+++ b/misk/src/test/kotlin/misk/web/ssl/JceksSslClientServerTest.kt
@@ -23,6 +23,7 @@ import misk.security.x509.X500Name
 import misk.testing.MiskTest
 import misk.testing.MiskTestModule
 import misk.testing.TestWebModule
+import misk.testing.assertThrows
 import misk.web.Post
 import misk.web.RequestBody
 import misk.web.RequestContentType
@@ -34,7 +35,6 @@ import misk.web.actions.WebAction
 import misk.web.jetty.JettyService
 import misk.web.mediatype.MediaTypes
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import javax.inject.Inject
@@ -85,14 +85,14 @@ internal class JceksSslClientServerTest {
   fun failsIfNoCertIsPresented() {
     // In this case the server just hangs up, which might result in a handshake exception
     // or a socket exception depending on the state of things at the time of hangup
-    assertThrows(Throwable::class.java) {
+    assertThrows<Throwable> {
       noCertClient.post<Dinosaur>("/hello", Dinosaur.Builder().name("trex").build())
     }
   }
 
   @Test
   fun failsIfServerIsUntrusted() {
-    assertThrows(SSLHandshakeException::class.java) {
+    assertThrows<SSLHandshakeException> {
       noTrustClient.post<Dinosaur>("/hello", Dinosaur.Builder().name("trex").build())
     }
   }

--- a/misk/src/test/kotlin/misk/web/ssl/PemSslClientServerTest.kt
+++ b/misk/src/test/kotlin/misk/web/ssl/PemSslClientServerTest.kt
@@ -23,6 +23,7 @@ import misk.security.x509.X500Name
 import misk.testing.MiskTest
 import misk.testing.MiskTestModule
 import misk.testing.TestWebModule
+import misk.testing.assertThrows
 import misk.web.Post
 import misk.web.RequestBody
 import misk.web.RequestContentType
@@ -34,7 +35,6 @@ import misk.web.actions.WebAction
 import misk.web.jetty.JettyService
 import misk.web.mediatype.MediaTypes
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import javax.inject.Inject
@@ -87,14 +87,14 @@ internal class PemSslClientServerTest {
   fun failsIfNoCertIsPresented() {
     // In this case the server just hangs up, which might result in a handshake exception
     // or a socket exception depending on the state of things at the time of hangup
-    assertThrows(Throwable::class.java) {
+    assertThrows<Throwable> {
       noCertClient.post<Dinosaur>("/hello", Dinosaur.Builder().name("trex").build())
     }
   }
 
   @Test
   fun failsIfServerIsUntrusted() {
-    assertThrows(SSLHandshakeException::class.java) {
+    assertThrows<SSLHandshakeException> {
       noTrustClient.post<Dinosaur>("/hello", Dinosaur.Builder().name("trex").build())
     }
   }

--- a/misk/src/test/kotlin/org/assertj/core/api/AssertExtensionsTest.kt
+++ b/misk/src/test/kotlin/org/assertj/core/api/AssertExtensionsTest.kt
@@ -1,7 +1,7 @@
 package org.assertj.core.api
 
+import misk.testing.assertThrows
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Test
 
 internal class AssertExtensionsTest {
@@ -24,7 +24,7 @@ internal class AssertExtensionsTest {
 
   @Test
   fun assertAsJsonMismatchedFieldName() {
-    assertThat(assertThrows(AssertionError::class.java) {
+    assertThat(assertThrows<AssertionError> {
       assertThat("""
 {
   "my_structure2"   : ["this", 45, "zip" ],
@@ -42,7 +42,7 @@ internal class AssertExtensionsTest {
 
   @Test
   fun assertAsJsonMismatchedFieldValue() {
-    assertThat(assertThrows(AssertionError::class.java) {
+    assertThat(assertThrows<AssertionError> {
       assertThat("""
 {
   "my_structure"    : ["thisisit", 45, "zip" ],
@@ -60,7 +60,7 @@ internal class AssertExtensionsTest {
 
   @Test
   fun assertAsJsonMismatchedWhitespaceInStringFieldValue() {
-    assertThat(assertThrows(AssertionError::class.java) {
+    assertThat(assertThrows<AssertionError> {
       assertThat("""
 {
   "my_structure"    : ["this", 45, "zip" ],

--- a/misk/testing/src/main/kotlin/misk/cloud/gcp/storage/CustomStorageRpcTestCases.kt
+++ b/misk/testing/src/main/kotlin/misk/cloud/gcp/storage/CustomStorageRpcTestCases.kt
@@ -10,8 +10,8 @@ import com.google.cloud.storage.Storage.BlobListOption.prefix
 import com.google.cloud.storage.StorageException
 import com.google.cloud.storage.StorageOptions
 import com.google.cloud.storage.spi.v1.StorageRpc
+import misk.testing.assertThrows
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import java.nio.ByteBuffer
@@ -74,7 +74,7 @@ internal abstract class CustomStorageRpcTestCases<T : StorageRpc> {
     assertThat(result.contentType).isEqualTo("text/plain")
     assertThat(String(result.getContent())).isEqualTo("This is my text")
 
-    assertThrows(StorageException::class.java) {
+    assertThrows<StorageException> {
       val contents2 = "This is my text"
       storage.create(BlobInfo.newBuilder(blobId)
           .setContentType("text/plain")
@@ -108,7 +108,7 @@ internal abstract class CustomStorageRpcTestCases<T : StorageRpc> {
     assertThat(result2.contentType).isEqualTo("text/plain")
     assertThat(String(result.getContent())).isEqualTo("This is another text")
 
-    assertThrows(StorageException::class.java) {
+    assertThrows<StorageException> {
       val contents3 = "This is the third text"
       storage.create(BlobInfo.newBuilder(blobId2) // Old generation
           .setContentType("text/plain")
@@ -203,7 +203,7 @@ internal abstract class CustomStorageRpcTestCases<T : StorageRpc> {
     assertThat(blob1.size).isEqualTo(contents1.length.toLong())
     assertThat(blob1.exists()).isTrue()
     assertThat(String(blob1.getContent())).isEqualTo(contents2)
-    assertThrows(StorageException::class.java) {
+    assertThrows<StorageException> {
       blob1.getContent(BlobSourceOption.generationMatch())
     }
 

--- a/misk/testing/src/main/kotlin/misk/logging/LogCollectorModule.kt
+++ b/misk/testing/src/main/kotlin/misk/logging/LogCollectorModule.kt
@@ -3,10 +3,11 @@ package misk.logging
 import com.google.common.util.concurrent.Service
 import misk.inject.KAbstractModule
 import misk.inject.addMultibinderBinding
+import misk.inject.to
 
 class LogCollectorModule : KAbstractModule() {
   override fun configure() {
-    bind(LogCollector::class.java).to(RealLogCollector::class.java)
-    binder().addMultibinderBinding<Service>().to(RealLogCollector::class.java)
+    bind<LogCollector>().to<RealLogCollector>()
+    binder().addMultibinderBinding<Service>().to<RealLogCollector>()
   }
 }

--- a/misk/testing/src/main/kotlin/misk/testing/JUnit.kt
+++ b/misk/testing/src/main/kotlin/misk/testing/JUnit.kt
@@ -1,0 +1,18 @@
+package misk.testing
+
+/** Confirms that `block` throws `T`, and returns what was thrown. */
+inline fun <reified T : Throwable> assertThrows(block: () -> Unit): T {
+  var throwable: Throwable? = null
+  try {
+    block()
+  } catch (expected: Throwable) {
+    throwable = expected
+  }
+
+  when (throwable) {
+    is T -> return throwable
+    null -> throw AssertionError("expected ${T::class.simpleName} was not thrown")
+    else -> throw AssertionError(
+        "expected ${T::class.simpleName} but was ${throwable::class.simpleName}", throwable)
+  }
+}

--- a/misk/testing/src/main/kotlin/misk/testing/MockTracingBackendModule.kt
+++ b/misk/testing/src/main/kotlin/misk/testing/MockTracingBackendModule.kt
@@ -6,6 +6,6 @@ import misk.inject.KAbstractModule
 
 class MockTracingBackendModule : KAbstractModule() {
   override fun configure() {
-    bind(Tracer::class.java).to(MockTracer::class.java).asEagerSingleton()
+    bind<Tracer>().to<MockTracer>().asEagerSingleton()
   }
 }

--- a/misk/testing/src/test/kotlin/misk/hibernate/TruncateTablesServiceTest.kt
+++ b/misk/testing/src/test/kotlin/misk/hibernate/TruncateTablesServiceTest.kt
@@ -103,7 +103,7 @@ internal class TruncateTablesServiceTest {
 
   class TestModule : KAbstractModule() {
     override fun configure() {
-      bind(Environment::class.java).toInstance(Environment.TESTING)
+      bind<Environment>().toInstance(Environment.TESTING)
       install(ResourceLoaderModule())
       install(MiskModule())
 

--- a/samples/urlshortener/src/main/kotlin/com/squareup/urlshortener/UrlShortenerModule.kt
+++ b/samples/urlshortener/src/main/kotlin/com/squareup/urlshortener/UrlShortenerModule.kt
@@ -20,7 +20,7 @@ class UrlShortenerModule(val environment: Environment) : KAbstractModule() {
     install(ResourceLoaderModule())
     install(EnvironmentModule(environment))
 
-    bind(UrlStore::class.java).to(RealUrlStore::class.java)
+    bind<UrlStore>().to<RealUrlStore>()
 
     install(HibernateModule(UrlShortener::class, config.data_source_cluster.writer))
     install(object : HibernateEntityModule(UrlShortener::class) {

--- a/samples/urlshortener/src/test/kotlin/com/squareup/urlshortener/ShortenUrlWebActionTest.kt
+++ b/samples/urlshortener/src/test/kotlin/com/squareup/urlshortener/ShortenUrlWebActionTest.kt
@@ -4,11 +4,11 @@ import misk.exceptions.BadRequestException
 import misk.exceptions.NotFoundException
 import misk.testing.MiskTest
 import misk.testing.MiskTestModule
+import misk.testing.assertThrows
 import misk.web.ResponseBody
 import okhttp3.HttpUrl
 import okio.Buffer
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Test
 import javax.inject.Inject
 
@@ -39,14 +39,14 @@ class ShortenUrlWebActionTest {
   @Test
   fun malformedLongUrl() {
     val longUrl = ""
-    assertThrows(BadRequestException::class.java) {
+    assertThrows<BadRequestException> {
       createShortUrlWebAction.createShortUrl(CreateShortUrlWebAction.Request(longUrl))
     }
   }
 
   @Test
   fun unknownToken() {
-    assertThrows(NotFoundException::class.java) {
+    assertThrows<NotFoundException> {
       shortUrlWebAction.follow("unknown")
     }
   }


### PR DESCRIPTION
To help, introduce our own assertThrows() method that works better with Kotlin