### PR TITLE
Adds client interceptor support

### DIFF
--- a/misk/src/main/kotlin/misk/client/BeginClientCallChain.kt
+++ b/misk/src/main/kotlin/misk/client/BeginClientCallChain.kt
@@ -1,0 +1,9 @@
+package misk.client
+
+import retrofit2.Call
+
+interface BeginClientCallChain {
+  val action: ClientAction
+  val args: List<*>
+  fun proceed(args: List<*>) : Call<Any>
+}

--- a/misk/src/main/kotlin/misk/client/ClientAction.kt
+++ b/misk/src/main/kotlin/misk/client/ClientAction.kt
@@ -1,0 +1,17 @@
+package misk.client
+
+import kotlin.reflect.KFunction
+import kotlin.reflect.KType
+
+data class ClientAction(
+  val name: String,
+  val function: KFunction<*>,
+  val parameterTypes: List<KType>,
+  val returnType: KType
+) {
+  internal constructor(clientName: String, method: KFunction<*>) :
+      this("$clientName.${method.name}",
+          method,
+          method.parameters.drop(1).map { it.type }, // drop the 'this' parameter
+          method.returnType)
+}

--- a/misk/src/main/kotlin/misk/client/ClientApplicationInterceptor.kt
+++ b/misk/src/main/kotlin/misk/client/ClientApplicationInterceptor.kt
@@ -1,0 +1,22 @@
+package misk.client
+
+import retrofit2.Call
+
+/**
+ * Intercepts client side calls at the application level, able to view and modify the
+ * outgoing request arguments, and to observe the application level response
+ */
+interface ClientApplicationInterceptor {
+  /** Intercepts the start of a new call. Can view or modify the arguments to the call */
+  fun interceptBeginCall(chain: BeginClientCallChain): Call<Any>
+
+  /**
+   * Intercepts the execution of a call. Can observe / modify the outgoing request, and
+   * can register a callback to observe the response
+   */
+  fun intercept(chain: ClientChain)
+
+  interface Factory {
+    fun create(action: ClientAction): ClientApplicationInterceptor?
+  }
+}

--- a/misk/src/main/kotlin/misk/client/ClientApplicationInterceptorModule.kt
+++ b/misk/src/main/kotlin/misk/client/ClientApplicationInterceptorModule.kt
@@ -1,0 +1,22 @@
+package misk.client
+
+import misk.inject.KAbstractModule
+import misk.inject.addMultibinderBinding
+
+/** Installs an application level [ClientApplicationInterceptor] which can observe calls to a peer */
+class ClientApplicationInterceptorModule<T : ClientApplicationInterceptor.Factory>(
+  private val interceptorFactory: Class<T>
+) : KAbstractModule() {
+  override fun configure() {
+    binder().addMultibinderBinding<ClientApplicationInterceptor.Factory>().to(interceptorFactory)
+  }
+
+  companion object {
+    @JvmStatic
+    fun <T : ClientApplicationInterceptor.Factory> create(interceptorFactory: Class<T>) =
+        ClientApplicationInterceptorModule(interceptorFactory)
+
+    inline fun <reified T : ClientApplicationInterceptor.Factory> create() = create(T::class.java)
+  }
+
+}

--- a/misk/src/main/kotlin/misk/client/ClientChain.kt
+++ b/misk/src/main/kotlin/misk/client/ClientChain.kt
@@ -1,0 +1,12 @@
+package misk.client
+
+import retrofit2.Call
+import retrofit2.Callback
+
+interface ClientChain {
+  val action: ClientAction
+  val args: List<*>
+  val call: Call<Any>
+  val callback: Callback<Any>
+  fun proceed(args: List<*>, callback: Callback<Any>)
+}

--- a/misk/src/main/kotlin/misk/client/ClientNetworkChain.kt
+++ b/misk/src/main/kotlin/misk/client/ClientNetworkChain.kt
@@ -1,0 +1,10 @@
+package misk.client
+
+import okhttp3.Request
+import okhttp3.Response
+
+interface ClientNetworkChain {
+  val action: ClientAction
+  val request: okhttp3.Request
+  fun proceed(request: Request): Response
+}

--- a/misk/src/main/kotlin/misk/client/ClientNetworkInterceptor.kt
+++ b/misk/src/main/kotlin/misk/client/ClientNetworkInterceptor.kt
@@ -1,0 +1,15 @@
+package misk.client
+
+import okhttp3.Response
+
+/**
+ * Intercepts client side calls at the application level, able to view and modify the
+ * outgoing HTTP request and observe the returned HTTP response
+ */
+interface ClientNetworkInterceptor {
+  fun intercept(chain: ClientNetworkChain) : Response
+
+  interface Factory {
+    fun create(action: ClientAction) : ClientNetworkInterceptor?
+  }
+}

--- a/misk/src/main/kotlin/misk/client/ClientNetworkInterceptorModule.kt
+++ b/misk/src/main/kotlin/misk/client/ClientNetworkInterceptorModule.kt
@@ -1,0 +1,20 @@
+package misk.client
+
+import misk.inject.KAbstractModule
+import misk.inject.addMultibinderBinding
+
+/** Installs a [ClientNetworkInterceptor] to observe outgoing HTTP traffic */
+class ClientNetworkInterceptorModule<T : ClientNetworkInterceptor.Factory> private constructor(
+  private val interceptorFactory: Class<T>
+) : KAbstractModule() {
+  override fun configure() {
+    binder().addMultibinderBinding<ClientNetworkInterceptor.Factory>().to(interceptorFactory)
+  }
+
+  companion object {
+    fun <T : ClientNetworkInterceptor.Factory> create(clazz: Class<T>) =
+        ClientNetworkInterceptorModule(clazz)
+
+    inline fun <reified T : ClientNetworkInterceptor.Factory> create() = create(T::class.java)
+  }
+}

--- a/misk/src/main/kotlin/misk/client/HttpClientModule.kt
+++ b/misk/src/main/kotlin/misk/client/HttpClientModule.kt
@@ -29,7 +29,7 @@ class HttpClientModule constructor(
     @Inject
     lateinit var httpClientsConfig: HttpClientsConfig
 
-    override fun get() = httpClientsConfig.newHttpClient(name)
+    override fun get() = httpClientsConfig[name].newHttpClient()
   }
 
   private class ProtoMessageHttpClientProvider(
@@ -43,8 +43,7 @@ class HttpClientModule constructor(
     lateinit var httpClientsConfig: HttpClientsConfig
 
     override fun get(): ProtoMessageHttpClient {
-      val endpointConfig = httpClientsConfig.endpoints[name] ?: throw IllegalArgumentException(
-          "no client configuration for endpoint $name")
+      val endpointConfig = httpClientsConfig[name]
       val httpClient = httpClientProvider.get()
       return ProtoMessageHttpClient(endpointConfig.url, moshi, httpClient)
     }

--- a/misk/src/main/kotlin/misk/client/RealBeginClientCallChain.kt
+++ b/misk/src/main/kotlin/misk/client/RealBeginClientCallChain.kt
@@ -1,0 +1,16 @@
+package misk.client
+
+import retrofit2.Call
+
+internal class RealBeginClientCallChain(
+  override val action: ClientAction,
+  override val args: List<*>,
+  private val interceptors: List<ClientApplicationInterceptor>,
+  private val index: Int = 0
+) : BeginClientCallChain {
+  override fun proceed(args: List<*>): Call<Any> {
+    check(index < interceptors.size) { "final interceptor must be terminal" }
+    val next = RealBeginClientCallChain(action, args, interceptors, index + 1)
+    return interceptors[index].interceptBeginCall(next)
+  }
+}

--- a/misk/src/main/kotlin/misk/client/RealClientChain.kt
+++ b/misk/src/main/kotlin/misk/client/RealClientChain.kt
@@ -1,0 +1,19 @@
+package misk.client
+
+import retrofit2.Callback
+import retrofit2.Call
+
+internal class RealClientChain(
+  override val action: ClientAction,
+  override val args: List<*>,
+  override val call: Call<Any>,
+  override val callback: Callback<Any>,
+  private val interceptors: List<ClientApplicationInterceptor>,
+  private val index: Int = 0
+) : ClientChain {
+  override fun proceed(args: List<*>, callback: Callback<Any>) {
+    check(index < interceptors.size) { "final interceptor must be terminal" }
+    val next = RealClientChain(action, args, call, callback, interceptors, index + 1)
+    return interceptors[index].intercept(next)
+  }
+}

--- a/misk/src/main/kotlin/misk/client/RealClientNetworkChain.kt
+++ b/misk/src/main/kotlin/misk/client/RealClientNetworkChain.kt
@@ -1,0 +1,12 @@
+package misk.client
+
+import okhttp3.Request
+import okhttp3.Response
+
+internal class RealClientNetworkChain(
+  private val okhttpChain: okhttp3.Interceptor.Chain,
+  override val action: ClientAction
+) : ClientNetworkChain {
+  override val request: okhttp3.Request = okhttpChain.request()
+  override fun proceed(request: Request): Response = okhttpChain.proceed(request)
+}

--- a/misk/src/main/kotlin/misk/web/RealChain.kt
+++ b/misk/src/main/kotlin/misk/web/RealChain.kt
@@ -6,25 +6,15 @@ import misk.web.actions.WebAction
 import kotlin.reflect.KFunction
 
 internal class RealChain(
-  private val _action: WebAction,
-  private val _args: List<Any?>,
+  override val action: WebAction,
+  override val args: List<Any?>,
   private val interceptors: List<ApplicationInterceptor>,
-  private val _function: KFunction<*>,
+  override val function: KFunction<*>,
   private val index: Int = 0
 ) : Chain {
-
-  override val action: WebAction
-    get() = _action
-
-  override val args: List<Any?>
-    get() = _args
-
-  override val function: KFunction<*>
-    get() = _function
-
   override fun proceed(args: List<Any?>): Any {
     check(index < interceptors.size) { "final interceptor must be terminal" }
-    val next = RealChain(_action, args, interceptors, function, index + 1)
+    val next = RealChain(action, args, interceptors, function, index + 1)
     return interceptors[index].intercept(next)
   }
 }

--- a/misk/src/test/kotlin/misk/client/TypedHttpClientInterceptorTest.kt
+++ b/misk/src/test/kotlin/misk/client/TypedHttpClientInterceptorTest.kt
@@ -1,0 +1,177 @@
+package misk.client
+
+import com.google.inject.Guice
+import com.google.inject.Provides
+import com.google.inject.util.Modules
+import helpers.protos.Dinosaur
+import misk.Action
+import misk.MiskModule
+import misk.NetworkChain
+import misk.NetworkInterceptor
+import misk.inject.KAbstractModule
+import misk.inject.addMultibinderBinding
+import misk.inject.getInstance
+import misk.inject.to
+import misk.moshi.MoshiModule
+import misk.testing.MiskTest
+import misk.testing.MiskTestModule
+import misk.testing.TestWebModule
+import misk.web.Post
+import misk.web.RequestBody
+import misk.web.RequestContentType
+import misk.web.ResponseContentType
+import misk.web.WebActionModule
+import misk.web.WebModule
+import misk.web.actions.WebAction
+import misk.web.jetty.JettyService
+import misk.web.mediatype.MediaTypes
+import okhttp3.Response
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import retrofit2.Call
+import retrofit2.Callback
+import retrofit2.http.Body
+import retrofit2.http.POST
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@MiskTest(startService = true)
+internal class TypedHttpClientInterceptorTest {
+  @MiskTestModule
+  val module = Modules.combine(
+      MiskModule(),
+      WebModule(),
+      TestWebModule(),
+      TestModule()
+  )
+
+  @Inject
+  private lateinit var jetty: JettyService
+
+  private lateinit var client: ReturnADinosaur
+
+  @BeforeEach
+  fun createClient() {
+    val clientInjector = Guice.createInjector(MoshiModule(), ClientModule(jetty))
+    client = clientInjector.getInstance()
+  }
+
+  @Test
+  fun useTypedClient() {
+    val response = client.getDinosaur(Dinosaur.Builder().name("trex").build()).execute()
+    assertThat(response.code()).isEqualTo(200)
+    assertThat(response.body()).isNotNull()
+    assertThat(response.body()?.name!!)
+        .isEqualTo("supertrex from dinosaur.getDinosaur intercepted on response")
+    assertThat(response.headers()["X-Original-From"]).isEqualTo("dinosaur.getDinosaur")
+  }
+
+  interface ReturnADinosaur {
+    @POST("/cooldinos")
+    fun getDinosaur(@Body request: Dinosaur): Call<Dinosaur>
+  }
+
+  class ReturnADinosaurAction : WebAction {
+    @Post("/cooldinos")
+    @RequestContentType(MediaTypes.APPLICATION_JSON)
+    @ResponseContentType(MediaTypes.APPLICATION_JSON)
+    fun getDinosaur(@RequestBody request: Dinosaur): Dinosaur = request.newBuilder()
+        .name("super${request.name}")
+        .build()
+  }
+
+  /** Server [NetworkInterceptor] that echos back the X-Originating-Action from the request */
+  class ServerHeaderInterceptor : NetworkInterceptor {
+    override fun intercept(chain: NetworkChain): misk.web.Response<*> {
+      val originatingAction = chain.request.headers["X-From"]
+      val response = chain.proceed(chain.request)
+      return if (originatingAction != null) {
+        val newHeaders = response.headers.newBuilder()
+            .add("X-Original-From", originatingAction)
+            .build()
+        misk.web.Response(response.body, newHeaders, response.statusCode)
+      } else response
+    }
+
+    class Factory : NetworkInterceptor.Factory {
+      override fun create(action: Action): NetworkInterceptor? = ServerHeaderInterceptor()
+    }
+  }
+
+  /** [ClientNetworkInterceptor] that adds the action name as a header */
+  class ClientHeaderInterceptor(private val name: String) : ClientNetworkInterceptor {
+    override fun intercept(chain: ClientNetworkChain): Response =
+        chain.proceed(chain.request.newBuilder()
+            .addHeader("X-From", name)
+            .build())
+
+    class Factory : ClientNetworkInterceptor.Factory {
+      override fun create(action: ClientAction) = ClientHeaderInterceptor(action.name)
+    }
+  }
+
+  /** [ClientApplicationInterceptor] that modifies the request to include the action name */
+  class ClientNameInterceptor(private val name: String) : ClientApplicationInterceptor {
+    override fun interceptBeginCall(chain: BeginClientCallChain): Call<Any> {
+      val dinosaur = chain.args[0] as? Dinosaur
+      return if (dinosaur != null) {
+        val newDinosaur = dinosaur.newBuilder()
+            .name("${dinosaur.name} from $name")
+            .build()
+        chain.proceed(listOf(newDinosaur))
+      } else chain.proceed(chain.args)
+    }
+
+    override fun intercept(chain: ClientChain) {
+      chain.proceed(chain.args, object : Callback<Any> {
+        override fun onFailure(call: Call<Any>, t: Throwable) {
+          chain.callback.onFailure(call, t)
+        }
+
+        override fun onResponse(call: Call<Any>, response: retrofit2.Response<Any>) {
+          val dinosaur = response.body() as? Dinosaur
+          val updatedResponse = if (dinosaur != null) {
+            val newDinosaur = dinosaur.newBuilder()
+                .name("${dinosaur.name} intercepted on response")
+                .build()
+            @Suppress("UNCHECKED_CAST")
+            retrofit2.Response.success(newDinosaur, response.headers()) as retrofit2.Response<Any>
+          } else response
+
+          chain.callback.onResponse(call, updatedResponse)
+        }
+      })
+    }
+
+    class Factory : ClientApplicationInterceptor.Factory {
+      override fun create(action: ClientAction) = ClientNameInterceptor(action.name)
+    }
+  }
+
+  class TestModule : KAbstractModule() {
+    override fun configure() {
+      install(WebActionModule.create<ReturnADinosaurAction>())
+      binder().addMultibinderBinding<NetworkInterceptor.Factory>()
+          .to<ServerHeaderInterceptor.Factory>()
+    }
+  }
+
+  class ClientModule(val jetty: JettyService) : KAbstractModule() {
+    override fun configure() {
+      install(TypedHttpClientModule.create<ReturnADinosaur>("dinosaur"))
+      install(ClientNetworkInterceptorModule.create<ClientHeaderInterceptor.Factory>())
+      install(ClientApplicationInterceptorModule.create<ClientNameInterceptor.Factory>())
+    }
+
+    @Provides
+    @Singleton
+    fun provideHttpClientConfig(): HttpClientsConfig {
+      return HttpClientsConfig(
+          endpoints = mapOf(
+              "dinosaur" to HttpClientEndpointConfig(jetty.httpServerUrl.toString())
+          ))
+    }
+  }
+
+}

--- a/misk/src/test/kotlin/misk/client/TypedHttpClientTest.kt
+++ b/misk/src/test/kotlin/misk/client/TypedHttpClientTest.kt
@@ -90,7 +90,5 @@ internal class TypedHttpClientTest {
               "dinosaur" to HttpClientEndpointConfig(jetty.httpServerUrl.toString())
           ))
     }
-
   }
-
 }


### PR DESCRIPTION
Supports both application level interceptors (which can intercept the
creation of the Retrofit call as well as the actual enqueue/execute) and
network level interceptors (which simply wrap the okhttp3 interceptor
chain). Both types of interceptors can be conditionally installed on a
per-client action (client + method).