### PR TITLE
Proxy/Resource Interceptor to Action Part 1

### DIFF
--- a/misk-hibernate/build.gradle
+++ b/misk-hibernate/build.gradle
@@ -7,13 +7,11 @@ apply plugin: "com.vanniktech.maven.publish"
 compileKotlin {
   kotlinOptions {
     jvmTarget = "1.8"
-    allWarningsAsErrors = true
   }
 }
 compileTestKotlin {
   kotlinOptions {
     jvmTarget = "1.8"
-    allWarningsAsErrors = true
   }
 }
 

--- a/misk/build.gradle
+++ b/misk/build.gradle
@@ -7,13 +7,11 @@ apply plugin: "com.vanniktech.maven.publish"
 compileKotlin {
   kotlinOptions {
     jvmTarget = "1.8"
-    allWarningsAsErrors = true
   }
 }
 compileTestKotlin {
   kotlinOptions {
     jvmTarget = "1.8"
-    allWarningsAsErrors = true
   }
 }
 

--- a/misk/src/main/kotlin/misk/web/WebActionEntry.kt
+++ b/misk/src/main/kotlin/misk/web/WebActionEntry.kt
@@ -1,0 +1,25 @@
+package misk.web
+
+import misk.web.actions.WebAction
+import kotlin.reflect.KClass
+
+/**
+ * WebActionEntry
+ *
+ * A registration of a web action with optional configuration to customize.
+ * @param actionClass: WebAction to multibind to WebServlet
+ * @param pathPrefix: defaults to "" empty string. If not empty, must match pattern requirements:
+ *   - must begin with "/"
+ *   - any number of non-whitespace characters (including additional path segments or "/")
+ *   - must terminate with a non-"/"
+ */
+data class WebActionEntry(
+  val actionClass: KClass<out WebAction>,
+  val pathPrefix: String = ""
+) {
+  init {
+    require(pathPrefix.matches(Regex("(/[^/]+)*"))) {
+      "unexpected path prefix: $pathPrefix"
+    }
+  }
+}

--- a/misk/src/main/kotlin/misk/web/WebActionFactory.kt
+++ b/misk/src/main/kotlin/misk/web/WebActionFactory.kt
@@ -1,0 +1,130 @@
+package misk.web
+
+import com.google.inject.Injector
+import misk.ApplicationInterceptor
+import misk.MiskDefault
+import misk.asAction
+import misk.web.actions.WebAction
+import misk.web.extractors.ParameterExtractor
+import misk.web.mediatype.MediaRange
+import okhttp3.MediaType
+import org.eclipse.jetty.http.HttpMethod
+import javax.inject.Inject
+import javax.inject.Provider
+import javax.inject.Singleton
+import kotlin.reflect.KClass
+import kotlin.reflect.KFunction
+import kotlin.reflect.full.findAnnotation
+
+@Singleton
+internal class WebActionFactory {
+  @Inject lateinit var injector: Injector
+
+  @Inject
+  lateinit var userProvidedApplicationInterceptorFactories: List<ApplicationInterceptor.Factory>
+
+  @Inject lateinit var userProvidedNetworkInterceptorFactories: List<NetworkInterceptor.Factory>
+
+  @Inject @MiskDefault lateinit var miskInterceptorFactories: List<NetworkInterceptor.Factory>
+
+  @Inject lateinit var parameterExtractorFactories: List<ParameterExtractor.Factory>
+
+  /**
+   * newBoundAction
+   *
+   * Transforms WebActionEntry into BoundAction
+   *
+   * @param entry: WebActionEntry
+   */
+  fun <A : WebAction> newBoundAction(
+    webActionClass: KClass<A>,
+    pathPrefix: String = ""
+  ): List<BoundAction<A, *>> {
+    // Find the function with Get or Post annotations. Only one such function is
+    // allow, but may have both Get and Post annotations if the action can handle
+    // both forms of HTTP method
+    val actionFunctions = webActionClass.members.mapNotNull {
+      if (it.findAnnotation<Get>() != null ||
+          it.findAnnotation<Post>() != null ||
+          it.findAnnotation<ConnectWebSocket>() != null) {
+        it as? KFunction<*>
+            ?: throw IllegalArgumentException("expected $it to be a function")
+      } else null
+    }
+
+    require(actionFunctions.isNotEmpty()) {
+      "no Get or Post annotations on ${webActionClass.simpleName}"
+    }
+
+    require(actionFunctions.size == 1) {
+      val actionFunctionNames = actionFunctions.joinToString(", ") { it.name }
+      "multiple annotated methods on ${webActionClass.simpleName}: $actionFunctionNames"
+    }
+
+    // Bind providers for each supported HTTP method
+    val actionFunction = actionFunctions.first()
+    val get = actionFunction.findAnnotation<Get>()
+
+    // Only one of ConnectWebSocket and Get may be specified
+    val connectWebSocket = actionFunction.findAnnotation<ConnectWebSocket>()
+    val post = actionFunction.findAnnotation<Post>()
+
+    val provider = injector.getProvider(webActionClass.java)
+
+    val result: MutableList<BoundAction<A, *>> = mutableListOf()
+
+    if (get != null) {
+      result += newBoundAction(provider, actionFunction, HttpMethod.GET,
+          pathPrefix + get.pathPattern, false)
+    }
+    if (connectWebSocket != null) {
+      result += newBoundAction(provider, actionFunction, HttpMethod.GET,
+          connectWebSocket.pathPattern, true)
+    }
+    if (post != null) {
+      result += newBoundAction(provider, actionFunction, HttpMethod.POST,
+          pathPrefix + post.pathPattern, false)
+    }
+
+    return result
+  }
+
+  private fun <A : WebAction> newBoundAction(
+    provider: Provider<A>,
+    function: KFunction<*>,
+    httpMethod: HttpMethod,
+    pathPattern: String,
+    isConnectWebSocketAction: Boolean
+  ): BoundAction<A, *> {
+    // NB: The response media type may be omitted; in this case only generic return types (String,
+    // ByteString, ResponseBody, etc) are supported
+    val responseContentType = function.responseContentType
+    val acceptedContentTypes = function.acceptedContentTypes
+
+    val action = function.asAction()
+
+    val networkInterceptors = ArrayList<NetworkInterceptor>()
+    // Ensure that default interceptors are called before any user provided interceptors
+    miskInterceptorFactories.mapNotNullTo(networkInterceptors) { it.create(action) }
+    userProvidedNetworkInterceptorFactories.mapNotNullTo(networkInterceptors) { it.create(action) }
+
+    val applicationInterceptors = ArrayList<ApplicationInterceptor>()
+    userProvidedApplicationInterceptorFactories.mapNotNullTo(applicationInterceptors) {
+      it.create(action)
+    }
+
+    return BoundAction(provider, networkInterceptors, applicationInterceptors,
+        parameterExtractorFactories, function, PathPattern.parse(pathPattern), httpMethod,
+        acceptedContentTypes, responseContentType, isConnectWebSocketAction)
+  }
+}
+
+private val KFunction<*>.acceptedContentTypes: List<MediaRange>
+  get() = findAnnotation<RequestContentType>()?.value?.flatMap {
+    MediaRange.parseRanges(it)
+  }?.toList() ?: listOf(MediaRange.ALL_MEDIA)
+
+private val KFunction<*>.responseContentType: MediaType?
+  get() = findAnnotation<ResponseContentType>()?.value?.let {
+    MediaType.parse(it)
+  }

--- a/misk/src/main/kotlin/misk/web/WebActionModule.kt
+++ b/misk/src/main/kotlin/misk/web/WebActionModule.kt
@@ -1,168 +1,30 @@
 package misk.web
 
-import com.google.inject.AbstractModule
-import com.google.inject.multibindings.Multibinder
-import misk.ApplicationInterceptor
-import misk.MiskDefault
-import misk.asAction
-import misk.inject.parameterizedType
-import misk.inject.subtypeOf
-import misk.inject.typeLiteral
+import misk.inject.KAbstractModule
 import misk.web.actions.WebAction
-import misk.web.extractors.ParameterExtractor
-import misk.web.mediatype.MediaRange
-import okhttp3.MediaType
-import org.eclipse.jetty.http.HttpMethod
-import javax.inject.Inject
-import javax.inject.Provider
 import kotlin.reflect.KClass
-import kotlin.reflect.KFunction
-import kotlin.reflect.full.findAnnotation
 
+@Suppress("DEPRECATION")
 class WebActionModule<A : WebAction> private constructor(
   val webActionClass: KClass<A>
-) : AbstractModule() {
+) : KAbstractModule() {
   override fun configure() {
-    @Suppress("UNCHECKED_CAST")
-    val binder: Multibinder<BoundAction<A, *>> = Multibinder.newSetBinder(
-        binder(),
-        parameterizedType<BoundAction<*, *>>(subtypeOf<WebAction>(),
-            subtypeOf<Any>()).typeLiteral()
-    ) as Multibinder<BoundAction<A, *>>
-
-    // Find the function with Get or Post annotations. Only one such function is
-    // allow, but may have both Get and Post annotations if the action can handle
-    // both forms of HTTP method
-    val actionFunctions = webActionClass.members.mapNotNull {
-      if (it.findAnnotation<Get>() != null ||
-          it.findAnnotation<Post>() != null ||
-          it.findAnnotation<ConnectWebSocket>() != null) {
-        it as? KFunction<*>
-            ?: throw IllegalArgumentException("expected $it to be a function")
-      } else null
-    }
-
-    require(actionFunctions.isNotEmpty()) {
-      "no Get or Post annotations on ${webActionClass.simpleName}"
-    }
-
-    require(actionFunctions.size == 1) {
-      val actionFunctionNames = actionFunctions.joinToString(", ") { it.name }
-      "multiple annotated methods on ${webActionClass.simpleName}: $actionFunctionNames"
-    }
-
-    // Bind providers for each supported HTTP method
-    val actionFunction = actionFunctions.first()
-    val get = actionFunction.findAnnotation<Get>()
-    if (get != null) {
-      val getProvider = buildProvider(actionFunction, HttpMethod.GET, get.pathPattern, false)
-      binder.addBinding().toProvider(getProvider)
-    }
-
-    // Only one of ConnectWebSocket and Get may be specified
-    val connectWebSocket = actionFunction.findAnnotation<ConnectWebSocket>()
-    require(connectWebSocket == null || get == null) {
-      "only one of Get or ConnectWebSocket may be specified for the same path on ${webActionClass.simpleName}"
-    }
-    if (connectWebSocket != null) {
-      val connectWebSocketProvider =
-          buildProvider(actionFunction, HttpMethod.GET, connectWebSocket.pathPattern, true)
-      binder.addBinding().toProvider(connectWebSocketProvider)
-    }
-
-    val post = actionFunction.findAnnotation<Post>()
-    if (post != null) {
-      val postProvider = buildProvider(actionFunction, HttpMethod.POST, post.pathPattern, false)
-      binder.addBinding().toProvider(postProvider)
-    }
-  }
-
-  private fun buildProvider(
-    function: KFunction<*>,
-    httpMethod: HttpMethod,
-    pathPattern: String,
-    isConnectWebSocketAction: Boolean
-  ):
-      BoundActionProvider<A, *> {
-    // NB(mmihic): The response media type may be ommitted; in this case only
-    // generic return types (String, ByteString, ResponseBody, etc) are supported
-    val responseContentType = function.responseContentType
-    val acceptedContentTypes = function.acceptedContentTypes
-    val provider = getProvider(webActionClass.java)
-    return BoundActionProvider(
-        provider,
-        function,
-        pathPattern,
-        httpMethod,
-        acceptedContentTypes,
-        responseContentType,
-        isConnectWebSocketAction
-    )
+    multibind<WebActionEntry>().toInstance(WebActionEntry(webActionClass))
   }
 
   companion object {
+    @Deprecated("use multibind<WebActionEntry>().toInstance(WebActionEntry(...))")
     inline fun <reified A : WebAction> create(): WebActionModule<A> = create(A::class)
 
+    @Deprecated("use multibind<WebActionEntry>().toInstance(WebActionEntry(...))")
     @JvmStatic
     fun <A : WebAction> create(webActionClass: Class<A>): WebActionModule<A> {
       return create(webActionClass.kotlin)
     }
 
+    @Deprecated("use multibind<WebActionEntry>().toInstance(WebActionEntry(...))")
     fun <A : WebAction> create(webActionClass: KClass<A>): WebActionModule<A> {
       return WebActionModule(webActionClass)
     }
-  }
-}
-
-private val KFunction<*>.acceptedContentTypes: List<MediaRange>
-  get() = findAnnotation<RequestContentType>()?.value?.flatMap {
-    MediaRange.parseRanges(it)
-  }?.toList() ?: listOf(MediaRange.ALL_MEDIA)
-
-private val KFunction<*>.responseContentType: MediaType?
-  get() = findAnnotation<ResponseContentType>()?.value?.let {
-    MediaType.parse(it)
-  }
-
-internal class BoundActionProvider<A : WebAction, R>(
-  val provider: Provider<A>,
-  val function: KFunction<R>,
-  private val pathPattern: String,
-  private val httpMethod: HttpMethod,
-  private val acceptedContentTypes: List<MediaRange>,
-  private val responseContentType: MediaType?,
-  private val isConnectWebSocketAction: Boolean
-) : Provider<BoundAction<A, *>> {
-
-  @Inject
-  private lateinit var userProvidedApplicationInterceptorFactories: List<ApplicationInterceptor.Factory>
-
-  @Inject
-  private lateinit var userProvidedNetworkInterceptorFactories: List<NetworkInterceptor.Factory>
-
-  @Inject
-  @JvmSuppressWildcards
-  @MiskDefault
-  private lateinit var miskInterceptorFactories: Set<NetworkInterceptor.Factory>
-
-  @Inject
-  private lateinit var parameterExtractorFactories: List<ParameterExtractor.Factory>
-
-  override fun get(): BoundAction<A, *> {
-    val action = function.asAction()
-
-    val networkInterceptors = ArrayList<NetworkInterceptor>()
-    // Ensure that default interceptors are called before any user provided interceptors
-    miskInterceptorFactories.mapNotNullTo(networkInterceptors) { it.create(action) }
-    userProvidedNetworkInterceptorFactories.mapNotNullTo(networkInterceptors) { it.create(action) }
-
-    val applicationInterceptors = ArrayList<ApplicationInterceptor>()
-    userProvidedApplicationInterceptorFactories.mapNotNullTo(applicationInterceptors) {
-      it.create(action)
-    }
-
-    return BoundAction(provider, networkInterceptors, applicationInterceptors,
-        parameterExtractorFactories, function, PathPattern.parse(pathPattern), httpMethod,
-        acceptedContentTypes, responseContentType, isConnectWebSocketAction)
   }
 }

--- a/misk/src/main/kotlin/misk/web/jetty/WebActionsServlet.kt
+++ b/misk/src/main/kotlin/misk/web/jetty/WebActionsServlet.kt
@@ -5,6 +5,8 @@ import misk.inject.keyOf
 import misk.scope.ActionScope
 import misk.web.BoundAction
 import misk.web.Request
+import misk.web.WebActionEntry
+import misk.web.WebActionFactory
 import misk.web.actions.WebAction
 import misk.web.mediatype.MediaRange
 import misk.web.mediatype.MediaTypes
@@ -24,9 +26,19 @@ import javax.servlet.http.HttpServletResponse
 
 @Singleton
 internal class WebActionsServlet @Inject constructor(
-  private val boundActions: MutableSet<BoundAction<out WebAction, *>>,
+  webActionFactory: WebActionFactory,
+  webActionEntries: List<WebActionEntry>,
   private val scope: ActionScope
 ) : WebSocketServlet() {
+
+  private val boundActions: MutableSet<BoundAction<out WebAction, *>> = mutableSetOf()
+
+  init {
+    for (entry in webActionEntries) {
+      boundActions += webActionFactory.newBoundAction(entry.actionClass, entry.pathPrefix)
+    }
+  }
+
   override fun doGet(request: HttpServletRequest, response: HttpServletResponse) {
     handleCall(request, response)
   }

--- a/samples/exemplar/build.gradle
+++ b/samples/exemplar/build.gradle
@@ -6,13 +6,11 @@ apply plugin: 'com.github.johnrengelman.shadow'
 compileKotlin {
   kotlinOptions {
     jvmTarget = "1.8"
-    allWarningsAsErrors = true
   }
 }
 compileTestKotlin {
   kotlinOptions {
     jvmTarget = "1.8"
-    allWarningsAsErrors = true
   }
 }
 

--- a/samples/exemplarchat/build.gradle
+++ b/samples/exemplarchat/build.gradle
@@ -6,13 +6,11 @@ apply plugin: 'com.github.johnrengelman.shadow'
 compileKotlin {
   kotlinOptions {
     jvmTarget = "1.8"
-    allWarningsAsErrors = true
   }
 }
 compileTestKotlin {
   kotlinOptions {
     jvmTarget = "1.8"
-    allWarningsAsErrors = true
   }
 }
 

--- a/samples/urlshortener/build.gradle
+++ b/samples/urlshortener/build.gradle
@@ -6,13 +6,11 @@ apply plugin: 'com.github.johnrengelman.shadow'
 compileKotlin {
   kotlinOptions {
     jvmTarget = "1.8"
-    allWarningsAsErrors = true
   }
 }
 compileTestKotlin {
   kotlinOptions {
     jvmTarget = "1.8"
-    allWarningsAsErrors = true
   }
 }
 


### PR DESCRIPTION
WebActionModule deprecated in favour of wrapping all WebActions in a WebActionEntry which can have an optional `pathPrefix` and be multibound. 

Also, "all warnings are errors" turned off in Gradle builds to allow for Deprecation warnings that don't fail the build.