### PR TITLE
All arbitrary tags to be passed in logs

### DIFF
--- a/misk/src/main/kotlin/misk/logging/Logging.kt
+++ b/misk/src/main/kotlin/misk/logging/Logging.kt
@@ -2,28 +2,75 @@ package misk.logging
 
 import mu.KLogger
 import mu.KotlinLogging
+import org.slf4j.MDC
 import org.slf4j.event.Level
+
+typealias Tag = Pair<String, String>
 
 inline fun <reified T> getLogger(): KLogger {
   return KotlinLogging.logger(T::class.qualifiedName!!)
 }
 
-fun KLogger.log(level: Level, message: String) {
-  when (level) {
-    Level.ERROR -> error(message)
-    Level.WARN -> warn(message)
-    Level.INFO -> info(message)
-    Level.DEBUG -> debug(message)
-    Level.TRACE -> trace(message)
+fun KLogger.info(vararg tags: Tag, message: () -> Any?) =
+    log(Level.INFO, tags = *tags, message = message)
+
+fun KLogger.warn(vararg tags: Tag, message: () -> Any?) =
+    log(Level.WARN, tags = *tags, message = message)
+
+fun KLogger.error(vararg tags: Tag, message: () -> Any?) =
+    log(Level.ERROR, tags = *tags, message = message)
+
+fun KLogger.debug(vararg tags: Tag, message: () -> Any?) =
+    log(Level.DEBUG, tags = *tags, message = message)
+
+fun KLogger.info(th: Throwable, vararg tags: Tag, message: () -> Any?) =
+    log(Level.INFO, th, tags = *tags, message = message)
+
+fun KLogger.warn(th: Throwable, vararg tags: Tag, message: () -> Any?) =
+    log(Level.WARN, th, tags = *tags, message = message)
+
+fun KLogger.error(th: Throwable, vararg tags: Tag, message: () -> Any?) =
+    log(Level.ERROR, th, tags = *tags, message = message)
+
+fun KLogger.debug(th: Throwable, vararg tags: Tag, message: () -> Any?) =
+    log(Level.DEBUG, th, tags = *tags, message = message)
+
+fun KLogger.log(level: Level, vararg tags: Tag, message: () -> Any?) {
+  withTags(*tags) {
+    when (level) {
+      Level.ERROR -> error(message)
+      Level.WARN -> warn(message)
+      Level.INFO -> info(message)
+      Level.DEBUG -> debug(message)
+      Level.TRACE -> trace(message)
+    }
   }
 }
 
-fun KLogger.log(level: Level, th: Throwable, message: () -> Any?) {
-  when (level) {
-    Level.ERROR -> error(th, message)
-    Level.INFO -> info(th, message)
-    Level.WARN -> warn(th, message)
-    Level.DEBUG -> debug(th, message)
-    Level.TRACE -> trace(th, message)
+fun KLogger.log(level: Level, th: Throwable, vararg tags: Tag, message: () -> Any?) {
+  withTags(*tags) {
+    when (level) {
+      Level.ERROR -> error(th, message)
+      Level.INFO -> info(th, message)
+      Level.WARN -> warn(th, message)
+      Level.DEBUG -> debug(th, message)
+      Level.TRACE -> trace(th, message)
+    }
+  }
+}
+
+private fun withTags(vararg tags: Tag, f: () -> Unit) {
+  // Establish MDC, saving prior MDC
+  val priorMDC = tags.map { (k, v) ->
+    val priorValue = MDC.get(k)
+    MDC.put(k, v)
+    k to priorValue
+  }
+
+  try {
+    f()
+  } finally {
+    // Restore or clear prior MDC
+    priorMDC.forEach { (k, v) -> if (v == null) MDC.remove(k) else MDC.put(k, v) }
   }
 }

--- a/misk/src/test/kotlin/misk/logging/LoggingTest.kt
+++ b/misk/src/test/kotlin/misk/logging/LoggingTest.kt
@@ -1,13 +1,109 @@
 package misk.logging
 
+import ch.qos.logback.classic.Level
+import ch.qos.logback.classic.LoggerContext
+import com.google.inject.util.Modules
+import misk.MiskServiceModule
+import misk.testing.MiskTest
+import misk.testing.MiskTestModule
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.containsExactly
 import org.junit.jupiter.api.Test
+import org.slf4j.LoggerFactory
+import org.slf4j.MDC
+import javax.inject.Inject
 
+@MiskTest(startService = true)
 class LoggingTest {
+  @MiskTestModule
+  val testModule = Modules.combine(MiskServiceModule(), LogCollectorModule())
+
+  @Inject private lateinit var logCollector: LogCollector
+
   private val logger = getLogger<LoggingTest>()
+  private val loggerContext = LoggerFactory.getILoggerFactory() as LoggerContext
 
   @Test
   fun loggerNameIsBasedOnTheOuterClass() {
     assertThat(logger.name).isEqualTo("misk.logging.LoggingTest")
+  }
+
+  @Test
+  fun loggingWithTags() {
+    // clear existing messages
+    logCollector.takeEvents(LoggingTest::class)
+
+    // Log without tags
+    logger.error(IllegalStateException("failed!")) { "untagged error" }
+    logger.info { "untagged info" }
+
+    val untaggedEvents = logCollector.takeEvents(LoggingTest::class)
+    assertThat(untaggedEvents).hasSize(2)
+    assertThat(untaggedEvents[0]).satisfies {
+      assertThat(it.level).isEqualTo(Level.ERROR)
+      assertThat(it.message).isEqualTo("untagged error")
+      assertThat(it.throwableProxy.className).isEqualTo(IllegalStateException::class.qualifiedName)
+      assertThat(it.mdcPropertyMap).isEmpty()
+    }
+    assertThat(untaggedEvents[1]).satisfies {
+      assertThat(it.level).isEqualTo(Level.INFO)
+      assertThat(it.message).isEqualTo("untagged info")
+      assertThat(it.throwableProxy).isNull()
+      assertThat(it.mdcPropertyMap).isEmpty()
+    }
+
+    // Log with tags
+    logger.info("user-id" to "blerb", "alias-id" to "d6F1EF53") { "tagged info" }
+    logger.error(NullPointerException("failed!"), "sample-size" to "200") { "tagged error" }
+
+    val taggedEvents = logCollector.takeEvents(LoggingTest::class)
+    assertThat(taggedEvents).hasSize(2)
+    assertThat(taggedEvents[0]).satisfies {
+      assertThat(it.level).isEqualTo(Level.INFO)
+      assertThat(it.message).isEqualTo("tagged info")
+      assertThat(it.throwableProxy).isNull()
+      assertThat(it.mdcPropertyMap).containsExactly(
+          "user-id" to "blerb",
+          "alias-id" to "d6F1EF53"
+      )
+    }
+    assertThat(taggedEvents[1]).satisfies {
+      assertThat(it.level).isEqualTo(Level.ERROR)
+      assertThat(it.message).isEqualTo("tagged error")
+      assertThat(it.throwableProxy.className).isEqualTo(NullPointerException::class.qualifiedName)
+      assertThat(it.mdcPropertyMap).containsExactly(
+          "sample-size" to "200"
+      )
+    }
+
+    // Establish external MDC, override with per-log message tags
+    try {
+      MDC.put("user-id", "inherited-external")
+      MDC.put("context-id", "111111")
+      logger.warn("context-id" to "overridden") { "inherited warn" }
+      logger.info { "uses default tags" }
+    } finally {
+      MDC.clear()
+    }
+
+    val defaultTaggedEvents = logCollector.takeEvents(LoggingTest::class)
+    assertThat(defaultTaggedEvents).hasSize(2)
+    assertThat(defaultTaggedEvents[0]).satisfies {
+      assertThat(it.level).isEqualTo(Level.WARN)
+      assertThat(it.message).isEqualTo("inherited warn")
+      assertThat(it.throwableProxy).isNull()
+      assertThat(it.mdcPropertyMap).containsExactly(
+          "user-id" to "inherited-external",
+          "context-id" to "overridden"
+      )
+    }
+    assertThat(defaultTaggedEvents[1]).satisfies {
+      assertThat(it.level).isEqualTo(Level.INFO)
+      assertThat(it.message).isEqualTo("uses default tags")
+      assertThat(it.mdcPropertyMap).containsExactly(
+          "user-id" to "inherited-external",
+          "context-id" to "111111"
+      )
+    }
   }
 }


### PR DESCRIPTION
Any passed tags are convered into MDC entries, which in turn get emitted
in JSON logs and indexed for searching