### PR TITLE
Change tab domain from `/_admin/{tab}` to `/_tab/{tab}`

### DIFF
--- a/misk/src/main/kotlin/misk/config/ConfigWebModule.kt
+++ b/misk/src/main/kotlin/misk/config/ConfigWebModule.kt
@@ -18,7 +18,7 @@ class ConfigWebModule : KAbstractModule() {
     ))
     // TODO(adrw) only add web proxy during development, otherwise add ResourceInterceptor (Jar)
     multibind<WebProxyEntry>().toInstance(
-        WebProxyEntry("/_admin/config", "http://localhost:3200/"))
-    multibind<WebActionEntry>().toInstance(WebActionEntry<WebProxyAction>("/_admin/config"))
+        WebProxyEntry("/_tab/config", "http://localhost:3200/"))
+    multibind<WebActionEntry>().toInstance(WebActionEntry<WebProxyAction>("/_tab/config"))
   }
 }

--- a/misk/src/main/kotlin/misk/web/AdminTabModule.kt
+++ b/misk/src/main/kotlin/misk/web/AdminTabModule.kt
@@ -23,20 +23,21 @@ class AdminTabModule : KAbstractModule() {
         WebActionEntry<WebProxyAction>("/_admin"))
 
     multibind<WebProxyEntry>().toInstance(
-        WebProxyEntry("/_admin/dashboard", "http://localhost:3110/"))
+        WebProxyEntry("/_tab/dashboard", "http://localhost:3110/"))
     multibind<WebActionEntry>().toInstance(
-        WebActionEntry<WebProxyAction>("/_admin/dashboard"))
+        WebActionEntry<WebProxyAction>("/_tab/dashboard"))
 
     multibind<WebProxyEntry>().toInstance(
         WebProxyEntry("/@misk", "http://localhost:9100/"))
     multibind<WebActionEntry>().toInstance(
         WebActionEntry<WebProxyAction>("/@misk"))
 
-    multibind<AdminTab>().toInstance(AdminTab(
-        "Dashboard",
-        "dashboard",
-        "/_admin/dashboard"
-    ))
+//    Testing
+//    multibind<AdminTab>().toInstance(AdminTab(
+//        "Dashboard",
+//        "dashboard",
+//        "/_admin/dashboard"
+//    ))
 
   }
 }

--- a/misk/web/@misk/common/tsconfig.json
+++ b/misk/web/@misk/common/tsconfig.json
@@ -6,6 +6,7 @@
         "declaration": true,
         "esModuleInterop": true,
         "jsx": "react",
+        "lib": ["es5", "es6", "dom", "es2017"],
         "module": "commonjs",
         "noEmit": true,
         "noEmitOnError": true,

--- a/misk/web/@misk/common/webpack.config.js
+++ b/misk/web/@misk/common/webpack.config.js
@@ -14,6 +14,11 @@ module.exports = {
     filename: '[name].js',
     library: ['Misk', 'Common'],
     libraryTarget: 'umd',
+    /**
+     * library will try to bind to browser `window` variable
+     * without below globalObject: library binding to browser `window` 
+     *    fails when run in Node or other non-browser
+     */
     globalObject: 'typeof window !== \'undefined\' ? window : this'
   },
   module: {

--- a/misk/web/@misk/common/webpack.vendors.config.js
+++ b/misk/web/@misk/common/webpack.vendors.config.js
@@ -12,6 +12,11 @@ module.exports = {
     filename: '[name].js',
     library: ['Misk', 'Common'],
     libraryTarget: 'umd',
+    /**
+     * library will try to bind to browser `window` variable
+     * without below globalObject: library binding to browser `window` 
+     *    fails when run in Node or other non-browser
+     */
     globalObject: 'typeof window !== \'undefined\' ? window : this'
   },
 };

--- a/misk/web/@misk/components/package.json
+++ b/misk/web/@misk/components/package.json
@@ -27,7 +27,7 @@
     "test": "echo no tests"
   },
   "dependencies": {
-    "@misk/common": "^0.0.12"
+    "@misk/common": "^0.0.13"
   },
   "devDependencies": {
     "@misk/dev": "^0.0.8"

--- a/misk/web/@misk/components/src/NavSidebarComponent.tsx
+++ b/misk/web/@misk/components/src/NavSidebarComponent.tsx
@@ -1,0 +1,24 @@
+import { Menu, MenuItem } from "@blueprintjs/core"
+import { IMiskAdminTabs } from "@misk/common"
+import * as React from "react"
+import styled from "styled-components" 
+
+interface ISidebarProps {
+  adminTabs: IMiskAdminTabs
+}
+
+const Sidebar = styled.div`
+  position: absolute;
+`
+
+const buildMenuItems = (adminTabs: IMiskAdminTabs) => (
+  Object.entries(adminTabs).map(([key, tab]) => <MenuItem key={key} href={tab.url_path_prefix} className="" icon={tab.icon} text={tab.name}/>)
+)
+
+export const NavSidebarComponent = (props: ISidebarProps) => (
+  <Sidebar>
+    <Menu>
+      {buildMenuItems(props.adminTabs)}
+    </Menu>
+  </Sidebar>
+)

--- a/misk/web/@misk/components/src/NavTopbarComponent.tsx
+++ b/misk/web/@misk/components/src/NavTopbarComponent.tsx
@@ -1,0 +1,15 @@
+import { Alignment, Navbar, NavbarDivider, NavbarGroup, NavbarHeading } from "@blueprintjs/core"
+import * as React from "react"
+
+export interface ITopbarProps {
+  name: string
+}
+
+export const NavTopbarComponent = (props: ITopbarProps) => (
+  <Navbar>
+    <NavbarGroup align={Alignment.LEFT}>
+      <NavbarHeading>{props.name}</NavbarHeading>
+      <NavbarDivider/>
+    </NavbarGroup>
+  </Navbar>
+)

--- a/misk/web/@misk/components/tsconfig.json
+++ b/misk/web/@misk/components/tsconfig.json
@@ -6,6 +6,7 @@
         "declaration": true,
         "esModuleInterop": true,
         "jsx": "react",
+        "lib": ["es5", "es6", "dom", "es2017"],
         "module": "commonjs",
         "noEmit": true,
         "noEmitOnError": true,

--- a/misk/web/@misk/components/webpack.config.js
+++ b/misk/web/@misk/components/webpack.config.js
@@ -12,6 +12,11 @@ module.exports = {
     filename: '[name].js',
     library: ['Misk', 'Components'],
     libraryTarget: 'umd',
+    /**
+     * library will try to bind to browser `window` variable
+     * without below globalObject: library binding to browser `window` 
+     *    fails when run in Node or other non-browser
+     */
     globalObject: 'typeof self !== \'undefined\' ? self : this'
   },
   module: {

--- a/misk/web/@misk/components/yarn.lock
+++ b/misk/web/@misk/components/yarn.lock
@@ -2,7 +2,7 @@
 # yarn lockfile v1
 
 
-"@blueprintjs/core@^3.0.1":
+"@blueprintjs/core@^3.3.0":
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/@blueprintjs/core/-/core-3.3.0.tgz#6fc5c7d811d1c0693c0c3d7a472549e171c455db"
   dependencies:
@@ -41,26 +41,30 @@
     reflect-metadata "^0.1.12"
     tslib "^1.8.1"
 
-"@misk/common@^0.0.8":
-  version "0.0.8"
-  resolved "https://registry.yarnpkg.com/@misk/common/-/common-0.0.8.tgz#c24ab7d5c74c8319e6716bab85c97bf5c785677b"
+"@misk/common@^0.0.13":
+  version "0.0.13"
+  resolved "https://registry.yarnpkg.com/@misk/common/-/common-0.0.13.tgz#10ddd509ecb8424b61f64b7000e16e25668e7626"
   dependencies:
-    "@blueprintjs/core" "^3.0.1"
+    "@blueprintjs/core" "^3.3.0"
     "@blueprintjs/icons" "^3.0.0"
     axios "^0.18.0"
-    connected-react-router "^4.3.0"
+    connected-react-router "^4.4.1"
+    dayjs "^1.7.5"
     history "^4.7.2"
-    react "^16.4.1"
-    react-dom "^16.4.1"
+    immutable "^3.8.2"
+    react "^16.4.2"
+    react-dom "^16.4.2"
     react-helmet "^5.2.0"
-    react-hot-loader "^4.3.3"
+    react-hot-loader "^4.3.4"
     react-redux "^5.0.7"
     react-router "^4.3.1"
     react-router-dom "^4.3.1"
-    react-transition-group "^2.2.1"
+    react-router-redux "^5.0.0-alpha.9"
+    react-transition-group "^2.4.0"
     redux "^4.0.0"
+    redux-saga "^0.16.0"
     skeleton-css "^2.0.4"
-    styled-components "^3.3.3"
+    styled-components "^3.4.2"
 
 "@misk/dev@^0.0.8":
   version "0.0.8"
@@ -1067,7 +1071,7 @@ connect-history-api-fallback@^1.3.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/connect-history-api-fallback/-/connect-history-api-fallback-1.5.0.tgz#b06873934bc5e344fef611a196a6faae0aee015a"
 
-connected-react-router@^4.3.0:
+connected-react-router@^4.4.1:
   version "4.4.1"
   resolved "https://registry.yarnpkg.com/connected-react-router/-/connected-react-router-4.4.1.tgz#352ad5340ca3d296e7ebac14adcf789eb8a20e0c"
   dependencies:
@@ -1309,6 +1313,10 @@ dashdash@^1.12.0:
 date-now@^0.1.4:
   version "0.1.4"
   resolved "https://npm.vip.global.square/date-now/-/date-now-0.1.4.tgz#eaf439fd4d4848ad74e5cc7dbef200672b9e345b"
+
+dayjs@^1.7.5:
+  version "1.7.5"
+  resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.7.5.tgz#14715cb565d1f8cb556a8531cb14bf1fc33067cc"
 
 debug@2.6.9, debug@^2.1.2, debug@^2.2.0, debug@^2.3.3, debug@^2.6.6, debug@^2.6.8:
   version "2.6.9"
@@ -3917,7 +3925,7 @@ rc@^1.1.7:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
-react-dom@^16.4.1:
+react-dom@^16.4.2:
   version "16.4.2"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.4.2.tgz#4afed569689f2c561d2b8da0b819669c38a0bda4"
   dependencies:
@@ -3935,7 +3943,7 @@ react-helmet@^5.2.0:
     prop-types "^15.5.4"
     react-side-effect "^1.1.0"
 
-react-hot-loader@^4.3.3:
+react-hot-loader@^4.3.4:
   version "4.3.4"
   resolved "https://registry.yarnpkg.com/react-hot-loader/-/react-hot-loader-4.3.4.tgz#4f9bdd55bb20d77a6ae8931fa1c187e5f0ce6279"
   dependencies:
@@ -3987,7 +3995,15 @@ react-router-dom@^4.3.1:
     react-router "^4.3.1"
     warning "^4.0.1"
 
-react-router@^4.3.1:
+react-router-redux@^5.0.0-alpha.9:
+  version "5.0.0-alpha.9"
+  resolved "https://registry.yarnpkg.com/react-router-redux/-/react-router-redux-5.0.0-alpha.9.tgz#825431516e0e6f1fd93b8807f6bd595e23ec3d10"
+  dependencies:
+    history "^4.7.2"
+    prop-types "^15.6.0"
+    react-router "^4.2.0"
+
+react-router@^4.2.0, react-router@^4.3.1:
   version "4.3.1"
   resolved "https://npm.vip.global.square/react-router/-/react-router-4.3.1.tgz#aada4aef14c809cb2e686b05cee4742234506c4e"
   dependencies:
@@ -4006,7 +4022,7 @@ react-side-effect@^1.1.0:
     exenv "^1.2.1"
     shallowequal "^1.0.1"
 
-react-transition-group@^2.2.1:
+react-transition-group@^2.2.1, react-transition-group@^2.4.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-2.4.0.tgz#1d9391fabfd82e016f26fabd1eec329dbd922b5a"
   dependencies:
@@ -4015,7 +4031,7 @@ react-transition-group@^2.2.1:
     prop-types "^15.6.2"
     react-lifecycles-compat "^3.0.4"
 
-react@^16.4.1:
+react@^16.4.2:
   version "16.4.2"
   resolved "https://registry.yarnpkg.com/react/-/react-16.4.2.tgz#2cd90154e3a9d9dd8da2991149fdca3c260e129f"
   dependencies:
@@ -4075,6 +4091,10 @@ redent@^1.0.0:
   dependencies:
     indent-string "^2.1.0"
     strip-indent "^1.0.1"
+
+redux-saga@^0.16.0:
+  version "0.16.0"
+  resolved "https://registry.yarnpkg.com/redux-saga/-/redux-saga-0.16.0.tgz#0a231db0a1489301dd980f6f2f88d8ced418f724"
 
 "redux@>= 3.7.2", redux@^4.0.0:
   version "4.0.0"
@@ -4768,7 +4788,7 @@ style-loader@^0.22.1:
     loader-utils "^1.1.0"
     schema-utils "^0.4.5"
 
-styled-components@^3.3.3:
+styled-components@^3.4.2:
   version "3.4.2"
   resolved "https://registry.yarnpkg.com/styled-components/-/styled-components-3.4.2.tgz#8f518419932327e47fe9144824e3184b3e2da95d"
   dependencies:

--- a/misk/web/tabs/config/src/containers/DashboardContainer.tsx
+++ b/misk/web/tabs/config/src/containers/DashboardContainer.tsx
@@ -1,8 +1,6 @@
 import * as React from "react"
 import { Helmet } from "react-helmet"
 
-
-
 export class DashboardContainer extends React.Component {
   render() {
     return (

--- a/misk/web/tabs/config/src/index.html
+++ b/misk/web/tabs/config/src/index.html
@@ -11,10 +11,10 @@
     <div id="config"></div>
 
     <!-- Misk Libraries -->
-    <script type="text/javascript" src="/_admin/config/@misk/styles.js" async></script>
-    <script type="text/javascript" src="/_admin/config/@misk/vendors.js" preload></script>
-    <script type="text/javascript" src="/_admin/config/@misk/common.js" preload></script>
-    <script type="text/javascript" src="/_admin/config/@misk/components.js" preload></script>
+    <script type="text/javascript" src="/_tab/config/@misk/styles.js" async></script>
+    <script type="text/javascript" src="/_tab/config/@misk/vendors.js" preload></script>
+    <script type="text/javascript" src="/_tab/config/@misk/common.js" preload></script>
+    <script type="text/javascript" src="/_tab/config/@misk/components.js" preload></script>
 </body>
 
 </html>

--- a/misk/web/tabs/config/src/routes/index.tsx
+++ b/misk/web/tabs/config/src/routes/index.tsx
@@ -1,12 +1,15 @@
+import { NoMatchComponent } from "@misk/components"
 import * as React from "react"
 import { Route, Switch } from "react-router"
 import { DashboardContainer, TabContainer } from "../containers"
 
 const routes = (
   <div>
-    <DashboardContainer/>
+    {/* <DashboardContainer/> */}
     <Switch>
-      <Route component={TabContainer}/>
+      <Route path="/_admin/config" component={TabContainer}/>
+      <Route path="/_tab/config" component={TabContainer}/>
+      <Route component={NoMatchComponent}/>
     </Switch>
   </div>
 )

--- a/misk/web/tabs/config/webpack.config.js
+++ b/misk/web/tabs/config/webpack.config.js
@@ -32,6 +32,11 @@ module.exports = {
     publicPath: "/",
     library: ['Tabs', 'Config'],
     libraryTarget: 'umd',
+    /**
+     * library will try to bind to browser `window` variable
+     * without below globalObject: library binding to browser `window` 
+     *    fails when run in Node or other non-browser
+     */
     globalObject: 'typeof self !== \'undefined\' ? self : this'
   },
   devServer: {

--- a/misk/web/tabs/config/webpack.config.js
+++ b/misk/web/tabs/config/webpack.config.js
@@ -18,8 +18,8 @@ const DefinePluginConfig = new webpack.DefinePlugin({
 
 const CopyWebpackPluginConfig = new CopyWebpackPlugin(
   [
-    { from: './node_modules/@misk/common/lib', to: '_admin/config/@misk/'},
-    { from: './node_modules/@misk/components/lib', to: '_admin/config/@misk/'}
+    { from: './node_modules/@misk/common/lib', to: '_tab/config/@misk/'},
+    { from: './node_modules/@misk/components/lib', to: '_tab/config/@misk/'}
   ], 
   { debug: 'info', copyUnmodified: true }
 )
@@ -27,7 +27,7 @@ const CopyWebpackPluginConfig = new CopyWebpackPlugin(
 module.exports = {
   entry: ['react-hot-loader/patch', path.join(__dirname, '/src/index.tsx')],
   output: {
-    filename: '_admin/config/tab_config.js',
+    filename: '_tab/config/tab_config.js',
     path: path.join(__dirname, 'dist'),
     publicPath: "/",
     library: ['Tabs', 'Config'],
@@ -76,5 +76,5 @@ module.exports = {
     ]
     : [HTMLWebpackPluginConfig, CopyWebpackPluginConfig,
       DefinePluginConfig],
-  externals: MiskCommon.Externals
+  externals: MiskCommon.externals
 }

--- a/misk/web/tabs/dashboard/src/containers/TabContainer.tsx
+++ b/misk/web/tabs/dashboard/src/containers/TabContainer.tsx
@@ -36,9 +36,9 @@ class TabContainerClass extends React.Component<ITabProps, {children : any}> {
     return (
       <Container>
         <div id={this.props.slug}/>
-        {testLinks}
-        <PathDebugComponent hash={this.props.hash} pathname={this.props.pathname} search={this.props.search}/>
-        <hr/>
+        {/* {testLinks} */}
+        {/* <PathDebugComponent hash={this.props.hash} pathname={this.props.pathname} search={this.props.search}/> */}
+        {/* <hr/> */}
         {this.props.children}
       </Container>
     )

--- a/misk/web/tabs/dashboard/src/index.html
+++ b/misk/web/tabs/dashboard/src/index.html
@@ -11,10 +11,10 @@
     <div id="dashboard"></div>
 
     <!-- Misk Libraries -->
-    <script type="text/javascript" src="/_admin/dashboard/@misk/styles.js" async></script>
-    <script type="text/javascript" src="/_admin/dashboard/@misk/vendors.js" preload></script>
-    <script type="text/javascript" src="/_admin/dashboard/@misk/common.js" preload></script>
-    <script type="text/javascript" src="/_admin/dashboard/@misk/components.js" preload></script>
+    <script type="text/javascript" src="/_tab/dashboard/@misk/styles.js" async></script>
+    <script type="text/javascript" src="/_tab/dashboard/@misk/vendors.js" preload></script>
+    <script type="text/javascript" src="/_tab/dashboard/@misk/common.js" preload></script>
+    <script type="text/javascript" src="/_tab/dashboard/@misk/components.js" preload></script>
 </body>
 
 </html>

--- a/misk/web/tabs/dashboard/src/routes/index.tsx
+++ b/misk/web/tabs/dashboard/src/routes/index.tsx
@@ -6,11 +6,11 @@ import { NavContainer, TabContainer } from "../containers"
 const routes = (
   <div>
     <NavContainer adminTabs={{}}/>
-    <TabContainer>
+    {/* <TabContainer/> */}
       {/* <Switch>
         <Route component={NoMatchComponent}/>
       </Switch> */}
-    </TabContainer>
+    {/* </TabContainer> */}
   </div>
 )
 

--- a/misk/web/tabs/dashboard/webpack.config.js
+++ b/misk/web/tabs/dashboard/webpack.config.js
@@ -18,8 +18,8 @@ const DefinePluginConfig = new webpack.DefinePlugin({
 
 const CopyWebpackPluginConfig = new CopyWebpackPlugin(
   [
-    { from: './node_modules/@misk/common/lib', to: '_admin/dashboard/@misk/'},
-    { from: './node_modules/@misk/components/lib', to: '_admin/dashboard/@misk/'}
+    { from: './node_modules/@misk/common/lib', to: '_tab/dashboard/@misk/'},
+    { from: './node_modules/@misk/components/lib', to: '_tab/dashboard/@misk/'}
   ], 
   { debug: 'info', copyUnmodified: true }
 )
@@ -27,7 +27,7 @@ const CopyWebpackPluginConfig = new CopyWebpackPlugin(
 module.exports = {
   entry: ['react-hot-loader/patch', path.join(__dirname, '/src/index.tsx')],
   output: {
-    filename: '_admin/dashboard/tab_dashboard.js',
+    filename: '_tab/dashboard/tab_dashboard.js',
     path: path.join(__dirname, 'dist'),
     publicPath: "/",
     library: ['Tabs', 'Dashboard'],

--- a/misk/web/tabs/dashboard/webpack.config.js
+++ b/misk/web/tabs/dashboard/webpack.config.js
@@ -32,6 +32,11 @@ module.exports = {
     publicPath: "/",
     library: ['Tabs', 'Dashboard'],
     libraryTarget: 'umd',
+    /**
+     * library will try to bind to browser `window` variable
+     * without below globalObject: library binding to browser `window` 
+     *    fails when run in Node or other non-browser
+     */
     globalObject: 'typeof self !== \'undefined\' ? self : this'
   },
   devServer: {

--- a/misk/web/tabs/loader/src/components/NavSidebarComponent.tsx
+++ b/misk/web/tabs/loader/src/components/NavSidebarComponent.tsx
@@ -1,0 +1,24 @@
+import { Menu, MenuItem } from "@blueprintjs/core"
+import { IMiskAdminTabs } from "@misk/common"
+import * as React from "react"
+import styled from "styled-components" 
+
+interface ISidebarProps {
+  adminTabs: IMiskAdminTabs
+}
+
+const Sidebar = styled.div`
+  position: absolute;
+`
+
+const buildMenuItems = (adminTabs: IMiskAdminTabs) => (
+  Object.entries(adminTabs).map(([key, tab]) => <MenuItem key={key} href={tab.url_path_prefix} className="" icon={tab.icon} text={tab.name}/>)
+)
+
+export const NavSidebarComponent = (props: ISidebarProps) => (
+  <Sidebar>
+    <Menu>
+      {buildMenuItems(props.adminTabs)}
+    </Menu>
+  </Sidebar>
+)

--- a/misk/web/tabs/loader/src/components/NavTopbarComponent.tsx
+++ b/misk/web/tabs/loader/src/components/NavTopbarComponent.tsx
@@ -1,0 +1,15 @@
+import { Alignment, Navbar, NavbarDivider, NavbarGroup, NavbarHeading } from "@blueprintjs/core"
+import * as React from "react"
+
+export interface ITopbarProps {
+  name: string
+}
+
+export const NavTopbarComponent = (props: ITopbarProps) => (
+  <Navbar>
+    <NavbarGroup align={Alignment.LEFT}>
+      <NavbarHeading>{props.name}</NavbarHeading>
+      <NavbarDivider/>
+    </NavbarGroup>
+  </Navbar>
+)

--- a/misk/web/tabs/loader/src/components/ScriptComponent.tsx
+++ b/misk/web/tabs/loader/src/components/ScriptComponent.tsx
@@ -11,8 +11,7 @@ export const ScriptComponent = (props: IScriptProps) => {
   return (
     <div>
       <Helmet>
-        <title>Test Title</title>
-        <script async={true} src={`${props.tab.url_path_prefix}/tab_${props.tab.slug}.js`}/>
+        <script async={true} src={`http://0.0.0.0:8080/_tab/${props.tab.slug}/tab_${props.tab.slug}.js`}/>
       </Helmet>
       <MountingDivComponent tab={props.tab}/>
     </div>

--- a/misk/web/tabs/loader/src/components/index.ts
+++ b/misk/web/tabs/loader/src/components/index.ts
@@ -1,3 +1,5 @@
 export * from "./AdminTabDebugComponent"
 export * from "./MountingDivComponent"
+export * from "./NavSidebarComponent"
+export * from "./NavTopbarComponent"
 export * from "./ScriptComponent"

--- a/misk/web/tabs/loader/src/containers/LoaderContainer.tsx
+++ b/misk/web/tabs/loader/src/containers/LoaderContainer.tsx
@@ -52,6 +52,7 @@ class LoaderContainer extends React.Component<ITabProps> {
           <Link to="/_admin/">Home</Link><br/>
           {tabLinks}
         </div>
+        
       )
     } else {
       return (

--- a/misk/web/tabs/loader/src/containers/LoaderContainer.tsx
+++ b/misk/web/tabs/loader/src/containers/LoaderContainer.tsx
@@ -5,27 +5,22 @@ import { connect } from "react-redux"
 import { Route, Switch } from "react-router"
 import { Link } from "react-router-dom"
 import { dispatchLoader } from "../actions"
-import { MountingDivComponent, ScriptComponent } from "../components"
+import { MountingDivComponent, NavSidebarComponent, NavTopbarComponent, ScriptComponent } from "../components"
 import { IState } from "../reducers"
 
-interface ITabProps {
-  adminTabComponents: any
-  adminTabs: IMiskAdminTabs
-  loadableTabs: any
-  loading: boolean
-  error: any
+export interface ILoaderProps {
+  loader: {
+    adminTabComponents: any
+    adminTabs: IMiskAdminTabs
+  }
   getComponent: any
-  getComponents: any
+  getComponentsAndTabs: any
   getTabs: any
 }
 
-export interface ILoaderState {
-  adminTabs: IMiskAdminTabs
-}
-
-class LoaderContainer extends React.Component<ITabProps> {
+class LoaderContainer extends React.Component<ILoaderProps> {
   componentDidMount() {
-    this.props.getComponents()
+    this.props.getComponentsAndTabs()
   }
 
   buildTabRouteMountingDiv(key: any, tab: IMiskAdminTab) {
@@ -33,15 +28,16 @@ class LoaderContainer extends React.Component<ITabProps> {
   }
 
   render() {
-    const { adminTabs } = this.props.adminTabs
-    const { adminTabComponents } = this.props.adminTabComponents
+    const { adminTabs } = this.props.loader
+    const { adminTabComponents } = this.props.loader
     if (adminTabs) {
       const tabRouteDivs = Object.entries(adminTabs).map(([key,tab]) => this.buildTabRouteMountingDiv(key, tab))
-      const tabLinks = Object.entries(adminTabs).map(([key,tab]) => <Link key={key} to={`/_admin/test/${tab.slug}`}>{tab.name}<br/></Link>)
+      const tabLinks = Object.entries(adminTabs).map(([key,tab]) => <Link key={key} to={`/_admin/${tab.slug}`}>{tab.name}<br/></Link>)
       console.log(adminTabs, adminTabComponents)
-      console.log(tabRouteDivs)
       return (
         <div>
+          <NavTopbarComponent name="Misk Admin Loader" />
+          <NavSidebarComponent adminTabs={adminTabs} />
           {Object.entries(adminTabs).map(([key,tab]) => (<ScriptComponent tab={tab}/>))}
           <Switch>
             {Object.entries(adminTabs).map(([key,tab]) => this.buildTabRouteMountingDiv(key, tab))}
@@ -51,6 +47,10 @@ class LoaderContainer extends React.Component<ITabProps> {
           <h1>Loader Debug</h1>
           <Link to="/_admin/">Home</Link><br/>
           {tabLinks}
+          <Link to="/_admin/asdf/asdf/asdf/asdf/">Bad Link</Link><br/>
+          <p>Revert NavSideBar so it uses Link instead of A Href</p>
+          <p>Next test that config actually keeps running with an updating timer from the last config</p>
+          <p>Turn off their routing, maybe with the hack redirect javscript set it to hide when not on matching route?</p>
         </div>
         
       )
@@ -65,13 +65,12 @@ class LoaderContainer extends React.Component<ITabProps> {
 }
 
 const mapStateToProps = (state: IState) => ({
-  adminTabComponents: state.loader.toJS(),
-  adminTabs: state.loader.toJS(),
+  loader: state.loader.toJS(),
 })
 
 const mapDispatchToProps = {
   getComponent: dispatchLoader.getOneComponent,
-  getComponents: dispatchLoader.getAllComponentsAndTabs,
+  getComponentsAndTabs: dispatchLoader.getAllComponentsAndTabs,
   getTabs: dispatchLoader.getAllTabs,
 }
 

--- a/misk/web/tabs/loader/src/containers/index.ts
+++ b/misk/web/tabs/loader/src/containers/index.ts
@@ -1,1 +1,1 @@
-export { default as LoaderContainer} from "./LoaderContainer"
+export { default as LoaderContainer } from "./LoaderContainer"

--- a/misk/web/tabs/loader/src/routes.tsx
+++ b/misk/web/tabs/loader/src/routes.tsx
@@ -4,9 +4,11 @@ import { Route, Switch } from "react-router"
 import { LoaderContainer } from "./containers"
 
 const routes = (
-  <Switch>
-    <Route component={LoaderContainer}/>
-  </Switch>
+  <div>
+    <Switch>
+      <Route path="/_admin" component={LoaderContainer}/>
+    </Switch>
+  </div>
 )
 
 export default routes

--- a/misk/web/tabs/loader/src/sagas/loaderSaga.ts
+++ b/misk/web/tabs/loader/src/sagas/loaderSaga.ts
@@ -41,7 +41,7 @@ function * handleGetAllAndTabs (action: IAction<IActionType, {}>) {
   for (const key in adminTabs) {
     if (adminTabs.hasOwnProperty(key)) {
       const tab = adminTabs[key]
-      const url = `${tab.url_path_prefix}/tab_${tab.slug}.js`
+      const url = `http://0.0.0.0:8080/_tab/${tab.slug}/tab_${tab.slug}.js`
       try {
         const { data } = yield call(axios.get, url)
         yield put(dispatchLoader.success({ adminTabComponents: { [tab.slug]: data } }))
@@ -54,7 +54,7 @@ function * handleGetAllAndTabs (action: IAction<IActionType, {}>) {
 
 function * handleGetOneComponent (action: IAction<IActionType, { tab: IMiskAdminTab }>) {
   const { tab } = action.payload
-  const url = `${tab.url_path_prefix}/tab_${tab.slug}.js`
+  const url = `http://0.0.0.0:8080/_tab/${tab.slug}/tab_${tab.slug}.js`
   try {
     const { data } = yield call(axios.get, url)
     yield put(dispatchLoader.success({ adminTabComponents: { [tab.slug]: data } }))


### PR DESCRIPTION
Why?: each tab used to compile to url domain `/_admin/{tab}`. Now that LoaderContainer is being used to render tabs, it should have control over routing their domain to the rendered tab, thus tab domains should be switched to `/_tab/{tab}` which is used for testing and for retrieving the tab compiled code.