### PR TITLE
Make default actions with with AccessControlModule

### DIFF
--- a/misk/src/main/kotlin/misk/metrics/web/MetricsJsonAction.kt
+++ b/misk/src/main/kotlin/misk/metrics/web/MetricsJsonAction.kt
@@ -1,6 +1,7 @@
 package misk.metrics.web
 
 import misk.metrics.Metrics
+import misk.security.authz.Unauthenticated
 import misk.web.Get
 import misk.web.ResponseContentType
 import misk.web.actions.WebAction
@@ -13,5 +14,6 @@ import javax.inject.Singleton
 class MetricsJsonAction @Inject internal constructor(val metrics: Metrics) : WebAction {
   @Get("/_metrics")
   @ResponseContentType(MediaTypes.APPLICATION_JSON)
+  @Unauthenticated
   fun getMetrics(): JsonMetrics = JsonMetrics(metrics)
 }

--- a/misk/src/main/kotlin/misk/web/actions/InternalErrorAction.kt
+++ b/misk/src/main/kotlin/misk/web/actions/InternalErrorAction.kt
@@ -1,11 +1,13 @@
 package misk.web.actions
 
+import misk.security.authz.Unauthenticated
 import misk.web.Get
 import javax.inject.Singleton
 
 @Singleton
 class InternalErrorAction : WebAction {
   @Get("/error")
+  @Unauthenticated
   fun error(): Nothing {
     throw UnsupportedOperationException()
   }

--- a/misk/src/main/kotlin/misk/web/actions/LivenessCheckAction.kt
+++ b/misk/src/main/kotlin/misk/web/actions/LivenessCheckAction.kt
@@ -3,6 +3,7 @@ package misk.web.actions
 import com.google.common.util.concurrent.Service
 import com.google.common.util.concurrent.Service.State
 import misk.logging.getLogger
+import misk.security.authz.Unauthenticated
 import misk.web.Get
 import misk.web.Response
 import misk.web.ResponseContentType
@@ -20,6 +21,7 @@ class LivenessCheckAction @Inject internal constructor(
 
   @Get("/_liveness")
   @ResponseContentType(MediaTypes.TEXT_PLAIN_UTF8)
+  @Unauthenticated
   fun livenessCheck(): Response<String> {
     val failedServices = services.filter {
       failedServiceStates.contains(it.state())

--- a/misk/src/main/kotlin/misk/web/actions/NotFoundAction.kt
+++ b/misk/src/main/kotlin/misk/web/actions/NotFoundAction.kt
@@ -1,5 +1,6 @@
 package misk.web.actions
 
+import misk.security.authz.Unauthenticated
 import misk.web.Get
 import misk.web.PathParam
 import misk.web.Post
@@ -18,6 +19,7 @@ class NotFoundAction : WebAction {
   @Post("/{path:.*}")
   @RequestContentType(MediaTypes.ALL)
   @ResponseContentType(MediaTypes.ALL)
+  @Unauthenticated
   fun notFound(@PathParam path: String): Response<ResponseBody> {
     return Response(
         body = "Nothing found at /$path".toResponseBody(),

--- a/misk/src/main/kotlin/misk/web/actions/ReadinessCheckAction.kt
+++ b/misk/src/main/kotlin/misk/web/actions/ReadinessCheckAction.kt
@@ -3,6 +3,7 @@ package misk.web.actions
 import com.google.common.util.concurrent.Service
 import misk.healthchecks.HealthCheck
 import misk.logging.getLogger
+import misk.security.authz.Unauthenticated
 import misk.web.Get
 import misk.web.Response
 import misk.web.ResponseContentType
@@ -20,6 +21,7 @@ class ReadinessCheckAction @Inject internal constructor(
 
   @Get("/_readiness")
   @ResponseContentType(MediaTypes.APPLICATION_JSON)
+  @Unauthenticated
   fun readinessCheck(): Response<String> {
     val servicesNotRunning = services.filter { !it.isRunning }
     val failedHealthChecks = healthChecks

--- a/misk/src/main/kotlin/misk/web/actions/StatusAction.kt
+++ b/misk/src/main/kotlin/misk/web/actions/StatusAction.kt
@@ -3,6 +3,7 @@ package misk.web.actions
 import com.google.common.util.concurrent.Service
 import misk.healthchecks.HealthCheck
 import misk.healthchecks.HealthStatus
+import misk.security.authz.Unauthenticated
 import misk.web.Get
 import misk.web.ResponseContentType
 import misk.web.mediatype.MediaTypes
@@ -21,6 +22,7 @@ class StatusAction @Inject internal constructor(
 
   @Get("/_status")
   @ResponseContentType(MediaTypes.APPLICATION_JSON)
+  @Unauthenticated
   fun getStatus(): ServerStatus {
     val serviceStatus = services.map { it.javaClass.simpleName to it.state() }.toMap()
     val healthCheckStatus = healthChecks.map { it.javaClass.simpleName to it.status() }.toMap()

--- a/misk/src/test/kotlin/misk/web/actions/DefaultActionsWithWithAccessControlModuleTest.kt
+++ b/misk/src/test/kotlin/misk/web/actions/DefaultActionsWithWithAccessControlModuleTest.kt
@@ -1,0 +1,29 @@
+package misk.web.actions
+
+import com.google.inject.util.Modules
+import misk.MiskCaller
+import misk.MiskModule
+import misk.security.authz.AccessControlModule
+import misk.security.authz.MiskCallerAuthenticator
+import misk.testing.MiskTest
+import misk.testing.MiskTestModule
+import org.junit.jupiter.api.Test
+
+@MiskTest(startService = true)
+internal class DefaultActionsWorkWithAccessControlModuleTest {
+  @MiskTestModule
+  val module = Modules.combine(
+      MiskModule(),
+      AccessControlModule(ExampleAuthenticator::class)
+  )
+
+  @Test fun confirmCanCreateService() {
+    // NB(mmihic): Nothing to do, the test is just to make sure that all
+    // of the default actions can be combined with access control
+  }
+
+  class ExampleAuthenticator : MiskCallerAuthenticator {
+    override fun getAuthenticatedCaller(): MiskCaller? = null
+  }
+}
+


### PR DESCRIPTION
When AccessControlModule is installed, all web actions must be marked as
@Authenticated or @Unauthenticated. The default actions were marked with
neither, but should be @Unauthenticated