### PR TITLE
Adds support for nullable Ids

### DIFF
--- a/misk-hibernate/src/main/kotlin/misk/hibernate/IdType.kt
+++ b/misk-hibernate/src/main/kotlin/misk/hibernate/IdType.kt
@@ -12,11 +12,11 @@ import java.sql.Types
 internal object IdType : UserType, ResultSetIdentifierConsumer {
   override fun hashCode(x: Any?) = (x as Id<*>).hashCode()
 
-  override fun deepCopy(value: Any) = value
+  override fun deepCopy(value: Any?) = value
 
   override fun replace(original: Any, target: Any, owner: Any?) = original
 
-  override fun equals(x: Any, y: Any) = (x as Id<*>) == (y as Id<*>)
+  override fun equals(x: Any?, y: Any?): Boolean = (x as? Id<*>) == (y as? Id<*>)
 
   override fun returnedClass() = Id::class.java
 

--- a/misk-hibernate/src/test/kotlin/misk/hibernate/DbCharacter.kt
+++ b/misk-hibernate/src/test/kotlin/misk/hibernate/DbCharacter.kt
@@ -34,16 +34,16 @@ class DbCharacter() : DbEntity<DbCharacter>, DbTimestampedEntity {
 
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "actor_id", updatable = false, insertable = false)
-  lateinit var actor: DbActor
+  var actor: DbActor? = null
 
   @Column
-  lateinit var actor_id: Id<DbActor>
+  var actor_id: Id<DbActor>? = null
 
-  constructor(name: String, movie: DbMovie, actor: DbActor) : this() {
+  constructor(name: String, movie: DbMovie, actor: DbActor?) : this() {
     this.name = name
     this.movie = movie
     this.movie_id = movie.id
     this.actor = actor
-    this.actor_id = actor.id
+    this.actor_id = actor?.id
   }
 }

--- a/misk-hibernate/src/test/kotlin/misk/hibernate/TransacterTest.kt
+++ b/misk-hibernate/src/test/kotlin/misk/hibernate/TransacterTest.kt
@@ -27,6 +27,7 @@ class TransacterTest {
     transacter.transaction { session ->
       val jp = session.save(DbMovie("Jurassic Park", LocalDate.of(1993, 6, 9)))
       val sw = session.save(DbMovie("Star Wars", LocalDate.of(1977, 5, 25)))
+      val lx = session.save(DbMovie("Luxo Jr.", LocalDate.of(1986, 8, 17)))
       assertThat(setOf(jp, sw)).hasSize(2) // Uniqueness check.
 
       val ld = session.save(DbActor("Laura Dern", LocalDate.of(1967, 2, 10)))
@@ -38,7 +39,8 @@ class TransacterTest {
       val es = session.save(DbCharacter("Ellie Sattler", session.load(jp), session.load(ld)))
       val im = session.save(DbCharacter("Ian Malcolm", session.load(jp), session.load(jg)))
       val lo = session.save(DbCharacter("Leia Organa", session.load(sw), session.load(cf)))
-      assertThat(setOf(ah, es, im, lo)).hasSize(4) // Uniqueness check.
+      val lj = session.save(DbCharacter("Luxo Jr.", session.load(lx), null))
+      assertThat(setOf(ah, es, im, lo, lj)).hasSize(5) // Uniqueness check.
     }
 
     // Query that data.
@@ -46,7 +48,7 @@ class TransacterTest {
       val ianMalcolm = queryFactory.newQuery<CharacterQuery>()
           .name("Ian Malcolm")
           .uniqueResult(session)!!
-      assertThat(ianMalcolm.actor.name).isEqualTo("Jeff Goldblum")
+      assertThat(ianMalcolm.actor?.name).isEqualTo("Jeff Goldblum")
       assertThat(ianMalcolm.movie.name).isEqualTo("Jurassic Park")
 
       val lauraDernMovies = queryFactory.newQuery<CharacterQuery>()

--- a/misk-hibernate/src/test/resources/misk/hibernate/moviestestmodule-schema/movies/v2__characters.sql
+++ b/misk-hibernate/src/test/resources/misk/hibernate/moviestestmodule-schema/movies/v2__characters.sql
@@ -4,5 +4,5 @@ CREATE TABLE characters(
   updated_at timestamp(3) NOT NULL DEFAULT NOW(3) ON UPDATE NOW(3),
   name varchar(255) NOT NULL,
   movie_id bigint NOT NULL,
-  actor_id bigint NOT NULL
+  actor_id bigint NULL
 );


### PR DESCRIPTION
Nullable ids or entity references fail on dirty check or deep copy.