### PR TITLE
Tidy up some Guice APIs

### DIFF
--- a/misk/src/main/kotlin/misk/MiskApplication.kt
+++ b/misk/src/main/kotlin/misk/MiskApplication.kt
@@ -16,7 +16,7 @@ class MiskApplication(private val modules: List<Module>, commands: List<MiskComm
   constructor(vararg modules: Module) : this(modules.toList())
   constructor(vararg commands: MiskCommand) : this(listOf(), commands.toList())
 
-  private val commands = commands.map { it.name to it }.toMap()
+  private val commands = commands.associateBy { it.name }
   private val jc: JCommander
 
   init {
@@ -41,9 +41,9 @@ class MiskApplication(private val modules: List<Module>, commands: List<MiskComm
   /**
    * Runs the application, raising a [CliException] if an error occurs. used for testing,
    * to ensure that properly friendly error message are printed when command line parsing
-   * fails or when command preconditions (required arguments etc) are not met
+   * fails or when command preconditions (required arguments etc) are not met.
    *
-   * If no command line arguments are specified, the service starts and blocks until terminated
+   * If no command line arguments are specified, the service starts and blocks until terminated.
    */
   @VisibleForTesting
   internal fun doRun(args: Array<String>) {

--- a/misk/src/main/kotlin/misk/MiskCommand.kt
+++ b/misk/src/main/kotlin/misk/MiskCommand.kt
@@ -23,8 +23,8 @@ abstract class MiskCommand(
 
   /**
    * Confirms that the given precondition is true, otherwise throws a [ParameterException]
-   * with the supplied message
-   * */
+   * with the supplied message.
+   */
   fun requireCli(value: Boolean, lazyMessage: () -> String) {
     if (!value) {
       val exception = ParameterException(lazyMessage())

--- a/misk/src/main/kotlin/misk/MiskModule.kt
+++ b/misk/src/main/kotlin/misk/MiskModule.kt
@@ -2,16 +2,15 @@ package misk
 
 import com.google.common.util.concurrent.Service
 import com.google.common.util.concurrent.ServiceManager
-import com.google.inject.AbstractModule
 import com.google.inject.Provides
 import misk.healthchecks.HealthChecksModule
-import misk.inject.newMultibinder
+import misk.inject.KAbstractModule
 import misk.metrics.MetricsModule
 import misk.moshi.MoshiModule
 import misk.time.ClockModule
 import javax.inject.Singleton
 
-class MiskModule : AbstractModule() {
+class MiskModule : KAbstractModule() {
   override fun configure() {
     install(HealthChecksModule())
     install(MetricsModule())
@@ -20,7 +19,7 @@ class MiskModule : AbstractModule() {
 
     // Always make sure List<Service> is bound, even if there
     // are no services registered (mostly for testing)
-    binder().newMultibinder<Service>()
+    newMultibinder<Service>()
   }
 
   @Provides

--- a/misk/src/main/kotlin/misk/client/ClientApplicationInterceptorModule.kt
+++ b/misk/src/main/kotlin/misk/client/ClientApplicationInterceptorModule.kt
@@ -1,14 +1,13 @@
 package misk.client
 
 import misk.inject.KAbstractModule
-import misk.inject.addMultibinderBinding
 
 /** Installs an application level [ClientApplicationInterceptor] which can observe calls to a peer */
 class ClientApplicationInterceptorModule<T : ClientApplicationInterceptor.Factory>(
   private val interceptorFactory: Class<T>
 ) : KAbstractModule() {
   override fun configure() {
-    binder().addMultibinderBinding<ClientApplicationInterceptor.Factory>().to(interceptorFactory)
+    multibind<ClientApplicationInterceptor.Factory>().to(interceptorFactory)
   }
 
   companion object {

--- a/misk/src/main/kotlin/misk/client/ClientNetworkInterceptorModule.kt
+++ b/misk/src/main/kotlin/misk/client/ClientNetworkInterceptorModule.kt
@@ -1,14 +1,13 @@
 package misk.client
 
 import misk.inject.KAbstractModule
-import misk.inject.addMultibinderBinding
 
 /** Installs a [ClientNetworkInterceptor] to observe outgoing HTTP traffic */
 class ClientNetworkInterceptorModule<T : ClientNetworkInterceptor.Factory> private constructor(
   private val interceptorFactory: Class<T>
 ) : KAbstractModule() {
   override fun configure() {
-    binder().addMultibinderBinding<ClientNetworkInterceptor.Factory>().to(interceptorFactory)
+    multibind<ClientNetworkInterceptor.Factory>().to(interceptorFactory)
   }
 
   companion object {

--- a/misk/src/main/kotlin/misk/client/TypedHttpClientModule.kt
+++ b/misk/src/main/kotlin/misk/client/TypedHttpClientModule.kt
@@ -6,12 +6,8 @@ import com.google.inject.Provider
 import com.squareup.moshi.Moshi
 import io.opentracing.Tracer
 import misk.inject.KAbstractModule
-import misk.inject.newMultibinder
 import okhttp3.OkHttpClient
-import retrofit2.Converter
 import retrofit2.Retrofit
-import retrofit2.converter.moshi.MoshiConverterFactory
-import retrofit2.converter.wire.WireConverterFactory
 import java.lang.reflect.Proxy
 import kotlin.reflect.KClass
 
@@ -24,8 +20,8 @@ class TypedHttpClientModule<T : Any>(
   override fun configure() {
     // Always initialize the network and application interceptor list, even if
     // we don't have any interceptors
-    binder().newMultibinder<ClientNetworkInterceptor.Factory>()
-    binder().newMultibinder<ClientApplicationInterceptor.Factory>()
+    newMultibinder<ClientNetworkInterceptor.Factory>()
+    newMultibinder<ClientApplicationInterceptor.Factory>()
 
     // Install raw HTTP client support
     install(HttpClientModule(name, annotation))

--- a/misk/src/main/kotlin/misk/cloud/gcp/GoogleCloudModule.kt
+++ b/misk/src/main/kotlin/misk/cloud/gcp/GoogleCloudModule.kt
@@ -17,8 +17,6 @@ import misk.cloud.gcp.storage.LocalStorageRpc
 import misk.cloud.gcp.storage.StorageConfig
 import misk.environment.Environment
 import misk.inject.KAbstractModule
-import misk.inject.addMultibinderBinding
-import misk.inject.to
 import misk.logging.getLogger
 import java.nio.file.Paths
 import javax.inject.Inject
@@ -26,7 +24,7 @@ import javax.inject.Inject
 /** Installs support for talking to real GCP services, either direct or via emulator */
 class GoogleCloudModule : KAbstractModule() {
   override fun configure() {
-    binder().addMultibinderBinding<Service>().to<GoogleCloud>()
+    multibind<Service>().to<GoogleCloud>()
   }
 
   @Provides

--- a/misk/src/main/kotlin/misk/cloud/gcp/storage/LocalStorageRpc.kt
+++ b/misk/src/main/kotlin/misk/cloud/gcp/storage/LocalStorageRpc.kt
@@ -10,7 +10,6 @@ import com.google.cloud.storage.spi.v1.StorageRpc.Option.IF_GENERATION_NOT_MATCH
 import com.squareup.moshi.Moshi
 import misk.io.listRecursively
 import misk.moshi.adapter
-import misk.nio.withLock
 import misk.okio.forEachBlock
 import okio.Okio
 import java.io.FileNotFoundException
@@ -578,3 +577,6 @@ private val BlobId.fullName get() = "$bucket:$name"
 
 private fun Path.toBlobId(childPath: Path): BlobId =
     BlobId.of(fileName.toString(), relativize(childPath).joinToString("/"))
+
+fun <T> FileChannel.withLock(shared: Boolean, action: () -> T) =
+    lock(0, Long.MAX_VALUE, shared).use { action() }

--- a/misk/src/main/kotlin/misk/concurrent/WrappingListeningExecutorService.kt
+++ b/misk/src/main/kotlin/misk/concurrent/WrappingListeningExecutorService.kt
@@ -20,7 +20,7 @@ abstract class WrappingListeningExecutorService : ForwardingListeningExecutorSer
   }
 
   override fun <T> submit(runnable: Runnable, result: T): ListenableFuture<T> {
-    return submit<T>({ runnable.run(); result })
+    return submit<T> { runnable.run(); result }
   }
 
   override fun submit(runnable: Runnable): ListenableFuture<*> {

--- a/misk/src/main/kotlin/misk/eventrouter/EventRouterTestingModule.kt
+++ b/misk/src/main/kotlin/misk/eventrouter/EventRouterTestingModule.kt
@@ -5,7 +5,6 @@ import com.google.common.util.concurrent.Service
 import com.google.inject.Provides
 import com.squareup.moshi.Moshi
 import misk.inject.KAbstractModule
-import misk.inject.addMultibinderBinding
 import misk.inject.asSingleton
 import misk.moshi.MoshiAdapterModule
 import misk.moshi.adapter
@@ -29,7 +28,7 @@ class EventRouterTestingModule internal constructor(val distributed: Boolean) : 
     } else {
       bind<EventRouter>().to<RealEventRouter>().asSingleton()
       bind<RealEventRouter>().asSingleton()
-      binder().addMultibinderBinding<Service>().toInstance(object: AbstractIdleService() {
+      multibind<Service>().toInstance(object: AbstractIdleService() {
         @Inject private lateinit var eventRouter: RealEventRouter
         @Inject private lateinit var eventRouterTester: EventRouterTester
         @Inject private lateinit var clusterMapper: FakeClusterMapper

--- a/misk/src/main/kotlin/misk/eventrouter/RealEventRouterModule.kt
+++ b/misk/src/main/kotlin/misk/eventrouter/RealEventRouterModule.kt
@@ -6,9 +6,7 @@ import com.squareup.moshi.Moshi
 import misk.environment.Environment
 import misk.healthchecks.HealthCheck
 import misk.inject.KAbstractModule
-import misk.inject.addMultibinderBinding
 import misk.inject.asSingleton
-import misk.inject.to
 import misk.moshi.MoshiAdapterModule
 import misk.moshi.adapter
 import misk.web.WebActionModule
@@ -23,11 +21,11 @@ class RealEventRouterModule(val environment: Environment) : KAbstractModule() {
   override fun configure() {
     bind<EventRouter>().to<RealEventRouter>().asSingleton()
     bind<RealEventRouter>().asSingleton()
-    binder().addMultibinderBinding<Service>().to<EventRouterService>()
+    multibind<Service>().to<EventRouterService>()
     if (environment == Environment.DEVELOPMENT) {
       bind<ClusterConnector>().to<LocalClusterConnector>()
     } else {
-      binder().addMultibinderBinding<HealthCheck>().to<KubernetesHealthCheck>()
+      multibind<HealthCheck>().to<KubernetesHealthCheck>()
       bind<ClusterConnector>().to<KubernetesClusterConnector>()
     }
     bind<ClusterMapper>().to<ConsistentHashing>()

--- a/misk/src/main/kotlin/misk/healthchecks/ClusterWideHealthModule.kt
+++ b/misk/src/main/kotlin/misk/healthchecks/ClusterWideHealthModule.kt
@@ -3,10 +3,8 @@ package misk.healthchecks
 import com.google.common.util.concurrent.Service
 import com.google.inject.Provides
 import misk.inject.KAbstractModule
-import misk.inject.addMultibinderBinding
-import misk.inject.to
-import misk.web.resources.StaticResourceMapper
 import misk.web.WebActionModule
+import misk.web.resources.StaticResourceMapper
 import java.util.concurrent.Executors
 import java.util.concurrent.ScheduledExecutorService
 import javax.inject.Qualifier
@@ -16,8 +14,8 @@ class ClusterWideHealthModule : KAbstractModule() {
   override fun configure() {
     install(WebActionModule.create<ClusterWideHealthPageAction>())
     install(WebActionModule.create<ClusterWideHealthService>())
-    binder().addMultibinderBinding<Service>().to<ClusterWideHealthService>()
-    binder().addMultibinderBinding<StaticResourceMapper.Entry>()
+    multibind<Service>().to<ClusterWideHealthService>()
+    multibind<StaticResourceMapper.Entry>()
         .toInstance(StaticResourceMapper.Entry("/admin/", "web/admin", "misk/web/admin/build"))
   }
 

--- a/misk/src/main/kotlin/misk/healthchecks/HealthChecksModule.kt
+++ b/misk/src/main/kotlin/misk/healthchecks/HealthChecksModule.kt
@@ -1,18 +1,16 @@
 package misk.healthchecks
 
 import misk.inject.KAbstractModule
-import misk.inject.addMultibinderBinding
-import misk.inject.newMultibinder
 
 class HealthChecksModule(
   private vararg val healthCheckClasses: Class<out HealthCheck>
 ) : KAbstractModule() {
   override fun configure() {
     // Always register binding for the list, even if there are no healthchecks
-    binder().newMultibinder<HealthCheck>()
+    newMultibinder<HealthCheck>()
 
     for (healthCheckClass in healthCheckClasses) {
-      binder().addMultibinderBinding<HealthCheck>().to(healthCheckClass)
+      multibind<HealthCheck>().to(healthCheckClass)
     }
   }
 }

--- a/misk/src/main/kotlin/misk/hibernate/HibernateEntityModule.kt
+++ b/misk/src/main/kotlin/misk/hibernate/HibernateEntityModule.kt
@@ -4,7 +4,6 @@ import com.google.inject.Key
 import com.google.inject.binder.LinkedBindingBuilder
 import com.google.inject.name.Names
 import misk.inject.KAbstractModule
-import misk.inject.newMultibinder
 import org.hibernate.event.spi.EventType
 import java.util.concurrent.atomic.AtomicInteger
 import kotlin.reflect.KClass
@@ -21,16 +20,15 @@ abstract class HibernateEntityModule(
 
   override fun configure() {
     // Initialize empty sets for our multibindings.
-    binder().newMultibinder<HibernateEntity>(qualifier)
-    binder().newMultibinder<ListenerRegistration>(qualifier)
+    newMultibinder<HibernateEntity>(qualifier)
+    newMultibinder<ListenerRegistration>(qualifier)
 
     configureHibernate()
   }
 
   protected fun addEntities(vararg entities: KClass<out DbEntity<*>>) {
     for (entity in entities) {
-      binder().newMultibinder<HibernateEntity>(qualifier)
-          .addBinding()
+      multibind<HibernateEntity>(qualifier)
           .toInstance(HibernateEntity(entity))
     }
   }
@@ -43,8 +41,7 @@ abstract class HibernateEntityModule(
     )
 
     // Create a multibinding for a ListenerRegistration that uses the above key.
-    binder().newMultibinder<ListenerRegistration>(qualifier)
-        .addBinding()
+    multibind<ListenerRegistration>(qualifier)
         .toInstance(ListenerRegistration(type, getProvider(key)))
 
     // Start the binding.

--- a/misk/src/main/kotlin/misk/hibernate/HibernateHealthCheckModule.kt
+++ b/misk/src/main/kotlin/misk/hibernate/HibernateHealthCheckModule.kt
@@ -2,7 +2,6 @@ package misk.hibernate
 
 import misk.healthchecks.HealthCheck
 import misk.inject.KAbstractModule
-import misk.inject.addMultibinderBinding
 import misk.inject.asSingleton
 import misk.jdbc.DataSourceConfig
 import org.hibernate.SessionFactory
@@ -19,7 +18,7 @@ class HibernateHealthCheckModule(
 ) : KAbstractModule() {
 
   override fun configure() {
-    binder().addMultibinderBinding<HealthCheck>()
+    multibind<HealthCheck>()
       .toProvider(object : Provider<HibernateHealthCheck> {
         @Inject lateinit var clock: Clock
 

--- a/misk/src/main/kotlin/misk/hibernate/HibernateModule.kt
+++ b/misk/src/main/kotlin/misk/hibernate/HibernateModule.kt
@@ -3,10 +3,8 @@ package misk.hibernate
 import com.google.common.util.concurrent.Service
 import misk.environment.Environment
 import misk.inject.KAbstractModule
-import misk.inject.addMultibinderBinding
 import misk.inject.asSingleton
 import misk.inject.setOfType
-import misk.inject.to
 import misk.inject.toKey
 import misk.jdbc.DataSourceConfig
 import misk.resources.ResourceLoader
@@ -60,7 +58,7 @@ class HibernateModule(
       SessionFactoryService(qualifier, config, environmentProvider.get(), entitiesProvider.get(),
           eventListenersProvider.get())
     }).asSingleton()
-    binder().addMultibinderBinding<Service>().to(sessionFactoryServiceKey)
+    multibind<Service>().to(sessionFactoryServiceKey)
 
     bind(schemaMigratorKey).toProvider(object : Provider<SchemaMigrator> {
       @Inject lateinit var resourceLoader: ResourceLoader
@@ -72,7 +70,7 @@ class HibernateModule(
       RealTransacter(sessionFactoryProvider.get(), config)
     }).asSingleton()
 
-    binder().addMultibinderBinding<Service>().toProvider(object : Provider<SchemaMigratorService> {
+    multibind<Service>().toProvider(object : Provider<SchemaMigratorService> {
       @Inject lateinit var environment: Environment
       override fun get(): SchemaMigratorService = SchemaMigratorService(
           qualifier, environment, schemaMigratorProvider)

--- a/misk/src/main/kotlin/misk/inject/KAbstractModule.kt
+++ b/misk/src/main/kotlin/misk/inject/KAbstractModule.kt
@@ -1,10 +1,14 @@
 package misk.inject
 
 import com.google.inject.AbstractModule
+import com.google.inject.Key
+import com.google.inject.TypeLiteral
 import com.google.inject.binder.AnnotatedBindingBuilder
 import com.google.inject.binder.LinkedBindingBuilder
 import com.google.inject.binder.ScopedBindingBuilder
 import com.google.inject.multibindings.Multibinder
+import com.google.inject.util.Types
+import kotlin.reflect.KClass
 
 /**
  * A class that provides helper methods for working with Kotlin and Guice, allowing implementing
@@ -34,13 +38,33 @@ abstract class KAbstractModule : AbstractModule() {
     return KotlinAnnotatedBindingBuilder<T>(binder().bind(T::class.java))
   }
 
-  protected inline fun <reified T : Any> AnnotatedBindingBuilder<in T>.to(): ScopedBindingBuilder {
+  protected inline fun <reified T : Any> LinkedBindingBuilder<in T>.to(): ScopedBindingBuilder {
     return to(T::class.java)
   }
 
-  protected inline fun <reified T : Any> newSetBinder(): Multibinder<T> {
-    return Multibinder.newSetBinder(binder(), T::class.java)
+  protected inline fun <reified T : Any> multibind(
+    annotation: KClass<out Annotation>? = null
+  ): LinkedBindingBuilder<T> = newMultibinder<T>(annotation).addBinding()
+
+  protected inline fun <reified T : Any> newMultibinder(
+    annotation: KClass<out Annotation>? = null
+  ): Multibinder<T> = newMultibinder(T::class, annotation)
+
+  @Suppress("UNCHECKED_CAST")
+  protected fun <T : Any> newMultibinder(
+    type: KClass<T>,
+    annotation: KClass<out Annotation>? = null
+  ): Multibinder<T> {
+    val setOfT = parameterizedType<Set<*>>(type.java).typeLiteral() as TypeLiteral<Set<T>>
+    val mutableSetOfTKey = setOfT.toKey(annotation) as Key<MutableSet<T>>
+    val listOfOutT =
+        parameterizedType<List<*>>(Types.subtypeOf(type.java)).typeLiteral() as TypeLiteral<List<T>>
+    val listOfOutTKey = listOfOutT.toKey(annotation)
+    bind(listOfOutTKey).toProvider(ListProvider(mutableSetOfTKey, getProvider(mutableSetOfTKey)))
+
+    return when (annotation) {
+      null -> Multibinder.newSetBinder(binder(), type.java)
+      else -> Multibinder.newSetBinder(binder(), type.java, annotation.java)
+    }
   }
 }
-
-

--- a/misk/src/main/kotlin/misk/metrics/backends/graphite/GraphiteBackendModule.kt
+++ b/misk/src/main/kotlin/misk/metrics/backends/graphite/GraphiteBackendModule.kt
@@ -5,19 +5,17 @@ import com.codahale.metrics.graphite.Graphite
 import com.codahale.metrics.graphite.GraphiteReporter
 import com.codahale.metrics.graphite.GraphiteSender
 import com.google.common.util.concurrent.Service
-import com.google.inject.AbstractModule
 import com.google.inject.Provides
 import com.google.inject.Singleton
 import misk.config.AppName
 import misk.environment.InstanceMetadata
-import misk.inject.addMultibinderBinding
-import misk.inject.to
+import misk.inject.KAbstractModule
 import misk.metrics.Metrics
 import java.util.concurrent.TimeUnit
 
-class GraphiteBackendModule : AbstractModule() {
+class GraphiteBackendModule : KAbstractModule() {
   override fun configure() {
-    binder().addMultibinderBinding<Service>().to<GraphiteReporterService>()
+    multibind<Service>().to<GraphiteReporterService>()
   }
 
   @Provides

--- a/misk/src/main/kotlin/misk/metrics/backends/signalfx/SignalFxBackendModule.kt
+++ b/misk/src/main/kotlin/misk/metrics/backends/signalfx/SignalFxBackendModule.kt
@@ -7,13 +7,11 @@ import com.signalfx.codahale.reporter.SignalFxReporter
 import com.signalfx.metrics.auth.StaticAuthToken
 import misk.config.AppName
 import misk.inject.KAbstractModule
-import misk.inject.addMultibinderBinding
-import misk.inject.to
 import javax.inject.Singleton
 
 class SignalFxBackendModule : KAbstractModule() {
   override fun configure() {
-    binder().addMultibinderBinding<Service>().to<SignalFxReporterService>()
+    multibind<Service>().to<SignalFxReporterService>()
   }
 
   @Provides

--- a/misk/src/main/kotlin/misk/metrics/backends/stackdriver/StackDriverBackendModule.kt
+++ b/misk/src/main/kotlin/misk/metrics/backends/stackdriver/StackDriverBackendModule.kt
@@ -8,9 +8,7 @@ import com.google.inject.Provides
 import com.google.inject.Singleton
 import misk.config.AppName
 import misk.inject.KAbstractModule
-import misk.inject.addMultibinderBinding
 import misk.inject.asSingleton
-import misk.inject.to
 
 class StackDriverBackendModule : KAbstractModule() {
   override fun configure() {
@@ -18,7 +16,7 @@ class StackDriverBackendModule : KAbstractModule() {
         .to<StackDriverBatchedSender>()
         .asSingleton()
 
-    binder().addMultibinderBinding<Service>().to<StackDriverReporterService>()
+    multibind<Service>().to<StackDriverReporterService>()
   }
 
   @Provides

--- a/misk/src/main/kotlin/misk/moshi/MoshiAdapterModule.kt
+++ b/misk/src/main/kotlin/misk/moshi/MoshiAdapterModule.kt
@@ -1,10 +1,9 @@
 package misk.moshi
 
 import misk.inject.KAbstractModule
-import misk.inject.newMultibinder
 
 class MoshiAdapterModule(private val jsonAdapter: Any) : KAbstractModule() {
   override fun configure() {
-    binder().newMultibinder<Any>(MoshiJsonAdapter::class).addBinding().toInstance(jsonAdapter)
+    multibind<Any>(MoshiJsonAdapter::class).toInstance(jsonAdapter)
   }
 }

--- a/misk/src/main/kotlin/misk/moshi/MoshiModule.kt
+++ b/misk/src/main/kotlin/misk/moshi/MoshiModule.kt
@@ -4,19 +4,16 @@ import com.google.inject.Provides
 import com.squareup.moshi.JsonAdapter
 import com.squareup.moshi.Moshi
 import misk.inject.KAbstractModule
-import misk.inject.newMultibinder
-import misk.inject.to
 import misk.moshi.okio.ByteStringAdapter
 import misk.moshi.wire.WireMessageAdapter
 import javax.inject.Singleton
 
 class MoshiModule : KAbstractModule() {
   override fun configure() {
-    val factoryBinder = binder().newMultibinder<JsonAdapter.Factory>(MoshiJsonAdapter::class)
-    factoryBinder.addBinding().to<WireMessageAdapter.Factory>()
+    multibind<JsonAdapter.Factory>(MoshiJsonAdapter::class)
+        .to<WireMessageAdapter.Factory>()
 
-    val adapterBinder = binder().newMultibinder<Any>(MoshiJsonAdapter::class)
-    adapterBinder.addBinding().toInstance(ByteStringAdapter)
+    multibind<Any>(MoshiJsonAdapter::class).toInstance(ByteStringAdapter)
   }
 
   @Provides

--- a/misk/src/main/kotlin/misk/nio/FileExtensions.kt
+++ b/misk/src/main/kotlin/misk/nio/FileExtensions.kt
@@ -1,8 +1,0 @@
-package misk.nio
-
-import java.nio.channels.FileChannel
-
-fun <T> FileChannel.withLock(shared: Boolean, action: () -> T) =
-    lock(0, Long.MAX_VALUE, shared).use { action() }
-
-

--- a/misk/src/main/kotlin/misk/security/authz/AccessControlModule.kt
+++ b/misk/src/main/kotlin/misk/security/authz/AccessControlModule.kt
@@ -3,9 +3,6 @@ package misk.security.authz
 import com.google.inject.TypeLiteral
 import misk.ApplicationInterceptor
 import misk.MiskCaller
-import misk.inject.addMultibinderBinding
-import misk.inject.newMultibinder
-import misk.inject.to
 import misk.scope.ActionScoped
 import misk.scope.ActionScopedProvider
 import misk.scope.ActionScopedProviderModule
@@ -25,11 +22,11 @@ class AccessControlModule(
 
   override fun configureProviders() {
     bindProvider(miskCallerType, MiskCallerProvider::class)
-    binder().newMultibinder<MiskCallerAuthenticator>() // In case no authenticators are registered
+    newMultibinder<MiskCallerAuthenticator>() // In case no authenticators are registered
     authenticators.forEach { authenticator ->
-      binder().newMultibinder<MiskCallerAuthenticator>().addBinding().to(authenticator.java)
+      multibind<MiskCallerAuthenticator>().to(authenticator.java)
     }
-    binder().addMultibinderBinding<ApplicationInterceptor.Factory>().to<AccessInterceptor.Factory>()
+    multibind<ApplicationInterceptor.Factory>().to<AccessInterceptor.Factory>()
   }
 
   class MiskCallerProvider : ActionScopedProvider<MiskCaller?> {

--- a/misk/src/main/kotlin/misk/time/ClockModule.kt
+++ b/misk/src/main/kotlin/misk/time/ClockModule.kt
@@ -2,13 +2,11 @@ package misk.time
 
 import com.google.common.util.concurrent.Service
 import misk.inject.KAbstractModule
-import misk.inject.addMultibinderBinding
-import misk.inject.to
 import java.time.Clock
 
 class ClockModule : KAbstractModule() {
   override fun configure() {
-    binder().addMultibinderBinding<Service>().to<ForceUtcTimeZoneService>()
+    multibind<Service>().to<ForceUtcTimeZoneService>()
 
     bind<Clock>().toInstance(Clock.systemUTC())
   }

--- a/misk/src/main/kotlin/misk/tracing/TracingModule.kt
+++ b/misk/src/main/kotlin/misk/tracing/TracingModule.kt
@@ -2,8 +2,6 @@ package misk.tracing
 
 import com.google.common.util.concurrent.Service
 import misk.inject.KAbstractModule
-import misk.inject.addMultibinderBinding
-import misk.inject.to
 import misk.logging.getLogger
 import misk.tracing.backends.TracingBackendConfig
 import misk.tracing.backends.jaeger.JaegerBackendModule
@@ -15,7 +13,7 @@ private val logger = getLogger<TracingModule>()
 
 class TracingModule(val config: TracingConfig) : KAbstractModule() {
   override fun configure() {
-    binder().addMultibinderBinding<Service>().to<TracingService>()
+    multibind<Service>().to<TracingService>()
 
     val configuredTracers = TracingBackendConfig::class.memberProperties.mapNotNull { it.get(config.backends) }
 

--- a/misk/src/main/kotlin/misk/tracing/backends/jaeger/JaegerBackendModule.kt
+++ b/misk/src/main/kotlin/misk/tracing/backends/jaeger/JaegerBackendModule.kt
@@ -1,15 +1,11 @@
 package misk.tracing.backends.jaeger
 
-import com.google.common.util.concurrent.Service
 import com.google.inject.Provides
 import com.google.inject.Singleton
 import com.uber.jaeger.Configuration
 import io.opentracing.Tracer
 import misk.config.AppName
 import misk.inject.KAbstractModule
-import misk.inject.addMultibinderBinding
-import misk.inject.to
-import misk.tracing.TracingService
 
 class JaegerBackendModule(val config: JaegerBackendConfig?) : KAbstractModule() {
   override fun configure() {}

--- a/misk/src/main/kotlin/misk/tracing/backends/zipkin/ZipkinBackendModule.kt
+++ b/misk/src/main/kotlin/misk/tracing/backends/zipkin/ZipkinBackendModule.kt
@@ -2,14 +2,10 @@ package misk.tracing.backends.zipkin
 
 import brave.Tracing
 import brave.opentracing.BraveTracer
-import com.google.common.util.concurrent.Service
 import com.google.inject.Provides
 import io.opentracing.Tracer
 import misk.config.AppName
 import misk.inject.KAbstractModule
-import misk.inject.addMultibinderBinding
-import misk.inject.to
-import misk.tracing.TracingService
 import zipkin2.reporter.AsyncReporter
 import zipkin2.reporter.okhttp3.OkHttpSender
 import java.util.concurrent.TimeUnit

--- a/misk/src/main/kotlin/misk/web/WebModule.kt
+++ b/misk/src/main/kotlin/misk/web/WebModule.kt
@@ -4,10 +4,6 @@ import misk.ApplicationInterceptor
 import misk.MiskDefault
 import misk.exceptions.ActionException
 import misk.inject.KAbstractModule
-import misk.inject.addMultibinderBinding
-import misk.inject.addMultibinderBindingWithAnnotation
-import misk.inject.newMultibinder
-import misk.inject.to
 import misk.scope.ActionScopedProviderModule
 import misk.security.ssl.CertificatesModule
 import misk.web.exceptions.ActionExceptionMapper
@@ -55,55 +51,55 @@ class WebModule : KAbstractModule() {
     install(UnmarshallerModule.create<ProtobufUnmarshaller.Factory>())
 
     // Create empty set binders of interceptor factories that can be added to by users.
-    binder().newMultibinder<NetworkInterceptor.Factory>()
-    binder().newMultibinder<ApplicationInterceptor.Factory>()
+    newMultibinder<NetworkInterceptor.Factory>()
+    newMultibinder<ApplicationInterceptor.Factory>()
 
     // Register built-in interceptors. Interceptors run in the order in which they are
     // installed, and the order of these interceptors is critical.
 
     // Handle all unexpected errors that occur during dispatch
-    binder().addMultibinderBindingWithAnnotation<NetworkInterceptor.Factory, MiskDefault>()
+    multibind<NetworkInterceptor.Factory>(MiskDefault::class)
         .to<InternalErrorInterceptorFactory>()
 
     // Optionally log request and response details
-    binder().addMultibinderBindingWithAnnotation<NetworkInterceptor.Factory, MiskDefault>()
+    multibind<NetworkInterceptor.Factory>(MiskDefault::class)
         .to<RequestLoggingInterceptor.Factory>()
 
     // Collect metrics on the status of results and response times of requests
-    binder().addMultibinderBindingWithAnnotation<NetworkInterceptor.Factory, MiskDefault>()
+    multibind<NetworkInterceptor.Factory>(MiskDefault::class)
         .to<MetricsInterceptor.Factory>()
 
     // Traces requests as they work their way through the system.
-    binder().addMultibinderBindingWithAnnotation<NetworkInterceptor.Factory, MiskDefault>()
+    multibind<NetworkInterceptor.Factory>(MiskDefault::class)
         .to<TracingInterceptor.Factory>()
 
     // Convert and log application level exceptions into their appropriate response format
-    binder().addMultibinderBindingWithAnnotation<NetworkInterceptor.Factory, MiskDefault>()
+    multibind<NetworkInterceptor.Factory>(MiskDefault::class)
         .to<ExceptionHandlingInterceptor.Factory>()
 
     // Convert typed responses into a ResponseBody that can marshal the response according to
     // the client's requested content-type
-    binder().addMultibinderBindingWithAnnotation<NetworkInterceptor.Factory, MiskDefault>()
+    multibind<NetworkInterceptor.Factory>(MiskDefault::class)
         .to<MarshallerInterceptor.Factory>()
 
-    binder().addMultibinderBindingWithAnnotation<NetworkInterceptor.Factory, MiskDefault>()
+    multibind<NetworkInterceptor.Factory>(MiskDefault::class)
         .to<StaticResourceInterceptor.Factory>()
-    binder().newMultibinder<StaticResourceMapper.Entry>()
+    newMultibinder<StaticResourceMapper.Entry>()
 
     install(ExceptionMapperModule.create<ActionException, ActionExceptionMapper>())
 
     // Register built-in parameter extractors
-    binder().addMultibinderBinding<ParameterExtractor.Factory>()
+    multibind<ParameterExtractor.Factory>()
         .toInstance(PathPatternParameterExtractorFactory)
-    binder().addMultibinderBinding<ParameterExtractor.Factory>()
+    multibind<ParameterExtractor.Factory>()
         .toInstance(QueryStringParameterExtractorFactory)
-    binder().addMultibinderBinding<ParameterExtractor.Factory>()
+    multibind<ParameterExtractor.Factory>()
         .toInstance(FormValueParameterExtractorFactory)
-    binder().addMultibinderBinding<ParameterExtractor.Factory>()
+    multibind<ParameterExtractor.Factory>()
         .toInstance(HeadersParameterExtractorFactory)
-    binder().addMultibinderBinding<ParameterExtractor.Factory>()
+    multibind<ParameterExtractor.Factory>()
         .toInstance(WebSocketParameterExtractorFactory)
-    binder().addMultibinderBinding<ParameterExtractor.Factory>()
+    multibind<ParameterExtractor.Factory>()
         .to<RequestBodyParameterExtractor.Factory>()
 
     // Install infrastructure support

--- a/misk/src/main/kotlin/misk/web/jetty/JettyModule.kt
+++ b/misk/src/main/kotlin/misk/web/jetty/JettyModule.kt
@@ -1,12 +1,10 @@
 package misk.web.jetty
 
 import com.google.common.util.concurrent.Service
-import com.google.inject.AbstractModule
-import misk.inject.addMultibinderBinding
-import misk.inject.to
+import misk.inject.KAbstractModule
 
-class JettyModule : AbstractModule() {
+class JettyModule : KAbstractModule() {
   override fun configure() {
-    binder().addMultibinderBinding<Service>().to<JettyService>()
+    multibind<Service>().to<JettyService>()
   }
 }

--- a/misk/src/main/kotlin/misk/web/marshal/MarshallerModule.kt
+++ b/misk/src/main/kotlin/misk/web/marshal/MarshallerModule.kt
@@ -1,12 +1,11 @@
 package misk.web.marshal
 
 import misk.inject.KAbstractModule
-import misk.inject.addMultibinderBinding
 import kotlin.reflect.KClass
 
 class MarshallerModule<T : Marshaller.Factory>(val kclass: KClass<T>) : KAbstractModule() {
   override fun configure() {
-    binder().addMultibinderBinding<Marshaller.Factory>().to(kclass.java)
+    multibind<Marshaller.Factory>().to(kclass.java)
   }
 
   companion object {

--- a/misk/src/main/kotlin/misk/web/marshal/UnmarshallerModule.kt
+++ b/misk/src/main/kotlin/misk/web/marshal/UnmarshallerModule.kt
@@ -1,12 +1,11 @@
 package misk.web.marshal
 
 import misk.inject.KAbstractModule
-import misk.inject.addMultibinderBinding
 import kotlin.reflect.KClass
 
 class UnmarshallerModule<T : Unmarshaller.Factory>(val kclass: KClass<T>) : KAbstractModule() {
   override fun configure() {
-    binder().addMultibinderBinding<Unmarshaller.Factory>().to(kclass.java)
+    multibind<Unmarshaller.Factory>().to(kclass.java)
   }
 
   companion object {

--- a/misk/src/test/kotlin/misk/client/TypedHttpClientInterceptorTest.kt
+++ b/misk/src/test/kotlin/misk/client/TypedHttpClientInterceptorTest.kt
@@ -6,16 +6,14 @@ import com.google.inject.util.Modules
 import helpers.protos.Dinosaur
 import misk.Action
 import misk.MiskModule
-import misk.web.NetworkChain
-import misk.web.NetworkInterceptor
 import misk.inject.KAbstractModule
-import misk.inject.addMultibinderBinding
 import misk.inject.getInstance
-import misk.inject.to
 import misk.moshi.MoshiModule
 import misk.testing.MiskTest
 import misk.testing.MiskTestModule
 import misk.testing.TestWebModule
+import misk.web.NetworkChain
+import misk.web.NetworkInterceptor
 import misk.web.Post
 import misk.web.RequestBody
 import misk.web.RequestContentType
@@ -152,8 +150,7 @@ internal class TypedHttpClientInterceptorTest {
   class TestModule : KAbstractModule() {
     override fun configure() {
       install(WebActionModule.create<ReturnADinosaurAction>())
-      binder().addMultibinderBinding<NetworkInterceptor.Factory>()
-          .to<ServerHeaderInterceptor.Factory>()
+      multibind<NetworkInterceptor.Factory>().to<ServerHeaderInterceptor.Factory>()
     }
   }
 

--- a/misk/src/test/kotlin/misk/healthchecks/FakeHealthCheckModule.kt
+++ b/misk/src/test/kotlin/misk/healthchecks/FakeHealthCheckModule.kt
@@ -1,11 +1,9 @@
 package misk.healthchecks
 
-import com.google.inject.AbstractModule
-import misk.inject.addMultibinderBinding
-import misk.inject.to
+import misk.inject.KAbstractModule
 
-class FakeHealthCheckModule : AbstractModule() {
+class FakeHealthCheckModule : KAbstractModule() {
   override fun configure() {
-    binder().addMultibinderBinding<HealthCheck>().to<FakeHealthCheck>()
+    multibind<HealthCheck>().to<FakeHealthCheck>()
   }
 }

--- a/misk/src/test/kotlin/misk/hibernate/EventListenersTest.kt
+++ b/misk/src/test/kotlin/misk/hibernate/EventListenersTest.kt
@@ -1,7 +1,6 @@
 package misk.hibernate
 
 import com.google.inject.util.Modules
-import misk.inject.to
 import misk.testing.MiskTest
 import misk.testing.MiskTestModule
 import org.assertj.core.api.Assertions.assertThat

--- a/misk/src/test/kotlin/misk/hibernate/SchemaMigratorTest.kt
+++ b/misk/src/test/kotlin/misk/hibernate/SchemaMigratorTest.kt
@@ -9,7 +9,6 @@ import misk.config.Config
 import misk.config.MiskConfig
 import misk.environment.Environment
 import misk.inject.KAbstractModule
-import misk.inject.addMultibinderBinding
 import misk.inject.toKey
 import misk.jdbc.DataSourceConfig
 import misk.resources.FakeResourceLoader
@@ -61,8 +60,8 @@ internal class SchemaMigratorTest {
 
       val sessionFactoryService =
           SessionFactoryService(Movies::class, config.data_source, defaultEnv)
-      binder().addMultibinderBinding<Service>().toInstance(sessionFactoryService)
-      binder().addMultibinderBinding<Service>().toInstance(dropTablesService)
+      multibind<Service>().toInstance(sessionFactoryService)
+      multibind<Service>().toInstance(dropTablesService)
       bind<SessionFactory>().annotatedWith<Movies>().toProvider(sessionFactoryService)
     }
   }

--- a/misk/src/test/kotlin/misk/services/FakeServiceModule.kt
+++ b/misk/src/test/kotlin/misk/services/FakeServiceModule.kt
@@ -1,12 +1,10 @@
 package misk.services
 
 import com.google.common.util.concurrent.Service
-import com.google.inject.AbstractModule
-import misk.inject.addMultibinderBinding
-import misk.inject.to
+import misk.inject.KAbstractModule
 
-class FakeServiceModule : AbstractModule() {
+class FakeServiceModule : KAbstractModule() {
   override fun configure() {
-    binder().addMultibinderBinding<Service>().to<FakeService>()
+    multibind<Service>().to<FakeService>()
   }
 }

--- a/misk/src/test/kotlin/misk/web/StaticResourceMapperTest.kt
+++ b/misk/src/test/kotlin/misk/web/StaticResourceMapperTest.kt
@@ -3,7 +3,6 @@ package misk.web
 import com.google.inject.util.Modules
 import misk.MiskModule
 import misk.inject.KAbstractModule
-import misk.inject.addMultibinderBinding
 import misk.resources.FakeResourceLoader
 import misk.resources.FakeResourceLoaderModule
 import misk.testing.MiskTest
@@ -108,7 +107,7 @@ class StaticResourceMapperTest {
     override fun configure() {
       install(WebActionModule.create<Hello>())
       install(WebActionModule.create<NotFoundAction>())
-      binder().addMultibinderBinding<StaticResourceMapper.Entry>()
+      multibind<StaticResourceMapper.Entry>()
           .toInstance(StaticResourceMapper.Entry("/", "web", "???"))
     }
   }

--- a/misk/src/test/kotlin/misk/web/interceptors/UserInterceptorTest.kt
+++ b/misk/src/test/kotlin/misk/web/interceptors/UserInterceptorTest.kt
@@ -2,16 +2,16 @@ package misk.web.interceptors
 
 import com.google.inject.util.Modules
 import misk.Action
-import misk.Chain
 import misk.ApplicationInterceptor
+import misk.Chain
 import misk.MiskModule
-import misk.web.NetworkChain
-import misk.web.NetworkInterceptor
 import misk.inject.KAbstractModule
 import misk.testing.MiskTest
 import misk.testing.MiskTestModule
 import misk.testing.TestWebModule
 import misk.web.Get
+import misk.web.NetworkChain
+import misk.web.NetworkInterceptor
 import misk.web.PathParam
 import misk.web.Response
 import misk.web.ResponseContentType
@@ -125,9 +125,9 @@ class UserInterceptorTest {
 
   internal class TestModule : KAbstractModule() {
     override fun configure() {
-      newSetBinder<NetworkInterceptor.Factory>().addBinding()
+      multibind<NetworkInterceptor.Factory>()
           .toInstance(UserCreatedNetworkInterceptor.Factory())
-      newSetBinder<ApplicationInterceptor.Factory>().addBinding()
+      multibind<ApplicationInterceptor.Factory>()
           .toInstance(UserCreatedInterceptor.Factory())
 
       install(WebActionModule.create<TestAction>())

--- a/misk/testing/src/main/kotlin/misk/cloud/gcp/datastore/FakeDatastoreModule.kt
+++ b/misk/testing/src/main/kotlin/misk/cloud/gcp/datastore/FakeDatastoreModule.kt
@@ -7,14 +7,12 @@ import com.google.common.util.concurrent.Service
 import com.google.inject.Provides
 import com.google.inject.Singleton
 import misk.inject.KAbstractModule
-import misk.inject.addMultibinderBinding
-import misk.inject.to
 import javax.inject.Inject
 
 /** Installs a version of the [Datastore] that works off an in-memory local store */
 class FakeDatastoreModule : KAbstractModule() {
   override fun configure() {
-    binder().addMultibinderBinding<Service>().to<FakeDatastoreService>()
+    multibind<Service>().to<FakeDatastoreService>()
   }
 
   @Provides

--- a/misk/testing/src/main/kotlin/misk/hibernate/HibernateTestingModule.kt
+++ b/misk/testing/src/main/kotlin/misk/hibernate/HibernateTestingModule.kt
@@ -2,10 +2,8 @@ package misk.hibernate
 
 import com.google.common.util.concurrent.Service
 import misk.inject.KAbstractModule
-import misk.inject.addMultibinderBinding
 import misk.inject.toKey
 import misk.jdbc.DataSourceConfig
-import org.hibernate.SessionFactory
 import javax.inject.Provider
 import kotlin.reflect.KClass
 
@@ -28,7 +26,7 @@ class HibernateTestingModule(
     val transacterKey = Transacter::class.toKey(qualifier)
     val transacterProvider = getProvider(transacterKey)
 
-    binder().addMultibinderBinding<Service>().to(truncateTablesServiceKey)
+    multibind<Service>().to(truncateTablesServiceKey)
 
     bind(truncateTablesServiceKey).toProvider(Provider<TruncateTablesService> {
       TruncateTablesService(

--- a/misk/testing/src/main/kotlin/misk/logging/LogCollectorModule.kt
+++ b/misk/testing/src/main/kotlin/misk/logging/LogCollectorModule.kt
@@ -2,12 +2,10 @@ package misk.logging
 
 import com.google.common.util.concurrent.Service
 import misk.inject.KAbstractModule
-import misk.inject.addMultibinderBinding
-import misk.inject.to
 
 class LogCollectorModule : KAbstractModule() {
   override fun configure() {
     bind<LogCollector>().to<RealLogCollector>()
-    binder().addMultibinderBinding<Service>().to<RealLogCollector>()
+    multibind<Service>().to<RealLogCollector>()
   }
 }

--- a/misk/testing/src/main/kotlin/misk/testing/AfterEachExtensionModule.kt
+++ b/misk/testing/src/main/kotlin/misk/testing/AfterEachExtensionModule.kt
@@ -2,7 +2,6 @@ package misk.testing
 
 import com.google.inject.Module
 import misk.inject.KAbstractModule
-import misk.inject.addMultibinderBinding
 import org.junit.jupiter.api.extension.AfterEachCallback
 import kotlin.reflect.KClass
 
@@ -12,7 +11,7 @@ class AfterEachExtensionModule<T : AfterEachCallback> constructor(
 ) : KAbstractModule() {
 
   override fun configure() {
-    binder().addMultibinderBinding<AfterEachCallback>().to(kclass.java)
+    multibind<AfterEachCallback>().to(kclass.java)
   }
 
   companion object {

--- a/misk/testing/src/main/kotlin/misk/testing/BeforeEachExtensionModule.kt
+++ b/misk/testing/src/main/kotlin/misk/testing/BeforeEachExtensionModule.kt
@@ -2,7 +2,6 @@ package misk.testing
 
 import com.google.inject.Module
 import misk.inject.KAbstractModule
-import misk.inject.addMultibinderBinding
 import org.junit.jupiter.api.extension.BeforeEachCallback
 import kotlin.reflect.KClass
 
@@ -12,7 +11,7 @@ class BeforeEachExtensionModule<T : BeforeEachCallback> constructor(
 ) : KAbstractModule() {
 
   override fun configure() {
-    binder().addMultibinderBinding<BeforeEachCallback>().to(kclass.java)
+    multibind<BeforeEachCallback>().to(kclass.java)
   }
 
   companion object {

--- a/misk/testing/src/main/kotlin/misk/testing/MiskTestingModule.kt
+++ b/misk/testing/src/main/kotlin/misk/testing/MiskTestingModule.kt
@@ -1,14 +1,13 @@
 package misk.testing
 
 import misk.inject.KAbstractModule
-import misk.inject.newMultibinder
 import org.junit.jupiter.api.extension.AfterEachCallback
 import org.junit.jupiter.api.extension.BeforeEachCallback
 
 /** Ensures there is always a binding for extension callbacks, even if none are registered */
 internal class MiskTestingModule : KAbstractModule() {
   override fun configure() {
-    binder().newMultibinder<BeforeEachCallback>()
-    binder().newMultibinder<AfterEachCallback>()
+    newMultibinder<BeforeEachCallback>()
+    newMultibinder<AfterEachCallback>()
   }
 }

--- a/samples/exemplarchat/src/main/kotlin/com/squareup/chat/ChatModule.kt
+++ b/samples/exemplarchat/src/main/kotlin/com/squareup/chat/ChatModule.kt
@@ -7,11 +7,9 @@ import com.squareup.chat.healthchecks.ManualHealthCheck
 import misk.healthchecks.ClusterWideHealthModule
 import misk.healthchecks.HealthCheck
 import misk.inject.KAbstractModule
-import misk.inject.addMultibinderBinding
-import misk.inject.to
-import misk.web.resources.StaticResourceMapper
 import misk.web.WebActionModule
 import misk.web.actions.DefaultActionsModule
+import misk.web.resources.StaticResourceMapper
 
 class ChatModule : KAbstractModule() {
   override fun configure() {
@@ -20,8 +18,8 @@ class ChatModule : KAbstractModule() {
     install(WebActionModule.create<ToggleManualHealthCheckAction>())
     install(DefaultActionsModule())
     install(ClusterWideHealthModule())
-    binder().addMultibinderBinding<HealthCheck>().to<ManualHealthCheck>()
-    binder().addMultibinderBinding<StaticResourceMapper.Entry>()
+    multibind<HealthCheck>().to<ManualHealthCheck>()
+    multibind<StaticResourceMapper.Entry>()
         .toInstance(StaticResourceMapper.Entry("/", "web/exemplarchat", "exemplarchat/web/build"))
   }
 }


### PR DESCRIPTION
Be more consistent with multibindings, and avoid needing to deference
the binder in the common case that we're in a KAbstractModule.