### PR TITLE
@misk/common externals issue & Loader Tab Links

### DIFF
--- a/misk/web/@misk/common/src/index.ts
+++ b/misk/web/@misk/common/src/index.ts
@@ -1,3 +1,1 @@
-import externals from "./externals"
-export { externals }
-export default externals
+export { default as externals } from "./externals"

--- a/misk/web/@misk/common/src/vendors.js
+++ b/misk/web/@misk/common/src/vendors.js
@@ -1,6 +1,5 @@
-window.Blueprint = {}
-window.Blueprint.Core = require('@blueprintjs/core')
-window.Blueprint.Icons = require('@blueprintjs/icons')
+window.BlueprintCore = require('@blueprintjs/core')
+window.BlueprintIcons = require('@blueprintjs/icons')
 window.Axios = require('axios');
 window.ConnectedReactRouter = require('connected-react-router');
 window.Dayjs = require('dayjs');

--- a/misk/web/tabs/loader/src/containers/LoaderContainer.tsx
+++ b/misk/web/tabs/loader/src/containers/LoaderContainer.tsx
@@ -5,6 +5,7 @@ import { Route, Switch } from "react-router"
 import { IAppState } from ".."
 import { dispatchAdminTabs } from "../actions"
 import { NoMatchComponent, ScriptComponent } from "../components"
+import { Link } from "react-router-dom";
 
 interface ITabProps {
   adminTabs: IAdminTabs
@@ -47,8 +48,11 @@ class LoaderContainer extends React.Component<ITabProps> {
     const { adminTabs } = this.props.adminTabs
     if (adminTabs) {
       const tabRouteComponents = Object.entries(adminTabs).map((tab) => this.buildTabRouteComponent(tab))
+      const tabLinks = Object.entries(adminTabs).map((tab) => <Link key={tab[0]} to={`/_admin/test/${tab[1].slug}`}>{tab[1].name}</Link>)
       return (
         <div>
+          <Link to="/_admin/">Home</Link><br/>
+          {tabLinks}
           <Switch>
             {tabRouteComponents}
             <Route component={NoMatchComponent}/>


### PR DESCRIPTION
Why
---
- Console error where Blueprint library couldn't be found anymore
- Want a way in Loader tab to test links between tabs in React Router