### PR TITLE
Adds support for clob properties in Hibernate mapping

### DIFF
--- a/misk-hibernate/src/main/kotlin/misk/hibernate/SessionFactoryService.kt
+++ b/misk-hibernate/src/main/kotlin/misk/hibernate/SessionFactoryService.kt
@@ -192,6 +192,7 @@ internal class SessionFactoryService(
       "char" -> Char::class
       "float" -> Float::class
       "double" -> Double::class
+      "materialized_clob" -> String::class
       else -> Class.forName(name).kotlin
     }
   }

--- a/misk-hibernate/src/test/kotlin/misk/hibernate/DbMovie.kt
+++ b/misk-hibernate/src/test/kotlin/misk/hibernate/DbMovie.kt
@@ -5,6 +5,7 @@ import java.time.LocalDate
 import javax.persistence.Column
 import javax.persistence.Entity
 import javax.persistence.GeneratedValue
+import javax.persistence.Lob
 import javax.persistence.Table
 
 @Entity
@@ -25,6 +26,9 @@ class DbMovie() : DbEntity<DbMovie>, DbTimestampedEntity {
 
   @Column(nullable = true)
   var release_date: LocalDate? = null
+
+  @Column @Lob
+  var synopsis: String? = null
 
   constructor(name: String, releaseDate: LocalDate?) : this() {
     this.name = name

--- a/misk-hibernate/src/test/resources/misk/hibernate/moviestestmodule-schema/movies/v1__movies.sql
+++ b/misk-hibernate/src/test/resources/misk/hibernate/moviestestmodule-schema/movies/v1__movies.sql
@@ -4,5 +4,6 @@ CREATE TABLE movies(
   updated_at timestamp(3) NOT NULL DEFAULT NOW(3) ON UPDATE NOW(3),
   name varchar(191) NOT NULL,
   release_date date NULL,
+  synopsis LONGTEXT NULL,
   UNIQUE KEY `unq_name` (`name`)
 );


### PR DESCRIPTION
Adds a mapping to support String properties annotated with @Lob. Note sure if this is the best way to add `@Lob` support though.