### PR TITLE
Load certificates and private keys with ResourceLoader

### DIFF
--- a/misk/src/main/kotlin/misk/security/ssl/PemComboFile.kt
+++ b/misk/src/main/kotlin/misk/security/ssl/PemComboFile.kt
@@ -3,10 +3,8 @@ package misk.security.ssl
 import okio.Buffer
 import okio.BufferedSource
 import okio.ByteString
-import okio.Okio
 import org.bouncycastle.asn1.ASN1Sequence
 import org.bouncycastle.asn1.pkcs.RSAPrivateKey
-import java.io.File
 import java.io.IOException
 import java.security.KeyStore
 import java.security.cert.Certificate
@@ -74,9 +72,6 @@ data class PemComboFile(
       return PemComboFile(certificates, privateRsaKeys, privateKeys,
           passphrase ?: "password")
     }
-
-    fun load(cert_key_combo: String, passphrase: String? = null) =
-        parse(Okio.buffer(Okio.source(File(cert_key_combo))), passphrase)
 
     fun convertPKCS1toPKCS8(pkcs1Key: ByteString): KeySpec {
       val keyObject = ASN1Sequence.fromByteArray(pkcs1Key.toByteArray())

--- a/misk/src/test/kotlin/misk/client/ProtoMessageHttpClientTest.kt
+++ b/misk/src/test/kotlin/misk/client/ProtoMessageHttpClientTest.kt
@@ -7,6 +7,7 @@ import helpers.protos.Dinosaur
 import misk.inject.KAbstractModule
 import misk.inject.getInstance
 import misk.moshi.MoshiModule
+import misk.resources.ResourceLoaderModule
 import misk.testing.MiskTest
 import misk.testing.MiskTestModule
 import misk.web.Post
@@ -36,7 +37,7 @@ class ProtoMessageHttpClientTest {
 
   @BeforeEach
   fun createClient() {
-    val clientInjector = Guice.createInjector(MoshiModule(), ClientModule(jetty))
+    val clientInjector = Guice.createInjector(ClientModule(jetty))
     httpClient = clientInjector.getInstance(Names.named("dinosaur"))
   }
 
@@ -77,6 +78,8 @@ class ProtoMessageHttpClientTest {
   // need to create the client module _after_ we start the services
   class ClientModule(val jetty: JettyService) : KAbstractModule() {
     override fun configure() {
+      install(MoshiModule())
+      install(ResourceLoaderModule())
       install(HttpClientModule("dinosaur", Names.named("dinosaur")))
     }
 

--- a/misk/src/test/kotlin/misk/client/TypedHttpClientInterceptorTest.kt
+++ b/misk/src/test/kotlin/misk/client/TypedHttpClientInterceptorTest.kt
@@ -7,6 +7,7 @@ import misk.Action
 import misk.inject.KAbstractModule
 import misk.inject.getInstance
 import misk.moshi.MoshiModule
+import misk.resources.ResourceLoaderModule
 import misk.testing.MiskTest
 import misk.testing.MiskTestModule
 import misk.web.NetworkChain
@@ -43,7 +44,7 @@ internal class TypedHttpClientInterceptorTest {
 
   @BeforeEach
   fun createClient() {
-    val clientInjector = Guice.createInjector(MoshiModule(), ClientModule(jetty))
+    val clientInjector = Guice.createInjector(ClientModule(jetty))
     client = clientInjector.getInstance()
   }
 
@@ -149,6 +150,8 @@ internal class TypedHttpClientInterceptorTest {
 
   class ClientModule(val jetty: JettyService) : KAbstractModule() {
     override fun configure() {
+      install(MoshiModule())
+      install(ResourceLoaderModule())
       install(TypedHttpClientModule.create<ReturnADinosaur>("dinosaur"))
       multibind<ClientNetworkInterceptor.Factory>().to<ClientHeaderInterceptor.Factory>()
       multibind<ClientApplicationInterceptor.Factory>().to<ClientNameInterceptor.Factory>()

--- a/misk/src/test/kotlin/misk/client/TypedHttpClientTest.kt
+++ b/misk/src/test/kotlin/misk/client/TypedHttpClientTest.kt
@@ -8,6 +8,7 @@ import helpers.protos.Dinosaur
 import misk.inject.KAbstractModule
 import misk.inject.getInstance
 import misk.moshi.MoshiModule
+import misk.resources.ResourceLoaderModule
 import misk.testing.MiskTest
 import misk.testing.MiskTestModule
 import misk.web.Post
@@ -41,7 +42,7 @@ internal class TypedHttpClientTest {
 
   @BeforeEach
   fun createClient() {
-    clientInjector = Guice.createInjector(MoshiModule(), ClientModule(jetty))
+    clientInjector = Guice.createInjector(ClientModule(jetty))
   }
 
   @Test
@@ -101,6 +102,8 @@ internal class TypedHttpClientTest {
 
   class ClientModule(val jetty: JettyService) : KAbstractModule() {
     override fun configure() {
+      install(MoshiModule())
+      install(ResourceLoaderModule())
       install(TypedHttpClientModule.create<ReturnADinosaur>("dinosaur", Names.named("dinosaur")))
       install(
           TypedHttpClientModule.create<ReturnAProtoDinosaur>("protoDino", Names.named("protoDino")))

--- a/misk/src/test/kotlin/misk/security/ssl/PemComboFileTest.kt
+++ b/misk/src/test/kotlin/misk/security/ssl/PemComboFileTest.kt
@@ -12,9 +12,9 @@ internal class PemComboFileTest {
   @MiskTestModule
   val module = ResourceLoaderModule()
 
-  val clientComboPemPath = "src/test/resources/ssl/client_cert_key_combo.pem"
-  val clientRsaComboPemPath = "src/test/resources/ssl/client_rsa_cert_key_combo.pem"
-  val clientCertPemPath = "src/test/resources/ssl/client_cert.pem"
+  val clientComboPemPath = "/resources/ssl/client_cert_key_combo.pem"
+  val clientRsaComboPemPath = "/resources/ssl/client_rsa_cert_key_combo.pem"
+  val clientCertPemPath = "/resources/ssl/client_cert.pem"
 
   @Inject lateinit var sslLoader: SslLoader
 

--- a/misk/src/test/kotlin/misk/security/ssl/SslLoaderTest.kt
+++ b/misk/src/test/kotlin/misk/security/ssl/SslLoaderTest.kt
@@ -15,9 +15,9 @@ internal class SslLoaderTest {
   @MiskTestModule
   val module = ResourceLoaderModule()
 
-  val clientComboPemPath = "src/test/resources/ssl/client_cert_key_combo.pem"
-  val clientTrustPemPath = "src/test/resources/ssl/client_cert.pem"
-  val serverKeystoreJceksPath = "src/test/resources/ssl/server_keystore.jceks"
+  val clientComboPemPath = "/resources/ssl/client_cert_key_combo.pem"
+  val clientTrustPemPath = "/resources/ssl/client_cert.pem"
+  val serverKeystoreJceksPath = "/resources/ssl/server_keystore.jceks"
 
   @Inject lateinit var sslLoader: SslLoader
 

--- a/misk/src/test/kotlin/misk/tracing/ClientServerTraceTest.kt
+++ b/misk/src/test/kotlin/misk/tracing/ClientServerTraceTest.kt
@@ -15,6 +15,7 @@ import misk.inject.KAbstractModule
 import misk.inject.getInstance
 import misk.inject.keyOf
 import misk.moshi.MoshiModule
+import misk.resources.ResourceLoaderModule
 import misk.testing.MiskTest
 import misk.testing.MiskTestModule
 import misk.testing.MockTracingBackendModule
@@ -56,8 +57,8 @@ internal class ClientServerTraceTest {
 
   @BeforeEach
   fun createClient() {
-    clientInjector =
-        Guice.createInjector(MockTracingBackendModule(), MoshiModule(), ClientModule(jetty))
+    clientInjector = Guice.createInjector(
+        MockTracingBackendModule(), MoshiModule(), ResourceLoaderModule(), ClientModule(jetty))
   }
 
   @Test
@@ -84,7 +85,8 @@ internal class ClientServerTraceTest {
 
   @Test
   fun noTracerNoTracesOrFailures() {
-    val clientInjector = Guice.createInjector(MoshiModule(), ClientModule(jetty))
+    val clientInjector = Guice.createInjector(
+        MoshiModule(), ResourceLoaderModule(), ClientModule(jetty))
     val client = clientInjector.getInstance<ReturnADinosaur>(Names.named("dinosaur"))
 
     client.getDinosaur(dinosaurRequest).execute()

--- a/misk/src/test/kotlin/misk/web/resources/WebProxyInterceptorTest.kt
+++ b/misk/src/test/kotlin/misk/web/resources/WebProxyInterceptorTest.kt
@@ -1,13 +1,12 @@
 package misk.web.resources
 
-import com.google.inject.name.Names
 import misk.asAction
 import misk.client.HttpClientEndpointConfig
-import misk.client.HttpClientModule
 import misk.client.HttpClientsConfig
 import misk.config.ConfigModule
 import misk.inject.KAbstractModule
 import misk.moshi.MoshiModule
+import misk.resources.ResourceLoaderModule
 import misk.testing.MiskTest
 import misk.testing.MiskTestModule
 import misk.web.Request
@@ -58,6 +57,7 @@ class WebProxyInterceptorTest {
   class TestModule(val upstreamServer: MockWebServer) : KAbstractModule() {
     override fun configure() {
       install(MoshiModule())
+      install(ResourceLoaderModule())
       install(WebProxyInterceptorModule())
       install(ConfigModule.create<HttpClientsConfig>("http_clients", HttpClientsConfig(
           endpoints = mapOf(

--- a/misk/src/test/kotlin/misk/web/ssl/Http2ConnectivityTest.kt
+++ b/misk/src/test/kotlin/misk/web/ssl/Http2ConnectivityTest.kt
@@ -9,6 +9,7 @@ import misk.client.HttpClientsConfig
 import misk.inject.KAbstractModule
 import misk.inject.getInstance
 import misk.moshi.MoshiModule
+import misk.resources.ResourceLoaderModule
 import misk.security.ssl.CertStoreConfig
 import misk.security.ssl.SslLoader
 import misk.security.ssl.TrustStoreConfig
@@ -115,7 +116,7 @@ class Http2ConnectivityTest {
       install(WebTestingModule(
           ssl = WebSslConfig(0,
               cert_store = CertStoreConfig(
-                  path = "src/test/resources/ssl/server_cert_key_combo.pem",
+                  path = "/resources/ssl/server_cert_key_combo.pem",
                   passphrase = "serverpassword",
                   format = SslLoader.FORMAT_PEM
               ),
@@ -129,6 +130,7 @@ class Http2ConnectivityTest {
   // _after_ we start the services
   class ClientModule(val jetty: JettyService) : KAbstractModule() {
     override fun configure() {
+      install(ResourceLoaderModule())
       install(MoshiModule())
       install(HttpClientModule("default"))
     }
@@ -143,7 +145,7 @@ class Http2ConnectivityTest {
                   ssl = HttpClientSSLConfig(
                       cert_store = null,
                       trust_store = TrustStoreConfig(
-                          path = "src/test/resources/ssl/server_cert.pem",
+                          path = "/resources/ssl/server_cert.pem",
                           format = SslLoader.FORMAT_PEM
                       )
                   )

--- a/misk/src/test/kotlin/misk/web/ssl/PemSslClientServerTest.kt
+++ b/misk/src/test/kotlin/misk/web/ssl/PemSslClientServerTest.kt
@@ -12,6 +12,7 @@ import misk.client.ProtoMessageHttpClient
 import misk.inject.KAbstractModule
 import misk.inject.getInstance
 import misk.moshi.MoshiModule
+import misk.resources.ResourceLoaderModule
 import misk.scope.ActionScoped
 import misk.security.cert.X500Name
 import misk.security.ssl.CertStoreConfig
@@ -52,7 +53,7 @@ internal class PemSslClientServerTest {
 
   @BeforeEach
   fun createClient() {
-    val clientInjector = Guice.createInjector(MoshiModule(), ClientModule(jetty))
+    val clientInjector = Guice.createInjector(ClientModule(jetty))
     certClient = clientInjector.getInstance(Names.named("cert-and-trust"))
     noCertClient = clientInjector.getInstance(Names.named("no-cert"))
     noTrustClient = clientInjector.getInstance(Names.named("no-trust"))
@@ -93,15 +94,16 @@ internal class PemSslClientServerTest {
 
   class TestModule : KAbstractModule() {
     override fun configure() {
+      install(ResourceLoaderModule())
       install(WebTestingModule(
           ssl = WebSslConfig(0,
               cert_store = CertStoreConfig(
-                  path = "src/test/resources/ssl/server_cert_key_combo.pem",
+                  path = "/resources/ssl/server_cert_key_combo.pem",
                   passphrase = "serverpassword",
                   format = SslLoader.FORMAT_PEM
               ),
               trust_store = TrustStoreConfig(
-                  path = "src/test/resources/ssl/client_cert.pem",
+                  path = "/resources/ssl/client_cert.pem",
                   format = SslLoader.FORMAT_PEM
               ),
               mutual_auth = WebSslConfig.MutualAuth.REQUIRED)
@@ -114,6 +116,8 @@ internal class PemSslClientServerTest {
   // need to create the client module _after_ we start the services
   class ClientModule(val jetty: JettyService) : KAbstractModule() {
     override fun configure() {
+      install(MoshiModule())
+      install(ResourceLoaderModule())
       install(HttpClientModule("cert-and-trust", Names.named("cert-and-trust")))
       install(HttpClientModule("no-cert", Names.named("no-cert")))
       install(HttpClientModule("no-trust", Names.named("no-trust")))
@@ -128,12 +132,12 @@ internal class PemSslClientServerTest {
                   jetty.httpsServerUrl!!.toString(),
                   ssl = HttpClientSSLConfig(
                       cert_store = CertStoreConfig(
-                          path = "src/test/resources/ssl/client_cert_key_combo.pem",
+                          path = "/resources/ssl/client_cert_key_combo.pem",
                           passphrase = "clientpassword",
                           format = SslLoader.FORMAT_PEM
                       ),
                       trust_store = TrustStoreConfig(
-                          path = "src/test/resources/ssl/server_cert.pem",
+                          path = "/resources/ssl/server_cert.pem",
                           format = SslLoader.FORMAT_PEM
                       )
                   )),
@@ -142,7 +146,7 @@ internal class PemSslClientServerTest {
                   ssl = HttpClientSSLConfig(
                       cert_store = null,
                       trust_store = TrustStoreConfig(
-                          path = "src/test/resources/ssl/server_cert.pem",
+                          path = "/resources/ssl/server_cert.pem",
                           format = SslLoader.FORMAT_PEM
                       )
                   )),
@@ -150,12 +154,12 @@ internal class PemSslClientServerTest {
                   jetty.httpsServerUrl!!.toString(),
                   ssl = HttpClientSSLConfig(
                       cert_store = CertStoreConfig(
-                          path = "src/test/resources/ssl/client_cert_key_combo.pem",
+                          path = "/resources/ssl/client_cert_key_combo.pem",
                           passphrase = "clientpassword",
                           format = SslLoader.FORMAT_PEM
                       ),
                       trust_store = TrustStoreConfig(
-                          path = "src/test/resources/ssl/client_cert.pem",
+                          path = "/resources/ssl/client_cert.pem",
                           format = SslLoader.FORMAT_PEM
                       )
                   ))


### PR DESCRIPTION
Previously this accessed the filesystem directly. This won't
work if these resources are elsewhere, such as in a secrets
store.