### PR TITLE
Add SSL support to jdbc connections

### DIFF
--- a/misk-hibernate/src/main/kotlin/misk/hibernate/DataSourceConfig.kt
+++ b/misk-hibernate/src/main/kotlin/misk/hibernate/DataSourceConfig.kt
@@ -56,7 +56,13 @@ data class DataSourceConfig(
   val connection_timeout: Duration = Duration.ofSeconds(30),
   val connection_max_lifetime: Duration = Duration.ofMinutes(30),
   val migrations_resource: String?,
-  val vitess_schema_dir: String?
+  val vitess_schema_dir: String?,
+  /*
+     See https://dev.mysql.com/doc/connector-j/8.0/en/connector-j-reference-using-ssl.html for
+     trust_certificate_key_store_* details.
+   */
+  val trust_certificate_key_store_url: String?,
+  val trust_certificate_key_store_password: String?
 )
 
 /** Configuration element for a cluster of DataSources */

--- a/misk-hibernate/src/main/kotlin/misk/hibernate/SessionFactoryService.kt
+++ b/misk-hibernate/src/main/kotlin/misk/hibernate/SessionFactoryService.kt
@@ -110,6 +110,24 @@ internal class SessionFactoryService(
         applySetting("hibernate.hikari.dataSource.elideSetAutoCommits", "true")
         applySetting("hibernate.hikari.dataSource.maintainTimeStats", "false")
       }
+
+      // https://dev.mysql.com/doc/connector-j/8.0/en/connector-j-reference-using-ssl.html
+      if (!config.trust_certificate_key_store_url.isNullOrBlank()) {
+        require(!config.trust_certificate_key_store_password.isNullOrBlank()) {
+          "must provide a trust_certificate_key_store_password"
+        }
+        applySetting(
+            "hibernate.hikari.dataSource.trustCertificateKeyStoreUrl",
+            "${config.trust_certificate_key_store_url}"
+        )
+        applySetting(
+            "hibernate.hikari.dataSource.trustCertificateKeyStorePassword",
+            config.trust_certificate_key_store_password
+        )
+        applySetting("hibernate.hikari.dataSource.verifyServerCertificate", "true")
+        applySetting("hibernate.hikari.dataSource.useSSL", "true")
+        applySetting("hibernate.hikari.dataSource.requireSSL", "true")
+      }
     }
 
     val registry = registryBuilder.build()


### PR DESCRIPTION
This only adds server authentication on the client side. The misk
application must provide a URL to a trust store which contains the
mysql server certificate.

For example if using RDS, the trust store must contain the Amazon RDS
certificate found at https://s3.amazonaws.com/rds-downloads/rds-combined-ca-bundle.pem

TODO: next to add a test in a followup, but at the moment our CI builds
do not have a mysql instance with ssl configured :(