### PR TITLE
Fail fast if any services are not Singleton

### DIFF
--- a/misk-aws/src/main/kotlin/misk/cloud/aws/logging/CloudwatchLogService.kt
+++ b/misk-aws/src/main/kotlin/misk/cloud/aws/logging/CloudwatchLogService.kt
@@ -13,7 +13,9 @@ import java.time.Clock
 import java.time.Duration
 import java.util.concurrent.BlockingQueue
 import java.util.concurrent.atomic.AtomicBoolean
+import javax.inject.Singleton
 
+@Singleton
 internal class CloudwatchLogService(
   private val events: BlockingQueue<CloudwatchLogEvent>,
   moshi: Moshi,

--- a/misk-gcp-testing/src/main/kotlin/misk/cloud/gcp/datastore/FakeDatastoreModule.kt
+++ b/misk-gcp-testing/src/main/kotlin/misk/cloud/gcp/datastore/FakeDatastoreModule.kt
@@ -10,6 +10,7 @@ import misk.inject.KAbstractModule
 import javax.inject.Inject
 
 /** Installs a version of the [Datastore] that works off an in-memory local store */
+@javax.inject.Singleton
 class FakeDatastoreModule : KAbstractModule() {
   override fun configure() {
     multibind<Service>().to<FakeDatastoreService>()

--- a/misk-gcp/src/main/kotlin/misk/cloud/gcp/GoogleCloudModule.kt
+++ b/misk-gcp/src/main/kotlin/misk/cloud/gcp/GoogleCloudModule.kt
@@ -81,6 +81,7 @@ class GoogleCloudModule : KAbstractModule() {
 }
 
 /** Logs cloud configuration on startup */
+@javax.inject.Singleton
 private class GoogleCloud @Inject internal constructor(
   private val datastore: Datastore,
   private val storage: Storage

--- a/misk-hibernate-testing/src/main/kotlin/misk/hibernate/StartVitessService.kt
+++ b/misk-hibernate-testing/src/main/kotlin/misk/hibernate/StartVitessService.kt
@@ -13,6 +13,7 @@ import mu.KotlinLogging
 import java.io.FileReader
 import java.nio.file.Files
 import java.nio.file.Paths
+import javax.inject.Singleton
 import kotlin.concurrent.thread
 import kotlin.streams.toList
 
@@ -87,6 +88,7 @@ internal class DockerVitessCluster(
   }
 }
 
+@Singleton
 internal class StartVitessService(val config: DataSourceConfig) : AbstractIdleService() {
   override fun startUp() {
     if (config.type != DataSourceType.VITESS) {

--- a/misk-hibernate-testing/src/main/kotlin/misk/hibernate/TruncateTablesService.kt
+++ b/misk-hibernate-testing/src/main/kotlin/misk/hibernate/TruncateTablesService.kt
@@ -8,6 +8,7 @@ import misk.inject.toKey
 import misk.logging.getLogger
 import java.util.*
 import javax.inject.Provider
+import javax.inject.Singleton
 import kotlin.reflect.KClass
 
 private val logger = getLogger<TruncateTablesService>()
@@ -21,6 +22,7 @@ private val logger = getLogger<TruncateTablesService>()
  * We truncate _before_ tests because that way we always have a clean slate, even if a preceding
  * test wasn't able to clean up after itself.
  */
+@Singleton
 internal class TruncateTablesService(
   private val qualifier: KClass<out Annotation>,
   private val config: DataSourceConfig,

--- a/misk-hibernate/src/main/kotlin/misk/hibernate/PingDatabaseService.kt
+++ b/misk-hibernate/src/main/kotlin/misk/hibernate/PingDatabaseService.kt
@@ -11,12 +11,14 @@ import misk.inject.toKey
 import java.time.Duration
 import java.util.*
 import javax.inject.Inject
+import javax.inject.Singleton
 import kotlin.reflect.KClass
 
 /**
  * Service that waits for the database to become healthy. This is needed if we're booting up a
  * Vitess cluster as part of the test run.
  */
+@Singleton
 class PingDatabaseService @Inject constructor(
   qualifier: KClass<out Annotation>,
   private val config: DataSourceConfig,

--- a/misk-hibernate/src/main/kotlin/misk/hibernate/SchemaMigratorService.kt
+++ b/misk-hibernate/src/main/kotlin/misk/hibernate/SchemaMigratorService.kt
@@ -6,8 +6,10 @@ import misk.DependentService
 import misk.environment.Environment
 import misk.inject.toKey
 import javax.inject.Provider
+import javax.inject.Singleton
 import kotlin.reflect.KClass
 
+@Singleton
 class SchemaMigratorService internal constructor(
   qualifier: KClass<out Annotation>,
   private val environment: Environment,

--- a/misk-hibernate/src/main/kotlin/misk/hibernate/SessionFactoryService.kt
+++ b/misk-hibernate/src/main/kotlin/misk/hibernate/SessionFactoryService.kt
@@ -25,6 +25,7 @@ import org.hibernate.mapping.SimpleValue
 import org.hibernate.service.spi.SessionFactoryServiceRegistry
 import org.hibernate.usertype.UserType
 import javax.inject.Provider
+import javax.inject.Singleton
 import kotlin.reflect.KClass
 import kotlin.reflect.jvm.jvmName
 
@@ -33,6 +34,7 @@ private val logger = getLogger<SessionFactoryService>()
 /**
  * Builds a bare connection to a Hibernate database. Doesn't do any schema migration or validation.
  */
+@Singleton
 internal class SessionFactoryService(
   private val qualifier: KClass<out Annotation>,
   private val config: DataSourceConfig,

--- a/misk-jaeger/src/main/kotlin/misk/tracing/backends/jaeger/JaegerTracingService.kt
+++ b/misk-jaeger/src/main/kotlin/misk/tracing/backends/jaeger/JaegerTracingService.kt
@@ -4,7 +4,9 @@ import com.google.common.util.concurrent.AbstractIdleService
 import io.opentracing.Tracer
 import io.opentracing.util.GlobalTracer
 import javax.inject.Inject
+import javax.inject.Singleton
 
+@Singleton
 internal class JaegerTracingService @Inject internal constructor(
   private val tracer: Tracer
 ) : AbstractIdleService() {

--- a/misk-zipkin/src/main/kotlin/misk/tracing/backends/zipkin/ZipkinTracingService.kt
+++ b/misk-zipkin/src/main/kotlin/misk/tracing/backends/zipkin/ZipkinTracingService.kt
@@ -4,7 +4,9 @@ import com.google.common.util.concurrent.AbstractIdleService
 import io.opentracing.Tracer
 import io.opentracing.util.GlobalTracer
 import javax.inject.Inject
+import javax.inject.Singleton
 
+@Singleton
 internal class ZipkinTracingService @Inject internal constructor(
   private val tracer: Tracer
 ) : AbstractIdleService() {

--- a/misk/src/main/kotlin/misk/MiskServiceModule.kt
+++ b/misk/src/main/kotlin/misk/MiskServiceModule.kt
@@ -30,6 +30,18 @@ class MiskServiceModule : KAbstractModule() {
   @Provides
   @Singleton
   fun provideServiceManager(services: List<Service>): ServiceManager {
+    // Confirm all services have been registered as singleton. If they aren't singletons,
+    // _readiness checks will fail
+    val invalidServices = services.map { it.javaClass }.filter { !isSingleton(it) }.map { it.name }
+    check(invalidServices.isEmpty()) {
+      "the following services are not marked as @Singleton: ${invalidServices.sorted().joinToString(
+          ", ")}"
+    }
+
     return CoordinatedService.coordinate(services)
   }
+
+  private fun isSingleton(clazz: Class<*>) =
+      clazz.getAnnotation(com.google.inject.Singleton::class.java) != null ||
+          clazz.getAnnotation(javax.inject.Singleton::class.java) != null
 }

--- a/misk/src/main/kotlin/misk/inject/Guice.kt
+++ b/misk/src/main/kotlin/misk/inject/Guice.kt
@@ -51,10 +51,20 @@ fun KType.typeLiteral(): TypeLiteral<*> = TypeLiteral.get(javaType)
 fun <T : Any> KClass<T>.typeLiteral(): TypeLiteral<T> = TypeLiteral.get(java)
 
 @Suppress("UNCHECKED_CAST") // The type system isn't aware of constructed types.
+fun <T> listOfType(elementType: TypeLiteral<T>): TypeLiteral<List<T>> = TypeLiteral.get(
+    Types.listOf(elementType.type)) as TypeLiteral<List<T>>
+
+fun <T : Any> listOfType(elementType: KClass<T>) = listOfType(elementType.typeLiteral())
+
+inline fun <reified T: Any> listOfType() = listOfType(T::class)
+
+@Suppress("UNCHECKED_CAST") // The type system isn't aware of constructed types.
 fun <T> setOfType(elementType: TypeLiteral<T>): TypeLiteral<Set<T>> = TypeLiteral.get(
     Types.setOf(elementType.type)) as TypeLiteral<Set<T>>
 
 fun <T : Any> setOfType(elementType: KClass<T>) = setOfType(elementType.typeLiteral())
+
+inline fun <reified T : Any> setOfType() = setOfType(T::class)
 
 inline fun <reified T : Any> Injector.getInstance(annotation: Annotation? = null): T {
   val key = annotation?.let { Key.get(T::class.java, it) } ?: Key.get(T::class.java)

--- a/misk/src/test/kotlin/misk/MiskServiceModuleTest.kt
+++ b/misk/src/test/kotlin/misk/MiskServiceModuleTest.kt
@@ -1,0 +1,55 @@
+package misk
+
+import com.google.common.util.concurrent.AbstractIdleService
+import com.google.common.util.concurrent.Service
+import com.google.common.util.concurrent.ServiceManager
+import com.google.inject.Guice
+import misk.inject.KAbstractModule
+import misk.inject.getInstance
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import kotlin.test.assertFailsWith
+
+internal class MiskServiceModuleTest {
+  @com.google.inject.Singleton
+  class SingletonService1 : AbstractIdleService() {
+    override fun startUp() {}
+    override fun shutDown() {}
+  }
+
+  @javax.inject.Singleton
+  class SingletonService2 : AbstractIdleService() {
+    override fun startUp() {}
+    override fun shutDown() {}
+  }
+
+  class NonSingletonService1 : AbstractIdleService() {
+    override fun startUp() {}
+    override fun shutDown() {}
+  }
+
+  class NonSingletonService2 : AbstractIdleService() {
+    override fun startUp() {}
+    override fun shutDown() {}
+  }
+
+  @Test fun detectsNonSingletonServices() {
+    assertThat(assertFailsWith<com.google.inject.ProvisionException> {
+      val injector = Guice.createInjector(
+          MiskServiceModule(),
+          object: KAbstractModule() {
+            override fun configure() {
+              multibind<Service>().to<SingletonService1>()
+              multibind<Service>().to<SingletonService2>()
+              multibind<Service>().to<NonSingletonService2>()
+              multibind<Service>().to<NonSingletonService1>()
+            }
+          }
+      )
+
+      injector.getInstance<ServiceManager>()
+    }.message).contains("the following services are not marked as @Singleton: " +
+        "misk.MiskServiceModuleTest\$NonSingletonService1, misk.MiskServiceModuleTest\$NonSingletonService2")
+  }
+
+}


### PR DESCRIPTION
readiness checks will fail with a difficult to debug error if any
services are not Singletons (since the readiness check will get a new
instance, which will be in the NEW state). Check for this explicitly
and fail fast with an obvious error. Note this doesn't handle cases
where services are registered asEagerSingleton or bound toInstance.