### PR TITLE
Change Dashboard Public Path to "/"

### DIFF
--- a/misk/web/tabs/dashboard/src/containers/TabContainer.tsx
+++ b/misk/web/tabs/dashboard/src/containers/TabContainer.tsx
@@ -1,6 +1,7 @@
 import { PathDebugComponent } from "@misk/components"
 import * as React from "react"
 import { connect } from "react-redux"
+import { Link } from "react-router-dom"
 import styled from "styled-components" 
 import { IAppState } from "../"
 
@@ -17,6 +18,14 @@ const Container = styled.div`
   margin-top: 20px;
 `
 
+const testLinks = (
+  <div>
+    <Link to="/_admin/dashboard/test1/1/test1">Test1</Link><br/>
+    <Link to="/_admin/dashboard/test2/2/test2">Test2</Link><br/>
+    <Link to="/_admin/dashboard/test3/3/test3">Test2</Link><br/>
+  </div>
+)
+
 class TabContainerClass extends React.Component<ITabProps, {children : any}> {
   constructor(props: ITabProps) {
     super(props)
@@ -26,7 +35,9 @@ class TabContainerClass extends React.Component<ITabProps, {children : any}> {
     return (
       <Container>
         <div id={this.props.slug}/>
+        {testLinks}
         <PathDebugComponent hash={this.props.hash} pathname={this.props.pathname} search={this.props.search}/>
+        {this.props.children}
       </Container>
     )
   }

--- a/misk/web/tabs/dashboard/src/routes/index.tsx
+++ b/misk/web/tabs/dashboard/src/routes/index.tsx
@@ -8,7 +8,7 @@ const routes = (
     <NavContainer adminTabs={{}}/>
     <TabContainer>
       <Switch>
-        <Route path="/_admin/dashboard/" component={NoMatchComponent}/>
+        <Route component={NoMatchComponent}/>
       </Switch>
     </TabContainer>
   </div>

--- a/misk/web/tabs/dashboard/webpack.config.js
+++ b/misk/web/tabs/dashboard/webpack.config.js
@@ -18,8 +18,8 @@ const DefinePluginConfig = new webpack.DefinePlugin({
 
 const CopyWebpackPluginConfig = new CopyWebpackPlugin(
   [
-    { from: './node_modules/@misk/common/lib', to: '@misk/'},
-    { from: './node_modules/@misk/components/lib', to: '@misk/'}
+    { from: './node_modules/@misk/common/lib', to: '_admin/dashboard/@misk/'},
+    { from: './node_modules/@misk/components/lib', to: '_admin/dashboard/@misk/'}
   ], 
   { debug: 'info', copyUnmodified: true }
 )
@@ -27,9 +27,9 @@ const CopyWebpackPluginConfig = new CopyWebpackPlugin(
 module.exports = {
   entry: ['react-hot-loader/patch', path.join(__dirname, '/src/index.tsx')],
   output: {
-    filename: 'tab_dashboard.js',
-    path: path.join(__dirname, 'dist/_admin/dashboard'),
-    publicPath: "/_admin/dashboard"
+    filename: '_admin/dashboard/tab_dashboard.js',
+    path: path.join(__dirname, 'dist'),
+    publicPath: "/"
   },
   devServer: {
     port: '3110',


### PR DESCRIPTION
Why
---
- React Router requires that the public path in Webpack config is "/" or it doesn't work