### PR TITLE
Use the opentracing enabled JDBC driver for MySQL data sources

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,6 +46,7 @@ ext {
           openTracingUtil      : 'io.opentracing:opentracing-util:0.31.0',
           openTracingMock      : 'io.opentracing:opentracing-mock:0.31.0',
           openTracingOkHttp    : 'io.opentracing.contrib:opentracing-okhttp3:0.1.0',
+          openTracingJdbc      : "io.opentracing.contrib:opentracing-jdbc:0.0.7",
           tracingJaeger        : 'com.uber.jaeger:jaeger-core:0.24.0',
           tracingZipkin        : 'io.opentracing.brave:brave-opentracing:0.29.0',
           zipkinReporter       : 'io.zipkin.reporter2:zipkin-sender-okhttp3:2.4.1',

--- a/misk-hibernate/build.gradle
+++ b/misk-hibernate/build.gradle
@@ -31,6 +31,7 @@ dependencies {
   compile dep.hikariCp
   compile dep.hsqldb
   compile dep.mysql
+  compile dep.openTracingJdbc
   compile dep.vitess
   compile project(':misk')
 

--- a/misk-hibernate/src/main/kotlin/misk/hibernate/DataSourceConfig.kt
+++ b/misk-hibernate/src/main/kotlin/misk/hibernate/DataSourceConfig.kt
@@ -11,7 +11,7 @@ enum class DataSourceType(
   val buildJdbcUrl: (DataSourceConfig, Environment) -> String
 ) {
   MYSQL(
-      driverClassName = "com.mysql.jdbc.Driver",
+      driverClassName = "io.opentracing.contrib.jdbc.TracingDriver",
       hibernateDialect = "org.hibernate.dialect.MySQL57Dialect",
       buildJdbcUrl = { config, env ->
         val port = config.port ?: 3306
@@ -38,7 +38,7 @@ enum class DataSourceType(
           queryParams += "&useSSL=true"
           queryParams += "&requireSSL=true"
         }
-        "jdbc:mysql://$host:$port/$database$queryParams"
+        "jdbc:tracing:mysql://$host:$port/$database$queryParams"
       }
   ),
   HSQLDB(


### PR DESCRIPTION
r @swankjesse @mmihic @ryanhall07 

This gives us statement-level tracing. More details here: https://github.com/opentracing-contrib/java-jdbc