### PR TITLE
Use URL-like schemes in resource addresses

### DIFF
--- a/misk-hibernate-testing/src/test/resources/test_truncatetables_app-common.yaml
+++ b/misk-hibernate-testing/src/test/resources/test_truncatetables_app-common.yaml
@@ -3,4 +3,4 @@ data_source:
   username: root
   password: ""
   database: truncatetables
-  migrations_path: /resources/misk/hibernate/truncatetables-migrations
+  migrations_resource: resources:/misk/hibernate/truncatetables-migrations

--- a/misk-hibernate/src/main/kotlin/misk/hibernate/DataSourceConfig.kt
+++ b/misk-hibernate/src/main/kotlin/misk/hibernate/DataSourceConfig.kt
@@ -53,7 +53,7 @@ data class DataSourceConfig(
   val fixed_pool_size: Int = 10,
   val connection_timeout: Duration = Duration.ofSeconds(30),
   val connection_max_lifetime: Duration = Duration.ofMinutes(30),
-  val migrations_path: String?
+  val migrations_resource: String?
 )
 
 /** Configuration element for a cluster of DataSources */

--- a/misk-hibernate/src/main/kotlin/misk/hibernate/SchemaMigrator.kt
+++ b/misk-hibernate/src/main/kotlin/misk/hibernate/SchemaMigrator.kt
@@ -19,8 +19,8 @@ private val logger = getLogger<SchemaMigrator>()
 /**
  * Manages **available** and **applied** schema migrations.
  *
- * Available schema migrations are SQL files in the datasource's `migrations_path` directory. Each
- * file should contain SQL statements terminated by a `;`. The files should be named like
+ * Available schema migrations are SQL files in the datasource's `migrations_resource` directory.
+ * Each file should contain SQL statements terminated by a `;`. The files should be named like
  * `v100__exemplar.sql` with a `v`, an integer version, two underscores, a description, and the
  * `.sql` suffix. The integer identifier is the migration version. Versions do not need to be
  * sequential. They are applied in increasing order.
@@ -36,13 +36,13 @@ internal class SchemaMigrator(
 ) {
   /** Returns a map from version to path. */
   fun availableMigrations(): NavigableMap<Int, String> {
-    val resources = config.migrations_path?.let { resourceLoader.list(it) } ?: listOf()
+    val resources = config.migrations_resource?.let { resourceLoader.list(it) } ?: listOf()
     return TreeMap(resources.associateBy { resourceVersion(it) })
   }
 
   /** Creates the `schema_version` table if it does not exist. Returns the applied migrations. */
   fun initialize(): NavigableSet<Int> {
-    if (config.migrations_path == null) {
+    if (config.migrations_resource == null) {
       return TreeSet()
     }
     try {

--- a/misk-hibernate/src/test/kotlin/misk/hibernate/SchemaMigratorTest.kt
+++ b/misk-hibernate/src/test/kotlin/misk/hibernate/SchemaMigratorTest.kt
@@ -71,10 +71,10 @@ internal class SchemaMigratorTest {
   @Test fun initializeAndMigrate() {
     val schemaMigrator = SchemaMigrator(resourceLoader, sessionFactory, config.data_source)
 
-    resourceLoader.put("${config.data_source.migrations_path}/v1001__movies.sql", """
+    resourceLoader.put("${config.data_source.migrations_resource}/v1001__movies.sql", """
         |CREATE TABLE table_1 (name varchar(255))
         |""".trimMargin())
-    resourceLoader.put("${config.data_source.migrations_path}/v1002__movies.sql", """
+    resourceLoader.put("${config.data_source.migrations_resource}/v1002__movies.sql", """
         |CREATE TABLE table_2 (name varchar(255))
         |""".trimMargin())
 
@@ -108,10 +108,10 @@ internal class SchemaMigratorTest {
     schemaMigrator.requireAll()
 
     // When new migrations are added they can be applied.
-    resourceLoader.put("${config.data_source.migrations_path}/v1003__movies.sql", """
+    resourceLoader.put("${config.data_source.migrations_resource}/v1003__movies.sql", """
         |CREATE TABLE table_3 (name varchar(255))
         |""".trimMargin())
-    resourceLoader.put("${config.data_source.migrations_path}/v1004__movies.sql", """
+    resourceLoader.put("${config.data_source.migrations_resource}/v1004__movies.sql", """
         |CREATE TABLE table_4 (name varchar(255))
         |""".trimMargin())
     schemaMigrator.applyAll("SchemaMigratorTest", setOf(1001, 1002))
@@ -128,10 +128,10 @@ internal class SchemaMigratorTest {
     val schemaMigrator = SchemaMigrator(resourceLoader, sessionFactory, config.data_source)
     schemaMigrator.initialize()
 
-    resourceLoader.put("${config.data_source.migrations_path}/v1001__foo.sql", """
+    resourceLoader.put("${config.data_source.migrations_resource}/v1001__foo.sql", """
         |CREATE TABLE table_1 (name varchar(255))
         |""".trimMargin())
-    resourceLoader.put("${config.data_source.migrations_path}/v1002__foo.sql", """
+    resourceLoader.put("${config.data_source.migrations_resource}/v1002__foo.sql", """
         |CREATE TABLE table_1 (name varchar(255))
         |""".trimMargin())
 
@@ -139,8 +139,8 @@ internal class SchemaMigratorTest {
       schemaMigrator.requireAll()
     }).hasMessage("""
           |schemamigrator is missing migrations:
-          |  ${config.data_source.migrations_path}/v1001__foo.sql
-          |  ${config.data_source.migrations_path}/v1002__foo.sql""".trimMargin())
+          |  ${config.data_source.migrations_resource}/v1001__foo.sql
+          |  ${config.data_source.migrations_resource}/v1002__foo.sql""".trimMargin())
   }
 
   @Test fun resourceVersionParsing() {

--- a/misk-hibernate/src/test/resources/boxedstring-common.yaml
+++ b/misk-hibernate/src/test/resources/boxedstring-common.yaml
@@ -3,4 +3,4 @@ data_source:
   username: root
   password: ""
   database: boxedstring
-  migrations_path: /resources/misk/hibernate/boxedstring-migrations
+  migrations_resource: resources:/misk/hibernate/boxedstring-migrations

--- a/misk-hibernate/src/test/resources/bytestringcolumn-common.yaml
+++ b/misk-hibernate/src/test/resources/bytestringcolumn-common.yaml
@@ -3,4 +3,4 @@ data_source:
   username: root
   password: ""
   database: bytestringcolumn
-  migrations_path: /resources/misk/hibernate/bytestringcolumn-migrations
+  migrations_resource: resources:/misk/hibernate/bytestringcolumn-migrations

--- a/misk-hibernate/src/test/resources/moviestestmodule-common.yaml
+++ b/misk-hibernate/src/test/resources/moviestestmodule-common.yaml
@@ -3,4 +3,4 @@ data_source:
   username: root
   password: ""
   database: movies
-  migrations_path: /resources/misk/hibernate/moviestestmodule-migrations
+  migrations_resource: resources:/misk/hibernate/moviestestmodule-migrations

--- a/misk-hibernate/src/test/resources/primitivecolumns-common.yaml
+++ b/misk-hibernate/src/test/resources/primitivecolumns-common.yaml
@@ -3,4 +3,4 @@ data_source:
   username: root
   password: ""
   database: primitivecolumns
-  migrations_path: /resources/misk/hibernate/primitivecolumns-migrations
+  migrations_resource: resources:/misk/hibernate/primitivecolumns-migrations

--- a/misk-hibernate/src/test/resources/test_schemamigrator_app-common.yaml
+++ b/misk-hibernate/src/test/resources/test_schemamigrator_app-common.yaml
@@ -3,4 +3,4 @@ data_source:
   username: root
   password: ""
   database: schemamigrator
-  migrations_path: /memory/migrations
+  migrations_resource: memory:/migrations

--- a/misk/src/main/kotlin/misk/resources/ClasspathResourceLoaderBackend.kt
+++ b/misk/src/main/kotlin/misk/resources/ClasspathResourceLoaderBackend.kt
@@ -8,7 +8,7 @@ import java.util.TreeMap
 /**
  * Read-only resources that are fetched from either the deployed .jar file or the local filesystem.
  *
- * This is mounted at `/resources`.
+ * This uses the scheme `resources:`.
  */
 internal object ClasspathResourceLoaderBackend : ResourceLoader.Backend() {
   private val resourcesByPath: Map<String, ClassPath.ResourceInfo>

--- a/misk/src/main/kotlin/misk/resources/FilesystemLoaderBackend.kt
+++ b/misk/src/main/kotlin/misk/resources/FilesystemLoaderBackend.kt
@@ -9,7 +9,7 @@ import javax.inject.Singleton
 /**
  * Read-only resources that are fetched from the local filesystem using absolute paths.
  *
- * This is mounted at `/filesystem`.
+ * This uses the scheme `filesystem:`.
  */
 @Singleton
 object FilesystemLoaderBackend : ResourceLoader.Backend() {

--- a/misk/src/main/kotlin/misk/resources/MemoryResourceLoaderBackend.kt
+++ b/misk/src/main/kotlin/misk/resources/MemoryResourceLoaderBackend.kt
@@ -10,7 +10,7 @@ import javax.inject.Singleton
  * Read-write resources stored only in memory. Most useful for testing. It is possible to have
  * multiple instances of this backend.
  *
- * This is mounted at `/memory`.
+ * This uses the scheme `memory:`.
  */
 @Singleton
 internal class MemoryResourceLoaderBackend : ResourceLoader.Backend() {

--- a/misk/src/main/kotlin/misk/resources/ResourceLoader.kt
+++ b/misk/src/main/kotlin/misk/resources/ResourceLoader.kt
@@ -11,22 +11,22 @@ import javax.inject.Singleton
  * ResourceLoader is a testable API for loading resources from the classpath, from the filesystem,
  * from memory, or from another [Backend] source.
  *
- * Resource paths look like UNIX filesystem paths: `/resources/migrations/v1.sql`. Paths always
- * start with a backend name like `/resources` or `/memory` and are followed by a path that is
- * backend-specific. This path may have any number of segments.
+ * Resource addresses have a scheme name, a colon, and an absolute filesystem-like path:
+ * `resources:/migrations/v1.sql`. Schemes identify backends `resources:` or `memory:`. Paths start
+ * with a slash and have any number of segments.
  *
- * **Classpath resources** have paths prefixed with `/resources`. The backend reads data from the
+ * **Classpath resources** use the scheme `resources:`. The backend reads data from the
  * `src/main/resources` of the project's modules and the contents of all library `.jar` files.
  * Classpath resources are read-only.
  *
- * **Filesystem resources** have paths prefixed with `/filesystem`. The backend reads data from the
- * host machine's local filesystem. It is read-only and does not support [list].
+ * **Filesystem resources** use the scheme `filesystem:`. The backend reads data from the host
+ * machine's local filesystem. It is read-only and does not support [list].
  *
- * **Memory resources** have paths prefixed with `/memory`. The backend starts empty and is
- * populated by calls to [put].
+ * **Memory resources** use the scheme `memory:`. The backend starts empty and is populated by calls
+ * to [put].
  *
- * Other backends are permitted. They should be registered with a `MapBinder` with the backend name
- * like `/resources` as the key.
+ * Other backends are permitted. They should be registered with a `MapBinder` with the backend
+ * scheme like `resources:` as the key.
  */
 @Singleton
 class ResourceLoader @Inject constructor(
@@ -35,78 +35,75 @@ class ResourceLoader @Inject constructor(
 ) {
   init {
     for (prefix in backends.keySet()) {
-      require(prefix.matches(Regex("/[^/]+")))
+      require(prefix.matches(Regex("[^/:]+:")))
     }
   }
 
-  /** Return a buffered source for `path`, or null if no such resource exists. */
-  fun open(path: String): BufferedSource? {
-    checkPath(path)
+  /** Return a buffered source for `address`, or null if no such resource exists. */
+  fun open(address: String): BufferedSource? {
+    checkAddress(address)
 
-    val (prefix, suffix) = splitPath(path)
-    val backend = backends[prefix] ?: return null
-    return backend.open(suffix)
+    val (scheme, path) = parseAddress(address)
+    val backend = backends[scheme] ?: return null
+    return backend.open(path)
   }
 
   /** Writes a resource as UTF-8. Throws if the backend is readonly. */
-  fun put(path: String, utf8: String) {
-    put(path, ByteString.encodeUtf8(utf8))
+  fun put(address: String, utf8: String) {
+    put(address, ByteString.encodeUtf8(utf8))
   }
 
   /** Writes a resource. Throws if the backend is readonly. */
-  fun put(path: String, data: ByteString) {
-    checkPath(path)
+  fun put(address: String, data: ByteString) {
+    checkAddress(address)
 
-    val (prefix, suffix) = splitPath(path)
-    val backend = backends[prefix] ?: return
-    backend.put(suffix, data)
+    val (scheme, path) = parseAddress(address)
+    val backend = backends[scheme] ?: return
+    backend.put(path, data)
   }
 
-  /** Returns true if a resource at `path` exists. */
-  fun exists(path: String): Boolean {
-    checkPath(path)
+  /** Returns true if a resource at `address` exists. */
+  fun exists(address: String): Boolean {
+    checkAddress(address)
 
-    val (prefix, suffix) = splitPath(path)
-    val backend = backends[prefix] ?: return false
-    return backend.exists(suffix)
+    val (scheme, path) = parseAddress(address)
+    val backend = backends[scheme] ?: return false
+    return backend.exists(path)
   }
 
-  /**
-   * Returns the full path of the resources that are immediate children of `path`. This path must
-   * start and end with `/`.
-   */
-  fun list(path: String): List<String> {
-    checkPath(path)
+  /** Returns the full path of the resources that are immediate children of `address`. */
+  fun list(address: String): List<String> {
+    checkAddress(address)
 
-    val (prefix, suffix) = splitPath(path)
-    val backend = backends[prefix] ?: return listOf()
-    return backend.list(suffix).map { prefix + it }
+    val (scheme, path) = parseAddress(address)
+    val backend = backends[scheme] ?: return listOf()
+    return backend.list(path).map { scheme + it }
   }
 
   /**
-   * Return the contents of `path` as a string, or null if no such resource exists. Note that this
-   * method decodes the resource on every use. It is the caller's responsibility to cache the result
-   * if it is to be loaded frequently.
+   * Return the contents of `address` as a string, or null if no such resource exists. Note that
+   * this method decodes the resource on every use. It is the caller's responsibility to cache the
+   * result if it is to be loaded frequently.
    */
-  fun utf8(path: String): String? {
-    val source = open(path) ?: return null
+  fun utf8(address: String): String? {
+    val source = open(address) ?: return null
     return source.use { it.readUtf8() }
   }
 
-  private fun checkPath(path: String) {
-    require(path.matches(Regex("(/[^/]+)+/?"))) { "unexpected path $path" }
+  private fun checkAddress(address: String) {
+    require(address.matches(Regex("([^/:]+:)(/[^/]+)+/?"))) { "unexpected address $address" }
   }
 
   /**
-   * Splits a path like `/resources/migrations/v1.sql` into a backend prefix like `/resources` and a
-   * backend-specific path like `/migrations/v1.sql`.
+   * Decodes an address like `resources:/migrations/v1.sql` into a backend scheme like `resources:`
+   * and a backend-specific path like `/migrations/v1.sql`.
    */
-  private fun splitPath(path: String): SplitPath {
-    val slash = path.indexOf('/', 1)
-    return SplitPath(path.substring(0, slash), path.substring(slash))
+  private fun parseAddress(path: String): Address {
+    val colon = path.indexOf(':')
+    return Address(path.substring(0, colon + 1), path.substring(colon + 1))
   }
 
-  private data class SplitPath(val prefix: String, val suffix: String)
+  private data class Address(val scheme: String, val path: String)
 
   abstract class Backend {
     abstract fun open(path: String): BufferedSource?

--- a/misk/src/main/kotlin/misk/resources/ResourceLoaderModule.kt
+++ b/misk/src/main/kotlin/misk/resources/ResourceLoaderModule.kt
@@ -7,8 +7,8 @@ class ResourceLoaderModule : KAbstractModule() {
   override fun configure() {
     val mapBinder = MapBinder.newMapBinder(
         binder(), String::class.java, ResourceLoader.Backend::class.java)
-    mapBinder.addBinding("/resources").toInstance(ClasspathResourceLoaderBackend)
-    mapBinder.addBinding("/filesystem").toInstance(FilesystemLoaderBackend)
-    mapBinder.addBinding("/memory").to<MemoryResourceLoaderBackend>()
+    mapBinder.addBinding("resources:").toInstance(ClasspathResourceLoaderBackend)
+    mapBinder.addBinding("filesystem:").toInstance(FilesystemLoaderBackend)
+    mapBinder.addBinding("memory:").to<MemoryResourceLoaderBackend>()
   }
 }

--- a/misk/src/main/kotlin/misk/security/ssl/CertStoreConfig.kt
+++ b/misk/src/main/kotlin/misk/security/ssl/CertStoreConfig.kt
@@ -1,7 +1,7 @@
 package misk.security.ssl
 
 data class CertStoreConfig(
-  val path: String,
+  val resource: String,
   val passphrase: String? = null,
   val format: String = SslLoader.FORMAT_JCEKS
 )

--- a/misk/src/main/kotlin/misk/security/ssl/SslLoader.kt
+++ b/misk/src/main/kotlin/misk/security/ssl/SslLoader.kt
@@ -42,7 +42,7 @@ class SslLoader @Inject internal constructor(
     }
   }
 
-  fun loadTrustStore(config: TrustStoreConfig) = loadTrustStore(config.path, config.format,
+  fun loadTrustStore(config: TrustStoreConfig) = loadTrustStore(config.resource, config.format,
       config.passphrase)
 
   private fun PemComboFile.toTrustStore(): TrustStore? {
@@ -76,7 +76,7 @@ class SslLoader @Inject internal constructor(
   }
 
   fun loadCertStore(config: CertStoreConfig) =
-      loadCertStore(config.path, config.format, config.passphrase)
+      loadCertStore(config.resource, config.format, config.passphrase)
 
   private fun PemComboFile.toCertStore(): CertStore? {
     if (certificates.isEmpty() || privateRsaKeys.size + privateKeys.size != 1) return null

--- a/misk/src/main/kotlin/misk/security/ssl/TrustStoreConfig.kt
+++ b/misk/src/main/kotlin/misk/security/ssl/TrustStoreConfig.kt
@@ -3,7 +3,7 @@ package misk.security.ssl
 import misk.security.ssl.SslLoader.Companion.FORMAT_JCEKS
 
 data class TrustStoreConfig(
-  val path: String,
+  val resource: String,
   val passphrase: String? = null,
   val format: String = FORMAT_JCEKS
 )

--- a/misk/src/test/kotlin/misk/security/ssl/PemComboFileTest.kt
+++ b/misk/src/test/kotlin/misk/security/ssl/PemComboFileTest.kt
@@ -12,9 +12,9 @@ internal class PemComboFileTest {
   @MiskTestModule
   val module = ResourceLoaderModule()
 
-  val clientComboPemPath = "/resources/ssl/client_cert_key_combo.pem"
-  val clientRsaComboPemPath = "/resources/ssl/client_rsa_cert_key_combo.pem"
-  val clientCertPemPath = "/resources/ssl/client_cert.pem"
+  val clientComboPemPath = "resources:/ssl/client_cert_key_combo.pem"
+  val clientRsaComboPemPath = "resources:/ssl/client_rsa_cert_key_combo.pem"
+  val clientCertPemPath = "resources:/ssl/client_cert.pem"
 
   @Inject lateinit var sslLoader: SslLoader
 

--- a/misk/src/test/kotlin/misk/security/ssl/SslLoaderTest.kt
+++ b/misk/src/test/kotlin/misk/security/ssl/SslLoaderTest.kt
@@ -15,9 +15,9 @@ internal class SslLoaderTest {
   @MiskTestModule
   val module = ResourceLoaderModule()
 
-  val clientComboPemPath = "/resources/ssl/client_cert_key_combo.pem"
-  val clientTrustPemPath = "/resources/ssl/client_cert.pem"
-  val serverKeystoreJceksPath = "/resources/ssl/server_keystore.jceks"
+  val clientComboPemPath = "resources:/ssl/client_cert_key_combo.pem"
+  val clientTrustPemPath = "resources:/ssl/client_cert.pem"
+  val serverKeystoreJceksPath = "resources:/ssl/server_keystore.jceks"
 
   @Inject lateinit var sslLoader: SslLoader
 

--- a/misk/src/test/kotlin/misk/web/StaticResourceMapperTest.kt
+++ b/misk/src/test/kotlin/misk/web/StaticResourceMapperTest.kt
@@ -25,17 +25,17 @@ class StaticResourceMapperTest {
 
   @BeforeEach
   internal fun setUp() {
-    resourceLoader.put("/memory/web/app.js", """
+    resourceLoader.put("memory:/web/app.js", """
         |alert("hello world");
         |""".trimMargin())
-    resourceLoader.put("/memory/web/index.html", """
+    resourceLoader.put("memory:/web/index.html", """
         |<html>
         |  <body>
         |    <p>Hello world</p>
         |  </body>
         |</html>
         |""".trimMargin())
-    resourceLoader.put("/memory/web/main.css", """
+    resourceLoader.put("memory:/web/main.css", """
         |hello > world {
         |  color: blue;
         |}
@@ -100,7 +100,7 @@ class StaticResourceMapperTest {
       multibind<WebActionEntry>().toInstance(WebActionEntry(Hello::class))
       multibind<WebActionEntry>().toInstance(WebActionEntry(NotFoundAction::class))
       multibind<StaticResourceMapper.Entry>()
-          .toInstance(StaticResourceMapper.Entry("/", "/memory/web", "???"))
+          .toInstance(StaticResourceMapper.Entry("/", "memory:/web", "???"))
     }
   }
 

--- a/misk/src/test/kotlin/misk/web/ssl/Http2ConnectivityTest.kt
+++ b/misk/src/test/kotlin/misk/web/ssl/Http2ConnectivityTest.kt
@@ -116,7 +116,7 @@ class Http2ConnectivityTest {
       install(WebTestingModule(
           ssl = WebSslConfig(0,
               cert_store = CertStoreConfig(
-                  path = "/resources/ssl/server_cert_key_combo.pem",
+                  resource = "resources:/ssl/server_cert_key_combo.pem",
                   passphrase = "serverpassword",
                   format = SslLoader.FORMAT_PEM
               ),
@@ -145,7 +145,7 @@ class Http2ConnectivityTest {
                   ssl = HttpClientSSLConfig(
                       cert_store = null,
                       trust_store = TrustStoreConfig(
-                          path = "/resources/ssl/server_cert.pem",
+                          resource = "resources:/ssl/server_cert.pem",
                           format = SslLoader.FORMAT_PEM
                       )
                   )

--- a/misk/src/test/kotlin/misk/web/ssl/JceksSslClientServerTest.kt
+++ b/misk/src/test/kotlin/misk/web/ssl/JceksSslClientServerTest.kt
@@ -99,11 +99,11 @@ internal class JceksSslClientServerTest {
       install(WebTestingModule(
           ssl = WebSslConfig(0,
               cert_store = CertStoreConfig(
-                  path = "/resources/ssl/server_keystore.jceks",
+                  resource = "resources:/ssl/server_keystore.jceks",
                   passphrase = "serverpassword"
               ),
               trust_store = TrustStoreConfig(
-                  path = "/resources/ssl/client_cert.pem",
+                  resource = "resources:/ssl/client_cert.pem",
                   format = SslLoader.FORMAT_PEM
               ),
               mutual_auth = WebSslConfig.MutualAuth.REQUIRED)))
@@ -130,11 +130,11 @@ internal class JceksSslClientServerTest {
                   jetty.httpsServerUrl!!.toString(),
                   ssl = HttpClientSSLConfig(
                       cert_store = CertStoreConfig(
-                          path = "/resources/ssl/client_keystore.jceks",
+                          resource = "resources:/ssl/client_keystore.jceks",
                           passphrase = "clientpassword"
                       ),
                       trust_store = TrustStoreConfig(
-                          path = "/resources/ssl/server_cert.pem",
+                          resource = "resources:/ssl/server_cert.pem",
                           format = SslLoader.FORMAT_PEM
                       )
                   )),
@@ -143,7 +143,7 @@ internal class JceksSslClientServerTest {
                   ssl = HttpClientSSLConfig(
                       cert_store = null,
                       trust_store = TrustStoreConfig(
-                          path = "/resources/ssl/server_cert.pem",
+                          resource = "resources:/ssl/server_cert.pem",
                           format = SslLoader.FORMAT_PEM
                       )
                   )),
@@ -151,11 +151,11 @@ internal class JceksSslClientServerTest {
                   jetty.httpsServerUrl!!.toString(),
                   ssl = HttpClientSSLConfig(
                       cert_store = CertStoreConfig(
-                          path = "/resources/ssl/client_keystore.jceks",
+                          resource = "resources:/ssl/client_keystore.jceks",
                           passphrase = "clientpassword"
                       ),
                       trust_store = TrustStoreConfig(
-                          path = "/resources/ssl/client_cert.pem",
+                          resource = "resources:/ssl/client_cert.pem",
                           format = SslLoader.FORMAT_PEM
                       )
                   ))

--- a/misk/src/test/kotlin/misk/web/ssl/PemSslClientServerTest.kt
+++ b/misk/src/test/kotlin/misk/web/ssl/PemSslClientServerTest.kt
@@ -98,12 +98,12 @@ internal class PemSslClientServerTest {
       install(WebTestingModule(
           ssl = WebSslConfig(0,
               cert_store = CertStoreConfig(
-                  path = "/resources/ssl/server_cert_key_combo.pem",
+                  resource = "resources:/ssl/server_cert_key_combo.pem",
                   passphrase = "serverpassword",
                   format = SslLoader.FORMAT_PEM
               ),
               trust_store = TrustStoreConfig(
-                  path = "/resources/ssl/client_cert.pem",
+                  resource = "resources:/ssl/client_cert.pem",
                   format = SslLoader.FORMAT_PEM
               ),
               mutual_auth = WebSslConfig.MutualAuth.REQUIRED)
@@ -132,12 +132,12 @@ internal class PemSslClientServerTest {
                   jetty.httpsServerUrl!!.toString(),
                   ssl = HttpClientSSLConfig(
                       cert_store = CertStoreConfig(
-                          path = "/resources/ssl/client_cert_key_combo.pem",
+                          resource = "resources:/ssl/client_cert_key_combo.pem",
                           passphrase = "clientpassword",
                           format = SslLoader.FORMAT_PEM
                       ),
                       trust_store = TrustStoreConfig(
-                          path = "/resources/ssl/server_cert.pem",
+                          resource = "resources:/ssl/server_cert.pem",
                           format = SslLoader.FORMAT_PEM
                       )
                   )),
@@ -146,7 +146,7 @@ internal class PemSslClientServerTest {
                   ssl = HttpClientSSLConfig(
                       cert_store = null,
                       trust_store = TrustStoreConfig(
-                          path = "/resources/ssl/server_cert.pem",
+                          resource = "resources:/ssl/server_cert.pem",
                           format = SslLoader.FORMAT_PEM
                       )
                   )),
@@ -154,12 +154,12 @@ internal class PemSslClientServerTest {
                   jetty.httpsServerUrl!!.toString(),
                   ssl = HttpClientSSLConfig(
                       cert_store = CertStoreConfig(
-                          path = "/resources/ssl/client_cert_key_combo.pem",
+                          resource = "resources:/ssl/client_cert_key_combo.pem",
                           passphrase = "clientpassword",
                           format = SslLoader.FORMAT_PEM
                       ),
                       trust_store = TrustStoreConfig(
-                          path = "/resources/ssl/client_cert.pem",
+                          resource = "resources:/ssl/client_cert.pem",
                           format = SslLoader.FORMAT_PEM
                       )
                   ))

--- a/samples/urlshortener/src/main/resources/urlshortener-common.yaml
+++ b/samples/urlshortener/src/main/resources/urlshortener-common.yaml
@@ -8,7 +8,7 @@ data_source_cluster:
     username: root
     password: ""
     database: urls
-    migrations_path: /resources/migrations
+    migrations_resource: resources:/migrations
 
 endpoint:
   base_url: http://localhost:8080/


### PR DESCRIPTION
This replaces the backend-type prefix /resources or /memory with a scheme
like resources: or memory:.

Closes: https://github.com/square/misk/issues/342