### PR TITLE
[#337] Add interfaces to @misk/common, prepare Dashboard for public path changes

### DIFF
--- a/misk/web/@misk/common/package.json
+++ b/misk/web/@misk/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@misk/common",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "description": "Microservice Kontainer Common Libraries, Externals, Styles",
   "author": "Square/Misk Authors (https://github.com/square/misk/graphs/contributors)",
   "main": "lib/common.js",

--- a/misk/web/@misk/common/src/externals.ts
+++ b/misk/web/@misk/common/src/externals.ts
@@ -2,7 +2,7 @@ export interface IExternal {
   [key: string]: string|string[]
 }
 
-export default makeExternals({
+export const externals = makeExternals({
   "@blueprintjs/core": ["Blueprint", "Core"],
   "@blueprintjs/icons": ["Blueprint", "Icons"],
   "axios": "Axios",

--- a/misk/web/@misk/common/src/externals.ts
+++ b/misk/web/@misk/common/src/externals.ts
@@ -23,6 +23,16 @@ export const externals = makeExternals({
   "styled-components": "StyledComponents"
 })
 
+/**
+ * 
+ * @param inExternals : IExternal
+ * 
+ * Create Webpack compatible externals object with following modifications
+ * - Concatenate scoped package arrays into single strings
+ * 
+ * Todo
+ * - Provide distinct package strings for amd, commonjs, commonjs2, root if necessary
+ */
 function makeExternals(inExternals: IExternal) : IExternal {
   const outExternals: IExternal = {}
   Object.keys(inExternals).forEach((name, index) => {

--- a/misk/web/@misk/common/src/externals.ts
+++ b/misk/web/@misk/common/src/externals.ts
@@ -5,8 +5,6 @@ export interface IExternal {
 export default makeExternals({
   "@blueprintjs/core": ["Blueprint", "Core"],
   "@blueprintjs/icons": ["Blueprint", "Icons"],
-  "@misk/common": ["Misk", "Common"],
-  "@misk/components": ["Misk", "Components"],
   "axios": "Axios",
   "connected-react-router": "ConnectedReactRouter",
   "dayjs": "Dayjs",
@@ -29,10 +27,9 @@ function makeExternals(inExternals: IExternal) : IExternal {
   const outExternals: IExternal = {}
   Object.keys(inExternals).forEach((name, index) => {
     outExternals[name] = inExternals.hasOwnProperty(name) ? 
-      // (Array.isArray(inExternals[name]) ? 
-        // (inExternals[name] as string[]).join("") : inExternals[name]
-      // ) : name
-      inExternals[name] : name
+      (Array.isArray(inExternals[name]) ? 
+        (inExternals[name] as string[]).join("") : inExternals[name]
+      ) : name
     })
   return outExternals
 }

--- a/misk/web/@misk/common/src/externals.ts
+++ b/misk/web/@misk/common/src/externals.ts
@@ -28,7 +28,11 @@ export default makeExternals({
 function makeExternals(inExternals: IExternal) : IExternal {
   const outExternals: IExternal = {}
   Object.keys(inExternals).forEach((name, index) => {
-    outExternals[name] = inExternals.hasOwnProperty(name) ? (Array.isArray(inExternals[name]) ? (inExternals[name] as string[]).join("") : inExternals[name]) : name
-  })
+    outExternals[name] = inExternals.hasOwnProperty(name) ? 
+      // (Array.isArray(inExternals[name]) ? 
+        // (inExternals[name] as string[]).join("") : inExternals[name]
+      // ) : name
+      inExternals[name] : name
+    })
   return outExternals
 }

--- a/misk/web/@misk/common/src/index.ts
+++ b/misk/web/@misk/common/src/index.ts
@@ -1,1 +1,2 @@
-export { default as externals } from "./externals"
+export * from "./externals"
+export * from "./interfaces"

--- a/misk/web/@misk/common/src/interfaces.ts
+++ b/misk/web/@misk/common/src/interfaces.ts
@@ -1,0 +1,13 @@
+import { IconName } from "@blueprintjs/icons"
+
+export interface IMiskAdminTab {
+  icon: IconName
+  name: string
+  slug: string
+  url_path_prefix: string
+}
+
+export interface IMiskAdminTabs {
+  [key:string]: IMiskAdminTab
+  toJS?: any
+}

--- a/misk/web/@misk/common/src/vendors.js
+++ b/misk/web/@misk/common/src/vendors.js
@@ -1,5 +1,5 @@
-window.BlueprintCore = require('@blueprintjs/core')
-window.BlueprintIcons = require('@blueprintjs/icons')
+window.BlueprintCore = require('@blueprintjs/core');
+window.BlueprintIcons = require('@blueprintjs/icons');
 window.Axios = require('axios');
 window.ConnectedReactRouter = require('connected-react-router');
 window.Dayjs = require('dayjs');

--- a/misk/web/@misk/common/webpack.config.js
+++ b/misk/web/@misk/common/webpack.config.js
@@ -5,7 +5,8 @@ module.exports = {
   mode: 'production',
   entry: {
     common: path.resolve(__dirname, 'src/index.ts'),
-    externals: path.resolve(__dirname, 'src/index.ts')
+    externals: path.resolve(__dirname, 'src/externals.ts'),
+    interfaces: path.resolve(__dirname, 'src/interfaces.ts')
   },
   devtool: 'source-map',
   output: {

--- a/misk/web/@misk/components/src/NoMatchComponent.tsx
+++ b/misk/web/@misk/components/src/NoMatchComponent.tsx
@@ -4,10 +4,8 @@ export interface INoMatchProps {
   prefix: string
 }
 
-const NoMatchComponent = (props: INoMatchProps) => (
+export const NoMatchComponent = (props: INoMatchProps) => (
   <div>
     {props.prefix}: No Match Found
   </div>
 )
-
-export { NoMatchComponent }

--- a/misk/web/@misk/components/src/PathDebugComponent.tsx
+++ b/misk/web/@misk/components/src/PathDebugComponent.tsx
@@ -6,7 +6,7 @@ export interface IPathDebugProps {
   search: string
 }
 
-const PathDebugComponent = (props: IPathDebugProps) => {
+export const PathDebugComponent = (props: IPathDebugProps) => {
   return (
     <div>
       <p>hash: {props.hash}</p>
@@ -15,5 +15,3 @@ const PathDebugComponent = (props: IPathDebugProps) => {
     </div>
   )
 }
-
-export { PathDebugComponent }

--- a/misk/web/tabs/config/package.json
+++ b/misk/web/tabs/config/package.json
@@ -12,7 +12,7 @@
     "test": "jest --coverage"
   },
   "dependencies": {
-    "@misk/common": "^0.0.12",
+    "@misk/common": "^0.0.13",
     "@misk/components": "^0.0.14"
   },
   "devDependencies": {

--- a/misk/web/tabs/config/yarn.lock
+++ b/misk/web/tabs/config/yarn.lock
@@ -66,6 +66,31 @@
     skeleton-css "^2.0.4"
     styled-components "^3.4.2"
 
+"@misk/common@^0.0.13":
+  version "0.0.13"
+  resolved "https://registry.yarnpkg.com/@misk/common/-/common-0.0.13.tgz#10ddd509ecb8424b61f64b7000e16e25668e7626"
+  dependencies:
+    "@blueprintjs/core" "^3.3.0"
+    "@blueprintjs/icons" "^3.0.0"
+    axios "^0.18.0"
+    connected-react-router "^4.4.1"
+    dayjs "^1.7.5"
+    history "^4.7.2"
+    immutable "^3.8.2"
+    react "^16.4.2"
+    react-dom "^16.4.2"
+    react-helmet "^5.2.0"
+    react-hot-loader "^4.3.4"
+    react-redux "^5.0.7"
+    react-router "^4.3.1"
+    react-router-dom "^4.3.1"
+    react-router-redux "^5.0.0-alpha.9"
+    react-transition-group "^2.4.0"
+    redux "^4.0.0"
+    redux-saga "^0.16.0"
+    skeleton-css "^2.0.4"
+    styled-components "^3.4.2"
+
 "@misk/components@^0.0.14":
   version "0.0.14"
   resolved "https://registry.yarnpkg.com/@misk/components/-/components-0.0.14.tgz#faca255fdc65c1ff9be9d3471afdc785e56ce1eb"

--- a/misk/web/tabs/dashboard/package.json
+++ b/misk/web/tabs/dashboard/package.json
@@ -12,7 +12,7 @@
     "test": "jest --coverage"
   },
   "dependencies": {
-    "@misk/common": "^0.0.12",
+    "@misk/common": "^0.0.13",
     "@misk/components": "^0.0.14"
   },
   "devDependencies": {

--- a/misk/web/tabs/dashboard/src/components/SidebarComponent.tsx
+++ b/misk/web/tabs/dashboard/src/components/SidebarComponent.tsx
@@ -1,35 +1,24 @@
 import { Menu, MenuItem } from "@blueprintjs/core"
+import { IMiskAdminTabs } from "@misk/common"
 import * as React from "react"
 import styled from "styled-components" 
-import { IMenuItem } from "../utils/menu"
 
 interface ISidebarProps {
-  menuItems: IMenuItem[]
+  adminTabs: IMiskAdminTabs
 }
 
 const Sidebar = styled.div`
   position: absolute;
 `
 
-export class SidebarComponent extends React.Component<ISidebarProps, {}> {
-  private renderedMenuItems: any
+const buildMenuItems = (adminTabs: IMiskAdminTabs) => (
+  Object.entries(adminTabs).map((tab) => <MenuItem key={tab[0]} href={tab[1].url_path_prefix} className="" icon={tab[1].icon} text={tab[1].name}/>)
+)
 
-  constructor(props: ISidebarProps) {
-    super(props)
-    this.renderedMenuItems = this.props.menuItems.map(
-      ({ text, icon="document", className="pt-minimal", url } : any) => (
-          <MenuItem key={url} href={url} className={className} icon={icon} text={text}/>
-        )
-      )
-  }
-
-  render() {
-    return (
-      <Sidebar>
-        <Menu>
-          {this.renderedMenuItems}
-        </Menu>
-      </Sidebar>
-    )
-  }
-}
+export const SidebarComponent = (props: ISidebarProps) => (
+  <Sidebar>
+    <Menu>
+      {buildMenuItems(props.adminTabs)}
+    </Menu>
+  </Sidebar>
+)

--- a/misk/web/tabs/dashboard/src/components/SidebarComponent.tsx
+++ b/misk/web/tabs/dashboard/src/components/SidebarComponent.tsx
@@ -12,7 +12,7 @@ const Sidebar = styled.div`
 `
 
 const buildMenuItems = (adminTabs: IMiskAdminTabs) => (
-  Object.entries(adminTabs).map((tab) => <MenuItem key={tab[0]} href={tab[1].url_path_prefix} className="" icon={tab[1].icon} text={tab[1].name}/>)
+  Object.entries(adminTabs).map(([key, tab]) => <MenuItem key={key} href={tab.url_path_prefix} className="" icon={tab.icon} text={tab.name}/>)
 )
 
 export const SidebarComponent = (props: ISidebarProps) => (

--- a/misk/web/tabs/dashboard/src/components/TopbarComponent.tsx
+++ b/misk/web/tabs/dashboard/src/components/TopbarComponent.tsx
@@ -5,19 +5,11 @@ export interface ITopbarProps {
   name: string
 }
 
-export class TopbarComponent extends React.Component<ITopbarProps, {}> {
-  constructor(props: ITopbarProps) {
-    super(props)
-  }
-
-  render() {
-    return (
-      <Navbar>
-        <NavbarGroup align={Alignment.LEFT}>
-          <NavbarHeading>{this.props.name}</NavbarHeading>
-          <NavbarDivider/>
-        </NavbarGroup>
-      </Navbar>
-    )
-  }
-}
+export const TopbarComponent = (props: ITopbarProps) => (
+  <Navbar>
+    <NavbarGroup align={Alignment.LEFT}>
+      <NavbarHeading>{props.name}</NavbarHeading>
+      <NavbarDivider/>
+    </NavbarGroup>
+  </Navbar>
+)

--- a/misk/web/tabs/dashboard/src/components/index.ts
+++ b/misk/web/tabs/dashboard/src/components/index.ts
@@ -1,3 +1,2 @@
-import { SidebarComponent } from "./SidebarComponent"
-import { TopbarComponent } from "./TopbarComponent"
-export { SidebarComponent, TopbarComponent }
+export * from "./SidebarComponent"
+export * from "./TopbarComponent"

--- a/misk/web/tabs/dashboard/src/containers/NavContainer.tsx
+++ b/misk/web/tabs/dashboard/src/containers/NavContainer.tsx
@@ -1,13 +1,16 @@
+import { IMiskAdminTabs } from "@misk/common"
 import * as React from "react"
-import { SidebarComponent, TopbarComponent } from "../components";
+import { SidebarComponent, TopbarComponent } from "../components"
 
-export class NavContainer extends React.Component {
-  render() {
-    return (
-      <div>
-        <TopbarComponent name="Misk Admin"/>
-        {/* <SidebarComponent menuItems={}/> */}
-      </div>
-    )
-  }
+interface INavProps {
+  adminTabs: IMiskAdminTabs
 }
+
+const NavContainer = (props: INavProps) => (
+  <div>
+    <TopbarComponent name="Misk Admin"/>
+    <SidebarComponent adminTabs={props.adminTabs}/>
+  </div>
+)
+
+export { NavContainer }

--- a/misk/web/tabs/dashboard/src/containers/TabContainer.tsx
+++ b/misk/web/tabs/dashboard/src/containers/TabContainer.tsx
@@ -1,6 +1,5 @@
 import { PathDebugComponent } from "@misk/components"
 import * as React from "react"
-import { Helmet } from "react-helmet"
 import { connect } from "react-redux"
 import styled from "styled-components" 
 import { IAppState } from "../"
@@ -18,7 +17,7 @@ const Container = styled.div`
   margin-top: 20px;
 `
 
-class TabContainer extends React.Component<ITabProps, {children : any}> {
+class TabContainerClass extends React.Component<ITabProps, {children : any}> {
   constructor(props: ITabProps) {
     super(props)
   }
@@ -26,9 +25,6 @@ class TabContainer extends React.Component<ITabProps, {children : any}> {
   render() {
     return (
       <Container>
-        <Helmet>
-          <script src={`/_admin/${this.props.slug}/tab_${this.props.slug}.js`} type="text/javascript" />
-        </Helmet>
         <div id={this.props.slug}/>
         <PathDebugComponent hash={this.props.hash} pathname={this.props.pathname} search={this.props.search}/>
       </Container>
@@ -42,4 +38,4 @@ const mapStateToProps = (state: IAppState) => ({
   search: state.router.location.search,
 })
 
-export default connect(mapStateToProps)(TabContainer)
+export const TabContainer = connect(mapStateToProps)(TabContainerClass)

--- a/misk/web/tabs/dashboard/src/containers/index.ts
+++ b/misk/web/tabs/dashboard/src/containers/index.ts
@@ -1,3 +1,2 @@
-import { NavContainer } from "./NavContainer"
-import TabContainer from "./TabContainer"
-export { NavContainer, TabContainer }
+export * from "./NavContainer"
+export * from "./TabContainer"

--- a/misk/web/tabs/dashboard/src/index.html
+++ b/misk/web/tabs/dashboard/src/index.html
@@ -11,10 +11,10 @@
     <div id="dashboard"></div>
 
     <!-- Misk Libraries -->
-    <script type="text/javascript" src="/_admin/@misk/styles.js" async></script>
-    <script type="text/javascript" src="/_admin/@misk/vendors.js" preload></script>
-    <script type="text/javascript" src="/_admin/@misk/common.js" preload></script>
-    <script type="text/javascript" src="/_admin/@misk/components.js" preload></script>
+    <script type="text/javascript" src="/_admin/dashboard/@misk/styles.js" async></script>
+    <script type="text/javascript" src="/_admin/dashboard/@misk/vendors.js" preload></script>
+    <script type="text/javascript" src="/_admin/dashboard/@misk/common.js" preload></script>
+    <script type="text/javascript" src="/_admin/dashboard/@misk/components.js" preload></script>
 </body>
 
 </html>

--- a/misk/web/tabs/dashboard/src/index.tsx
+++ b/misk/web/tabs/dashboard/src/index.tsx
@@ -8,6 +8,9 @@ import { applyMiddleware, compose, createStore } from "redux"
 import App from "./App"
 import rootReducer from "./reducers"
 
+export * from "./containers"
+export * from "./components"
+
 export interface IAppState {
   count: number,
   router: {

--- a/misk/web/tabs/dashboard/src/routes/index.tsx
+++ b/misk/web/tabs/dashboard/src/routes/index.tsx
@@ -5,7 +5,7 @@ import { NavContainer, TabContainer } from "../containers"
 
 const routes = (
   <div>
-    <NavContainer/>
+    <NavContainer adminTabs={{}}/>
     <TabContainer>
       <Switch>
         <Route path="/_admin/dashboard/" component={NoMatchComponent}/>

--- a/misk/web/tabs/dashboard/yarn.lock
+++ b/misk/web/tabs/dashboard/yarn.lock
@@ -66,6 +66,31 @@
     skeleton-css "^2.0.4"
     styled-components "^3.4.2"
 
+"@misk/common@^0.0.13":
+  version "0.0.13"
+  resolved "https://registry.yarnpkg.com/@misk/common/-/common-0.0.13.tgz#10ddd509ecb8424b61f64b7000e16e25668e7626"
+  dependencies:
+    "@blueprintjs/core" "^3.3.0"
+    "@blueprintjs/icons" "^3.0.0"
+    axios "^0.18.0"
+    connected-react-router "^4.4.1"
+    dayjs "^1.7.5"
+    history "^4.7.2"
+    immutable "^3.8.2"
+    react "^16.4.2"
+    react-dom "^16.4.2"
+    react-helmet "^5.2.0"
+    react-hot-loader "^4.3.4"
+    react-redux "^5.0.7"
+    react-router "^4.3.1"
+    react-router-dom "^4.3.1"
+    react-router-redux "^5.0.0-alpha.9"
+    react-transition-group "^2.4.0"
+    redux "^4.0.0"
+    redux-saga "^0.16.0"
+    skeleton-css "^2.0.4"
+    styled-components "^3.4.2"
+
 "@misk/components@^0.0.14":
   version "0.0.14"
   resolved "https://registry.yarnpkg.com/@misk/components/-/components-0.0.14.tgz#faca255fdc65c1ff9be9d3471afdc785e56ce1eb"

--- a/misk/web/tabs/loader/package.json
+++ b/misk/web/tabs/loader/package.json
@@ -12,7 +12,7 @@
     "test": "jest --coverage"
   },
   "dependencies": {
-    "@misk/common": "^0.0.12",
+    "@misk/common": "^0.0.13",
     "@misk/components": "^0.0.14"
   },
   "devDependencies": {

--- a/misk/web/tabs/loader/src/components/ScriptComponent.tsx
+++ b/misk/web/tabs/loader/src/components/ScriptComponent.tsx
@@ -1,11 +1,10 @@
 import { Icon } from "@blueprintjs/core"
+import { IMiskAdminTab } from "@misk/common"
 import * as React from "react"
 import Helmet from "react-helmet"
-import styled from "styled-components" 
-import { IAdminTab } from "../containers/LoaderContainer"
 
 interface IScriptProps {
-  tab: IAdminTab,
+  tab: IMiskAdminTab,
 }
 
 export const ScriptComponent = (props: IScriptProps) => {

--- a/misk/web/tabs/loader/src/containers/LoaderContainer.tsx
+++ b/misk/web/tabs/loader/src/containers/LoaderContainer.tsx
@@ -1,33 +1,21 @@
-import { IconName } from "@blueprintjs/icons"
+import { IMiskAdminTab, IMiskAdminTabs } from "@misk/common"
 import * as React from "react"
 import { connect } from "react-redux"
 import { Route, Switch } from "react-router"
+import { Link } from "react-router-dom"
 import { IAppState } from ".."
 import { dispatchAdminTabs } from "../actions"
 import { NoMatchComponent, ScriptComponent } from "../components"
-import { Link } from "react-router-dom";
 
 interface ITabProps {
-  adminTabs: IAdminTabs
+  adminTabs: IMiskAdminTabs
   loading: boolean
   error: any
   getTabs: any
 }
 
 export interface ILoaderState {
-  adminTabs: IAdminTabs
-}
-
-export interface IAdminTabs {
-  [key:string]: IAdminTab
-  toJS: any
-}
-
-export interface IAdminTab {
-  icon: IconName
-  name: string
-  slug: string
-  url_path_prefix: string
+  adminTabs: IMiskAdminTabs
 }
 
 class LoaderContainer extends React.Component<ITabProps> {
@@ -37,10 +25,10 @@ class LoaderContainer extends React.Component<ITabProps> {
 
   /**
    * 
-   * @param tab [tabname: string, IAdminTab]
+   * @param tab [tabname: string, IMiskAdminTab]
    * @returns React Router subroute for the tab that renders a ScriptComponent with the tab passed in as props
    */
-  buildTabRouteComponent(tab: [string, IAdminTab]) {
+  buildTabRouteComponent(tab: [string, IMiskAdminTab]) {
     return(<Route key={tab[0]} path={`/_admin/test/${tab[1].slug}`} render={() => <ScriptComponent key={tab[0]} tab={tab[1]}/>}/>)
   }
 

--- a/misk/web/tabs/loader/src/containers/LoaderContainer.tsx
+++ b/misk/web/tabs/loader/src/containers/LoaderContainer.tsx
@@ -28,15 +28,15 @@ class LoaderContainer extends React.Component<ITabProps> {
    * @param tab [tabname: string, IMiskAdminTab]
    * @returns React Router subroute for the tab that renders a ScriptComponent with the tab passed in as props
    */
-  buildTabRouteComponent(tab: [string, IMiskAdminTab]) {
-    return(<Route key={tab[0]} path={`/_admin/test/${tab[1].slug}`} render={() => <ScriptComponent key={tab[0]} tab={tab[1]}/>}/>)
+  buildTabRouteComponent(tab: IMiskAdminTab) {
+    return(<Route key={tab.slug} path={`/_admin/test/${tab.slug}`} render={() => <ScriptComponent key={tab.slug} tab={tab}/>}/>)
   }
 
   render() {
     const { adminTabs } = this.props.adminTabs
     if (adminTabs) {
-      const tabRouteComponents = Object.entries(adminTabs).map((tab) => this.buildTabRouteComponent(tab))
-      const tabLinks = Object.entries(adminTabs).map((tab) => <Link key={tab[0]} to={`/_admin/test/${tab[1].slug}`}>{tab[1].name}</Link>)
+      const tabRouteComponents = Object.entries(adminTabs).map(([key,tab]) => this.buildTabRouteComponent(tab))
+      const tabLinks = Object.entries(adminTabs).map(([key,tab]) => <Link key={key} to={`/_admin/test/${tab.slug}`}>{tab.name}</Link>)
       return (
         <div>
           <Link to="/_admin/">Home</Link><br/>

--- a/misk/web/tabs/loader/src/index.tsx
+++ b/misk/web/tabs/loader/src/index.tsx
@@ -1,4 +1,4 @@
-import { IconNames } from "@blueprintjs/icons";
+import { IMiskAdminTabs } from "@misk/common"
 import { connectRouter, routerMiddleware } from "connected-react-router"
 import { createBrowserHistory } from "history"
 import * as React from "react"
@@ -8,12 +8,12 @@ import { Provider } from "react-redux"
 import { applyMiddleware, compose, createStore } from "redux"
 import createSagaMiddleware from "redux-saga"
 import App from "./App"
-import { IAdminTabs, ILoaderState } from "./containers/LoaderContainer"
+import { ILoaderState } from "./containers/LoaderContainer"
 import rootReducer from "./reducers"
-import rootSaga from "./sagas";
+import rootSaga from "./sagas"
 
 export interface IAppState {
-  adminTabs: IAdminTabs
+  adminTabs: IMiskAdminTabs
   loader: ILoaderState
   router: IRouterState
 }

--- a/misk/web/tabs/loader/src/reducers/index.ts
+++ b/misk/web/tabs/loader/src/reducers/index.ts
@@ -1,6 +1,6 @@
+import { IMiskAdminTabs } from "@misk/common"
 import { RouterState } from "connected-react-router"
 import { combineReducers } from "redux"
-import { IAdminTabs } from "../containers/LoaderContainer"
 import adminTabsReducer from "./adminTabs"
 import itemReducer from "./item"
 
@@ -10,7 +10,7 @@ const rootReducer = combineReducers({
 })
 
 export interface IState {
-  adminTabs: IAdminTabs
+  adminTabs: IMiskAdminTabs
   item: any
   router: RouterState
 }

--- a/misk/web/tabs/loader/yarn.lock
+++ b/misk/web/tabs/loader/yarn.lock
@@ -66,6 +66,31 @@
     skeleton-css "^2.0.4"
     styled-components "^3.4.2"
 
+"@misk/common@^0.0.13":
+  version "0.0.13"
+  resolved "https://registry.yarnpkg.com/@misk/common/-/common-0.0.13.tgz#10ddd509ecb8424b61f64b7000e16e25668e7626"
+  dependencies:
+    "@blueprintjs/core" "^3.3.0"
+    "@blueprintjs/icons" "^3.0.0"
+    axios "^0.18.0"
+    connected-react-router "^4.4.1"
+    dayjs "^1.7.5"
+    history "^4.7.2"
+    immutable "^3.8.2"
+    react "^16.4.2"
+    react-dom "^16.4.2"
+    react-helmet "^5.2.0"
+    react-hot-loader "^4.3.4"
+    react-redux "^5.0.7"
+    react-router "^4.3.1"
+    react-router-dom "^4.3.1"
+    react-router-redux "^5.0.0-alpha.9"
+    react-transition-group "^2.4.0"
+    redux "^4.0.0"
+    redux-saga "^0.16.0"
+    skeleton-css "^2.0.4"
+    styled-components "^3.4.2"
+
 "@misk/components@^0.0.14":
   version "0.0.14"
   resolved "https://registry.yarnpkg.com/@misk/components/-/components-0.0.14.tgz#faca255fdc65c1ff9be9d3471afdc785e56ce1eb"


### PR DESCRIPTION
Why
---
- Preparing Dashboard tab to change public path to "/" similar to Loader
  - Since Dashboard will be loaded like a simple rendering component, core interfaces for AdminTabs should be moved to `@misk/common` so they are shared between Loader and Dashboard tabs
  - `@misk` packages should be removed from `@misk/common` externals to prevent circular dependencies
  - `makeExternals` in `@misk/common` is difficult to parse nested ternary functions, should be reformatted for better readability
- By the above 3 items, release new version 0.0.13 of `@misk/common`
- [#337] Update Dashboard issue for new pure component approach