### PR TITLE
Add Common TsConfig to @misk/common

### DIFF
--- a/misk/web/@misk/common/package.json
+++ b/misk/web/@misk/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@misk/common",
-  "version": "0.0.17",
+  "version": "0.0.19",
   "description": "Microservice Kontainer Common Libraries, Externals, Styles",
   "author": "Square/Misk Authors (https://github.com/square/misk/graphs/contributors)",
   "main": "lib/common.js",

--- a/misk/web/@misk/common/package.json
+++ b/misk/web/@misk/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@misk/common",
-  "version": "0.0.16",
+  "version": "0.0.17",
   "description": "Microservice Kontainer Common Libraries, Externals, Styles",
   "author": "Square/Misk Authors (https://github.com/square/misk/graphs/contributors)",
   "main": "lib/common.js",

--- a/misk/web/@misk/common/src/base/tsconfig.base.json
+++ b/misk/web/@misk/common/src/base/tsconfig.base.json
@@ -1,0 +1,34 @@
+{
+  "compileOnSave": true,
+  "compilerOptions": {
+      "allowSyntheticDefaultImports": true,
+      "declaration": true,
+      "esModuleInterop": true,
+      "experimentalDecorators": true,
+      "importHelpers": true,
+      "jsx": "react",
+      "lib": [
+          "dom",
+          "dom.iterable",
+          "es5",
+          "es2015.collection",
+          "es2015.iterable",
+          "es6",
+          "es2017"
+      ],
+      "module": "commonjs",
+      "moduleResolution": "node",
+      "noFallthroughCasesInSwitch": true,
+      "noImplicitAny": true,
+      "noImplicitReturns": true,
+      "noUnusedLocals": true,
+      "noUnusedParameters": true,
+      "pretty": true,
+      "removeComments": false,
+      "sourceMap": true,
+      "stripInternal": true,
+      "target": "es5",
+      "types": ["node"],
+      "typeRoots": ["../node_modules/@types"]  
+  }
+}

--- a/misk/web/@misk/common/tsconfig.json
+++ b/misk/web/@misk/common/tsconfig.json
@@ -1,58 +1,6 @@
 {
-    "compileOnSave": true,
+    "extends": "./src/base/tsconfig.base",
     "compilerOptions": {
-        "allowSyntheticDefaultImports": true,
-        "declaration": true,
-        "esModuleInterop": true,
-        "experimentalDecorators": true,
-        "importHelpers": true,
-        "jsx": "react",
-        "lib": [
-            "dom",
-            "dom.iterable",
-            "es5",
-            "es2015.collection",
-            "es2015.iterable"
-        ],
-        "module": "commonjs",
-        "moduleResolution": "node",
-        "noFallthroughCasesInSwitch": true,
-        "noImplicitAny": true,
-        "noImplicitReturns": true,
-        "noUnusedLocals": true,
-        "noUnusedParameters": true,
         "outDir": "./lib",
-        "pretty": true,
-        "removeComments": false,
-        "sourceMap": true,
-        "stripInternal": true,
-        "target": "es3",
-        "types": ["node"],
-        "typeRoots": ["../node_modules/@types"]  
-    },
-}
-
-{
-    "compileOnSave": true,
-    "compilerOptions": {
-        "alwaysStrict": true,
-        "jsx": "react",
-        "lib": ["es5", "es6", "dom", "es2017"],
-        "module": "commonjs",
-        "noEmit": true,
-        "noEmitOnError": true,
-        "noImplicitAny": true,
-        "noImplicitThis": true,
-        "outDir": "./lib/",
-        "skipLibCheck": true,
-        "sourceMap": true,
-        "strict": true,
-        "target": "es6",
-    },
-    "include": [
-        "./src/**/*"
-    ],
-    "exclude": [
-        "node_modules/**"
-    ]
+    }
 }

--- a/misk/web/@misk/common/tsconfig.json
+++ b/misk/web/@misk/common/tsconfig.json
@@ -2,9 +2,40 @@
     "compileOnSave": true,
     "compilerOptions": {
         "allowSyntheticDefaultImports": true,
-        "alwaysStrict": true,
         "declaration": true,
         "esModuleInterop": true,
+        "experimentalDecorators": true,
+        "importHelpers": true,
+        "jsx": "react",
+        "lib": [
+            "dom",
+            "dom.iterable",
+            "es5",
+            "es2015.collection",
+            "es2015.iterable"
+        ],
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitAny": true,
+        "noImplicitReturns": true,
+        "noUnusedLocals": true,
+        "noUnusedParameters": true,
+        "outDir": "./lib",
+        "pretty": true,
+        "removeComments": false,
+        "sourceMap": true,
+        "stripInternal": true,
+        "target": "es3",
+        "types": ["node"],
+        "typeRoots": ["../node_modules/@types"]  
+    },
+}
+
+{
+    "compileOnSave": true,
+    "compilerOptions": {
+        "alwaysStrict": true,
         "jsx": "react",
         "lib": ["es5", "es6", "dom", "es2017"],
         "module": "commonjs",

--- a/misk/web/@misk/common/webpack.config.js
+++ b/misk/web/@misk/common/webpack.config.js
@@ -1,4 +1,13 @@
+const CopyWebpackPlugin = require('copy-webpack-plugin');
 const path = require('path');
+
+const CopyWebpackPluginConfig = new CopyWebpackPlugin(
+  [
+    { from: './tsconfig.json'},
+    { from: './tslint.json'},
+  ], 
+  { debug: 'info', copyUnmodified: true }
+)
 
 module.exports = {
   name: "library",
@@ -30,4 +39,7 @@ module.exports = {
   resolve: {
     extensions: [".ts", ".tsx"]
   },
+  plugins: [
+    CopyWebpackPluginConfig
+  ]
 };

--- a/misk/web/@misk/common/webpack.config.js
+++ b/misk/web/@misk/common/webpack.config.js
@@ -3,8 +3,7 @@ const path = require('path');
 
 const CopyWebpackPluginConfig = new CopyWebpackPlugin(
   [
-    { from: './tsconfig.json'},
-    { from: './tslint.json'},
+    { from: './src/base/'},
   ], 
   { debug: 'info', copyUnmodified: true }
 )

--- a/misk/web/@misk/dev/package.json
+++ b/misk/web/@misk/dev/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@misk/dev",
-  "version": "0.0.8",
+  "version": "0.0.10",
   "description": "Microservice Kontainer Development Libraries",
   "author": "Square/Misk Authors (https://github.com/square/misk/graphs/contributors)",
   "repository": {

--- a/misk/web/tabs/config/package.json
+++ b/misk/web/tabs/config/package.json
@@ -12,7 +12,7 @@
     "test": "jest --coverage"
   },
   "dependencies": {
-    "@misk/common": "^0.0.17",
+    "@misk/common": "^0.0.19",
     "@misk/components": "^0.0.16",
     "@misk/tabs": "^0.0.1",
     "gray-matter": "^4.0.1",
@@ -20,6 +20,6 @@
     "json2yaml": "^1.1.0"
   },
   "devDependencies": {
-    "@misk/dev": "^0.0.8"
+    "@misk/dev": "^0.0.10"
   }
 }

--- a/misk/web/tabs/config/package.json
+++ b/misk/web/tabs/config/package.json
@@ -20,6 +20,7 @@
     "json2yaml": "^1.1.0"
   },
   "devDependencies": {
-    "@misk/dev": "^0.0.8"
+    "@misk/dev": "^0.0.8",
+    "@types/webpack-env":"^1.13.6"
   }
 }

--- a/misk/web/tabs/config/package.json
+++ b/misk/web/tabs/config/package.json
@@ -12,7 +12,7 @@
     "test": "jest --coverage"
   },
   "dependencies": {
-    "@misk/common": "^0.0.16",
+    "@misk/common": "^0.0.17",
     "@misk/components": "^0.0.16",
     "@misk/tabs": "^0.0.1",
     "gray-matter": "^4.0.1",
@@ -20,7 +20,6 @@
     "json2yaml": "^1.1.0"
   },
   "devDependencies": {
-    "@misk/dev": "^0.0.8",
-    "@types/webpack-env":"^1.13.6"
+    "@misk/dev": "^0.0.8"
   }
 }

--- a/misk/web/tabs/config/src/components/ConfigComponent.tsx
+++ b/misk/web/tabs/config/src/components/ConfigComponent.tsx
@@ -1,5 +1,5 @@
 // tslint:disable-next-line:no-var-requires
-const YAML = require("json2yaml")
+// const YAML = require("json2yaml")
 import * as React from "react"
 import styled from "styled-components"
 import { IConfigFile } from "../containers/TabContainer"

--- a/misk/web/tabs/config/src/containers/TabContainer.tsx
+++ b/misk/web/tabs/config/src/containers/TabContainer.tsx
@@ -1,4 +1,3 @@
-import { PathDebugComponent } from "@misk/components"
 import * as React from "react"
 import { connect } from "react-redux"
 import styled from "styled-components" 

--- a/misk/web/tabs/config/src/index.tsx
+++ b/misk/web/tabs/config/src/index.tsx
@@ -1,3 +1,4 @@
+///<reference types="webpack-env" />
 import { IMiskWindow } from "@misk/common"
 import { connectRouter, routerMiddleware } from "connected-react-router"
 import { createBrowserHistory } from "history"

--- a/misk/web/tabs/config/src/reducers/index.ts
+++ b/misk/web/tabs/config/src/reducers/index.ts
@@ -1,4 +1,3 @@
-import { IMiskAdminTabs } from "@misk/common"
 import { RouterState } from "connected-react-router"
 import { fromJS, List } from "immutable"
 import { combineReducers } from "redux"

--- a/misk/web/tabs/config/src/sagas/configSaga.ts
+++ b/misk/web/tabs/config/src/sagas/configSaga.ts
@@ -11,7 +11,7 @@ import { all, call, put, takeLatest } from "redux-saga/effects"
 const dayjs = require("dayjs")
 
 import {
-  CONFIG, dispatchConfig, IAction, IActionType
+  CONFIG, dispatchConfig
 } from "../actions"
 
 const dateFormat = "YYYY-MM-DD HH:mm:ss"

--- a/misk/web/tabs/config/tsconfig.json
+++ b/misk/web/tabs/config/tsconfig.json
@@ -1,14 +1,38 @@
 {
-  "compilerOptions": {
-      "outDir": "./dist",
-      "sourceMap": true,
-      "noImplicitAny": true,
-      "module": "commonjs",
-      "jsx": "react",
-      "target": "esnext",
-      "lib": ["es5", "es6", "dom", "es2017"]
-  },
-  "include": [
-      "./src/**/*"
-  ]
+    "compileOnSave": true,
+    "compilerOptions": {
+        "allowSyntheticDefaultImports": true,
+        "declaration": true,
+        "esModuleInterop": true,
+        "experimentalDecorators": true,
+        "importHelpers": true,
+        "jsx": "react",
+        "lib": [
+            "dom",
+            "dom.iterable",
+            "es5",
+            "es2015.collection",
+            "es2015.iterable",
+            "es6",
+            "es2017"
+        ],
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitAny": true,
+        "noImplicitReturns": true,
+        "noUnusedLocals": true,
+        "noUnusedParameters": true,
+        "outDir": "./dist",
+        "pretty": true,
+        "removeComments": false,
+        "sourceMap": true,
+        "stripInternal": true,
+        "target": "es5",
+        "types": ["node"],
+        "typeRoots": ["../node_modules/@types"]  
+    },
+    "include": [
+        "./src/**/*"
+    ]
 }

--- a/misk/web/tabs/config/tsconfig.json
+++ b/misk/web/tabs/config/tsconfig.json
@@ -1,38 +1,6 @@
 {
-    "compileOnSave": true,
+    "extends": "./node_modules/@misk/common/lib/tsconfig.base",
     "compilerOptions": {
-        "allowSyntheticDefaultImports": true,
-        "declaration": true,
-        "esModuleInterop": true,
-        "experimentalDecorators": true,
-        "importHelpers": true,
-        "jsx": "react",
-        "lib": [
-            "dom",
-            "dom.iterable",
-            "es5",
-            "es2015.collection",
-            "es2015.iterable",
-            "es6",
-            "es2017"
-        ],
-        "module": "commonjs",
-        "moduleResolution": "node",
-        "noFallthroughCasesInSwitch": true,
-        "noImplicitAny": true,
-        "noImplicitReturns": true,
-        "noUnusedLocals": true,
-        "noUnusedParameters": true,
-        "outDir": "./dist",
-        "pretty": true,
-        "removeComments": false,
-        "sourceMap": true,
-        "stripInternal": true,
-        "target": "es5",
-        "types": ["node"],
-        "typeRoots": ["../node_modules/@types"]  
-    },
-    "include": [
-        "./src/**/*"
-    ]
-}
+        "outDir": "./dist"
+    }
+  }

--- a/misk/web/tabs/config/yarn.lock
+++ b/misk/web/tabs/config/yarn.lock
@@ -66,9 +66,9 @@
     skeleton-css "^2.0.4"
     styled-components "^3.4.2"
 
-"@misk/common@^0.0.17":
-  version "0.0.17"
-  resolved "https://registry.yarnpkg.com/@misk/common/-/common-0.0.17.tgz#48ff238164c2644b1823869259dc5f906cffff3d"
+"@misk/common@^0.0.19":
+  version "0.0.19"
+  resolved "https://registry.yarnpkg.com/@misk/common/-/common-0.0.19.tgz#113170cd571abf0357b86cff3ef2389439709591"
   dependencies:
     "@blueprintjs/core" "^3.3.0"
     "@blueprintjs/icons" "^3.0.0"
@@ -97,11 +97,10 @@
   dependencies:
     "@misk/common" "^0.0.14"
 
-"@misk/dev@^0.0.8":
-  version "0.0.8"
-  resolved "https://registry.yarnpkg.com/@misk/dev/-/dev-0.0.8.tgz#b89f4eee8e4185fcb472569fa498ebae74271af1"
+"@misk/dev@^0.0.10":
+  version "0.0.10"
+  resolved "https://registry.yarnpkg.com/@misk/dev/-/dev-0.0.10.tgz#7ec29a6d148785b756b5e642b0ab5184d0242638"
   dependencies:
-    "@types/immutable" "^3.8.7"
     "@types/node" "^10.7.0"
     "@types/react" "^16.4.10"
     "@types/react-dom" "^16.0.7"
@@ -150,12 +149,6 @@
 "@types/history@*":
   version "4.6.2"
   resolved "https://npm.vip.global.square/@types%2fhistory/-/history-4.6.2.tgz#12cfaba693ba20f114ed5765467ff25fdf67ddb0"
-
-"@types/immutable@^3.8.7":
-  version "3.8.7"
-  resolved "https://registry.yarnpkg.com/@types/immutable/-/immutable-3.8.7.tgz#536d33d30f3f3d9a6d4642a219419fd82af633fb"
-  dependencies:
-    immutable "*"
 
 "@types/node@*":
   version "10.5.0"
@@ -2431,7 +2424,7 @@ ignore@^3.3.5:
   version "3.3.10"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-3.3.10.tgz#0a97fb876986e8081c631160f8f9f389157f0043"
 
-immutable@*, immutable@^3.8.1, immutable@^3.8.2:
+immutable@^3.8.1, immutable@^3.8.2:
   version "3.8.2"
   resolved "https://npm.vip.global.square/immutable/-/immutable-3.8.2.tgz#c2439951455bb39913daf281376f1530e104adf3"
 

--- a/misk/web/tabs/config/yarn.lock
+++ b/misk/web/tabs/config/yarn.lock
@@ -66,9 +66,9 @@
     skeleton-css "^2.0.4"
     styled-components "^3.4.2"
 
-"@misk/common@^0.0.16":
-  version "0.0.16"
-  resolved "https://registry.yarnpkg.com/@misk/common/-/common-0.0.16.tgz#b67715f82776401bf2c5c078fcbe203cc3a9d5b3"
+"@misk/common@^0.0.17":
+  version "0.0.17"
+  resolved "https://registry.yarnpkg.com/@misk/common/-/common-0.0.17.tgz#48ff238164c2644b1823869259dc5f906cffff3d"
   dependencies:
     "@blueprintjs/core" "^3.3.0"
     "@blueprintjs/icons" "^3.0.0"

--- a/misk/web/tabs/loader/package.json
+++ b/misk/web/tabs/loader/package.json
@@ -12,7 +12,7 @@
     "test": "jest --coverage"
   },
   "dependencies": {
-    "@misk/common": "^0.0.16",
+    "@misk/common": "^0.0.17",
     "@misk/components": "^0.0.16",
     "@misk/tabs": "^0.0.1"
   },

--- a/misk/web/tabs/loader/package.json
+++ b/misk/web/tabs/loader/package.json
@@ -12,11 +12,11 @@
     "test": "jest --coverage"
   },
   "dependencies": {
-    "@misk/common": "^0.0.17",
+    "@misk/common": "^0.0.19",
     "@misk/components": "^0.0.16",
     "@misk/tabs": "^0.0.1"
   },
   "devDependencies": {
-    "@misk/dev": "^0.0.8"
+    "@misk/dev": "^0.0.10"
   }
 }

--- a/misk/web/tabs/loader/src/actions/index.ts
+++ b/misk/web/tabs/loader/src/actions/index.ts
@@ -1,4 +1,4 @@
-import { IMiskAdminTab, IMiskAdminTabs } from "@misk/common"
+import { IMiskAdminTab } from "@misk/common"
 import { IMultibinder } from "../utils/binder"
 import { IActionType, ITEM, LOADER } from "./types"
 import { createAction, IAction } from "./utils"

--- a/misk/web/tabs/loader/src/containers/LoaderContainer.tsx
+++ b/misk/web/tabs/loader/src/containers/LoaderContainer.tsx
@@ -1,6 +1,5 @@
-import { IMiskAdminTab, IMiskAdminTabs } from "@misk/common"
+import { IMiskAdminTab } from "@misk/common"
 import { NavSidebarComponent, NavTopbarComponent, NoMatchComponent } from "@misk/components"
-import { externals as MiskTabCommon } from "@misk/tabs" 
 import { RouterState } from "connected-react-router"
 import * as React from "react"
 import { connect } from "react-redux"
@@ -10,10 +9,6 @@ import { dispatchLoader } from "../actions"
 import { MountingDivComponent, ScriptComponent } from "../components"
 import { ILoaderState, IState } from "../reducers"
 import { IMultibinder } from "../utils/binder"
-
-interface IMiskTabs {
-  [app:string]: any
-}
 
 export interface ILoaderProps {
   loader: ILoaderState
@@ -30,20 +25,19 @@ class LoaderContainer extends React.Component<ILoaderProps> {
     this.props.getTabs()
   }
 
-  buildTabRouteMountingDiv(key: any, tab: IMiskAdminTab) {
-    return(<Route key={key} path={`/_admin/${tab.slug}/`} render={() => <MountingDivComponent key={key} tab={tab}/>}/>)
+  buildTabRouteMountingDiv(tab: IMiskAdminTab) {
+    return(<Route path={`/_admin/${tab.slug}/`} render={() => <MountingDivComponent tab={tab}/>}/>)
   }
 
   render() {
     const { adminTabs, adminTabComponents, staleTabCache } = this.props.loader
     if (adminTabs) {
-      const tabRouteDivs = Object.entries(adminTabs).map(([key,tab]) => this.buildTabRouteMountingDiv(key, tab))
-      const tabLinks = Object.entries(adminTabs).map(([key,tab]) => <Link key={key} to={`/_admin/${tab.slug}/`}>{tab.name}<br/></Link>)
+      const tabLinks = Object.entries(adminTabs).map(([,tab]) => <Link key={tab.slug} to={`/_admin/${tab.slug}/`}>{tab.name}<br/></Link>)
       return (
         <div>
           <NavTopbarComponent name="Misk Admin Loader" />
           <NavSidebarComponent adminTabs={adminTabs} />
-          {Object.entries(adminTabs).map(([key,tab]) => (<ScriptComponent tab={tab}/>))}
+          {Object.entries(adminTabs).map(([key,tab]) => (<ScriptComponent key={key} tab={tab}/>))}
           <Switch>
             <Route component={NoMatchComponent}/>
           </Switch>

--- a/misk/web/tabs/loader/src/index.tsx
+++ b/misk/web/tabs/loader/src/index.tsx
@@ -1,3 +1,4 @@
+///<reference types="webpack-env" />
 import { IMiskWindow } from "@misk/common"
 import { connectRouter, routerMiddleware } from "connected-react-router"
 import { createBrowserHistory } from "history"

--- a/misk/web/tabs/loader/src/routes.tsx
+++ b/misk/web/tabs/loader/src/routes.tsx
@@ -1,4 +1,3 @@
-import { NoMatchComponent } from "@misk/components"
 import * as React from "react"
 import { Route, Switch } from "react-router"
 import { LoaderContainer } from "./containers"

--- a/misk/web/tabs/loader/src/sagas/loaderSaga.tsx
+++ b/misk/web/tabs/loader/src/sagas/loaderSaga.tsx
@@ -6,7 +6,7 @@
 // import { push } from react-router-redux and then
 // yield put(push('/next-page'))
 
-import { IMiskAdminTab, IMiskAdminTabs } from "@misk/common"
+import { IMiskAdminTab } from "@misk/common"
 import axios from "axios"
 import { all, call, put, takeEvery, takeLatest } from "redux-saga/effects"
 
@@ -35,7 +35,7 @@ function * handleGetAllTabs () {
   }
 }
 
-function * handleGetAllAndTabs (action: IAction<IActionType, {}>) {
+function * handleGetAllAndTabs () {
   let adminTabs: any = {}
   try {
     yield put(dispatchLoader.getAllTabs())

--- a/misk/web/tabs/loader/tsconfig.json
+++ b/misk/web/tabs/loader/tsconfig.json
@@ -1,14 +1,6 @@
 {
-  "compilerOptions": {
-      "outDir": "./dist",
-      "sourceMap": true,
-      "noImplicitAny": true,
-      "module": "commonjs",
-      "jsx": "react",
-      "target": "esnext",
-      "lib": ["es5", "es6", "dom", "es2017"]
-  },
-  "include": [
-      "./src/**/*"
-  ]
-}
+    "extends": "./node_modules/@misk/common/lib/tsconfig.base",
+    "compilerOptions": {
+        "outDir": "./dist"
+    }
+  }

--- a/misk/web/tabs/loader/yarn.lock
+++ b/misk/web/tabs/loader/yarn.lock
@@ -66,9 +66,9 @@
     skeleton-css "^2.0.4"
     styled-components "^3.4.2"
 
-"@misk/common@^0.0.16":
-  version "0.0.16"
-  resolved "https://registry.yarnpkg.com/@misk/common/-/common-0.0.16.tgz#b67715f82776401bf2c5c078fcbe203cc3a9d5b3"
+"@misk/common@^0.0.17":
+  version "0.0.17"
+  resolved "https://registry.yarnpkg.com/@misk/common/-/common-0.0.17.tgz#48ff238164c2644b1823869259dc5f906cffff3d"
   dependencies:
     "@blueprintjs/core" "^3.3.0"
     "@blueprintjs/icons" "^3.0.0"

--- a/misk/web/tabs/loader/yarn.lock
+++ b/misk/web/tabs/loader/yarn.lock
@@ -66,9 +66,9 @@
     skeleton-css "^2.0.4"
     styled-components "^3.4.2"
 
-"@misk/common@^0.0.17":
-  version "0.0.17"
-  resolved "https://registry.yarnpkg.com/@misk/common/-/common-0.0.17.tgz#48ff238164c2644b1823869259dc5f906cffff3d"
+"@misk/common@^0.0.19":
+  version "0.0.19"
+  resolved "https://registry.yarnpkg.com/@misk/common/-/common-0.0.19.tgz#113170cd571abf0357b86cff3ef2389439709591"
   dependencies:
     "@blueprintjs/core" "^3.3.0"
     "@blueprintjs/icons" "^3.0.0"
@@ -97,11 +97,10 @@
   dependencies:
     "@misk/common" "^0.0.14"
 
-"@misk/dev@^0.0.8":
-  version "0.0.8"
-  resolved "https://registry.yarnpkg.com/@misk/dev/-/dev-0.0.8.tgz#b89f4eee8e4185fcb472569fa498ebae74271af1"
+"@misk/dev@^0.0.10":
+  version "0.0.10"
+  resolved "https://registry.yarnpkg.com/@misk/dev/-/dev-0.0.10.tgz#7ec29a6d148785b756b5e642b0ab5184d0242638"
   dependencies:
-    "@types/immutable" "^3.8.7"
     "@types/node" "^10.7.0"
     "@types/react" "^16.4.10"
     "@types/react-dom" "^16.0.7"
@@ -150,12 +149,6 @@
 "@types/history@*":
   version "4.6.2"
   resolved "https://npm.vip.global.square/@types%2fhistory/-/history-4.6.2.tgz#12cfaba693ba20f114ed5765467ff25fdf67ddb0"
-
-"@types/immutable@^3.8.7":
-  version "3.8.7"
-  resolved "https://registry.yarnpkg.com/@types/immutable/-/immutable-3.8.7.tgz#536d33d30f3f3d9a6d4642a219419fd82af633fb"
-  dependencies:
-    immutable "*"
 
 "@types/node@*":
   version "10.5.0"
@@ -2422,7 +2415,7 @@ ignore@^3.3.5:
   version "3.3.10"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-3.3.10.tgz#0a97fb876986e8081c631160f8f9f389157f0043"
 
-immutable@*, immutable@^3.8.1, immutable@^3.8.2:
+immutable@^3.8.1, immutable@^3.8.2:
   version "3.8.2"
   resolved "https://npm.vip.global.square/immutable/-/immutable-3.8.2.tgz#c2439951455bb39913daf281376f1530e104adf3"
 


### PR DESCRIPTION
Ensure common Typescript build environment across all Misk front end development with all `tsconfig.json` Typescript compiler options extending the same base in `@misk/common/src/base`. Existing tabs updated to extend base options.

Side Effect: many fixes to code in Config/Loader tabs since the common `tsconfig.json` rules are stricter than the existing ones that were in each tab.

Depends on PR #423 merging