### PR TITLE
Move Webpack Externals from @misk/common to @misk/dev

### DIFF
--- a/misk/web/@misk/common/README.md
+++ b/misk/web/@misk/common/README.md
@@ -9,6 +9,13 @@ Getting Started
 $ yarn add @misk/common
 ```
 
+Automatic Inclusion
+---
+- If your Webpack config builds off of a template in `@misk/dev`, `vendors.js` and `styles.js` will automatically be included in the build of that repo.
+- If your Webpack config does not build off of a template in `@misk/dev`, use the Manual Inclusion steps below.
+
+Manual Inclusion
+---
 - Using the common vendors libraries and styles. We use [`copy-webpack-plugin`](https://github.com/webpack-contrib/copy-webpack-plugin) to copy the compiled `vendor.js` and `styles.js` files into build folder.
   - Install [`copy-webpack-plugin`](https://github.com/webpack-contrib/copy-webpack-plugin)
     
@@ -50,22 +57,6 @@ $ yarn add @misk/common
     </body>
     ```
 
-- Use `@misk/common` externals to keep Webpack from bundling duplicate libraries and styles into your Misk module. Add the following to your `webpack.config.js` as relevant.
-  
-  ```Typescript
-  const MiskCommon = require('@misk/common')
-
-  ...
-
-  module.exports = {
-    mode
-    entry
-    ...
-    externals: { ...MiskCommon.vendorExternals, ...MiskCommon.miskExternals },
-  }
-
-  ```
-
 Included Libraries
 ---
 From `package.json`:
@@ -106,13 +97,13 @@ Contributing
 ---
 #Adding a new package
 - `yarn add {package}` to add the package to `package.json`
-- Add package to window variable mapping to `src/externals.ts`
+- Add package to `vendorExternals` in `@misk/dev/externals.js`
 - Add window to javascript require include in `src/vendors.js`
 - Update `README.md` with a copy of the updated `package.json` list of packages
 
 Webpack Configs
 ---
-- `webpack.config.js`: Exports common variables including `MiskCommon.Externals`
+- `webpack.config.js`: Exports common variables and functions
 - `webpack.static.config.js`: Exports common styles file
 - `webpack.vendor.config.js`: Exports common vendors library file
 

--- a/misk/web/@misk/common/package.json
+++ b/misk/web/@misk/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@misk/common",
-  "version": "0.0.30",
+  "version": "0.0.31",
   "description": "Microservice Kontainer Common Libraries, Externals, Styles",
   "author": "Square/Misk Authors (https://github.com/square/misk/graphs/contributors)",
   "main": "lib/common.js",
@@ -50,7 +50,7 @@
     "styled-components": "^3.4.2"
   },
   "devDependencies": {
-    "@misk/dev": "^0.0.22",
+    "@misk/dev": "^0.0.25",
     "@misk/tslint": "^0.0.3"
   }
 }

--- a/misk/web/@misk/common/src/index.ts
+++ b/misk/web/@misk/common/src/index.ts
@@ -1,5 +1,3 @@
-export * from "./externals"
-
 /**
  * Common Interfaces
  */

--- a/misk/web/@misk/common/yarn.lock
+++ b/misk/web/@misk/common/yarn.lock
@@ -41,9 +41,9 @@
     reflect-metadata "^0.1.12"
     tslib "^1.8.1"
 
-"@misk/dev@^0.0.21":
-  version "0.0.21"
-  resolved "https://registry.yarnpkg.com/@misk/dev/-/dev-0.0.21.tgz#af9a9ff64b71af531e9926ceef558532224987d4"
+"@misk/dev@^0.0.25":
+  version "0.0.25"
+  resolved "https://registry.yarnpkg.com/@misk/dev/-/dev-0.0.25.tgz#efdf4e112d865c1f8413a58ffde5e0223b4e4739"
   dependencies:
     "@types/node" "^10.9.4"
     "@types/react" "^16.4.13"

--- a/misk/web/@misk/components/package.json
+++ b/misk/web/@misk/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@misk/components",
-  "version": "0.0.20",
+  "version": "0.0.21",
   "description": "Microservice Kontainer Common Components",
   "author": "Square/Misk Authors (https://github.com/square/misk/graphs/contributors)",
   "main": "lib/components.js",
@@ -27,10 +27,10 @@
     "test": "echo no tests"
   },
   "dependencies": {
-    "@misk/common": "^0.0.30"
+    "@misk/common": "^0.0.31"
   },
   "devDependencies": {
-    "@misk/dev": "^0.0.22",
+    "@misk/dev": "^0.0.25",
     "@misk/tslint": "^0.0.3"
   }
 }

--- a/misk/web/@misk/components/webpack.config.js
+++ b/misk/web/@misk/components/webpack.config.js
@@ -1,5 +1,5 @@
-const path = require('path');
-const MiskCommon = require('@misk/common');
+const path = require('path')
+const MiskDev = require('@misk/dev')
 
 module.exports = {
   mode: 'production',
@@ -33,5 +33,5 @@ module.exports = {
   resolve: {
     extensions: [".ts", ".tsx", ".js", ".jsx", ".json"]
   },
-  externals: MiskCommon.vendorExternals
-};
+  externals: MiskDev.vendorExternals
+}

--- a/misk/web/@misk/components/yarn.lock
+++ b/misk/web/@misk/components/yarn.lock
@@ -41,9 +41,9 @@
     reflect-metadata "^0.1.12"
     tslib "^1.8.1"
 
-"@misk/common@^0.0.30":
-  version "0.0.30"
-  resolved "https://registry.yarnpkg.com/@misk/common/-/common-0.0.30.tgz#f47570ac6fdb09e4201048c0fe543bd4fe65f93e"
+"@misk/common@^0.0.31":
+  version "0.0.31"
+  resolved "https://registry.yarnpkg.com/@misk/common/-/common-0.0.31.tgz#feff4a350500ec30f728e74e82f546efadaeef8f"
   dependencies:
     "@blueprintjs/core" "^3.3.0"
     "@blueprintjs/icons" "^3.0.0"
@@ -66,9 +66,9 @@
     skeleton-css "^2.0.4"
     styled-components "^3.4.2"
 
-"@misk/dev@^0.0.20":
-  version "0.0.20"
-  resolved "https://registry.yarnpkg.com/@misk/dev/-/dev-0.0.20.tgz#254a0f726f7f2072ed1436cbcba7c3ad2ad02ac9"
+"@misk/dev@^0.0.25":
+  version "0.0.25"
+  resolved "https://registry.yarnpkg.com/@misk/dev/-/dev-0.0.25.tgz#efdf4e112d865c1f8413a58ffde5e0223b4e4739"
   dependencies:
     "@types/node" "^10.9.4"
     "@types/react" "^16.4.13"

--- a/misk/web/@misk/dev/README.md
+++ b/misk/web/@misk/dev/README.md
@@ -27,17 +27,53 @@ Webpack Template
 Create a `webpack.config.js` file in the repo root directory with the following:
 
 ```Javascript
-const { MiskWebpackConfigBase } = require("@misk/dev")
+const { miskTabWebpackBuilder } = require("@misk/dev")
 const path = require('path')
 const miskTabWebpack = require(path.join(process.cwd(), "package.json")).miskTabWebpack
-module.exports = MiskWebpackConfigBase(process.env.NODE_ENV, {
+module.exports = miskTabWebpackBuilder(process.env.NODE_ENV, {
   "dirname": __dirname,
   miskTabWebpack
 },
 {
-  // optional: any other Webpack config fields to be merged with the Misk Webpack Base Config
+  // optional: any other Webpack config fields to be merged with the Misk Tab Webpack Config
 })
 ```
+
+Webpack Externals
+---
+Used in `miskTabWebpackBuilder` but also available as an export of `@misk/dev` are the following externals objects that are formatted for use by Webpack to exclude libraries from compiled code:
+
+- `vendorExternals`: vendor libraries included in `@misk/common/lib/vendors.js`
+- `miskExternals`: all Misk libraries
+
+If you are using one of the Webpack builders in `@misk/dev`, all externals above are included in the Webpack config. To use the externals in other Webpack configs, follow the steps below.
+
+- Add the following to your `webpack.config.js` as relevant.
+  
+  ```Javascript
+  const MiskDev = require('@misk/dev')
+
+  ...
+
+  module.exports = {
+    mode
+    entry
+    ...
+    externals: { ...MiskDev.vendorExternals, ...MiskDev.miskExternals },
+  }
+
+  ```
+
+To build your own externals, use the exported function `makeExternals` which consumes an object of the below structure which maps a key (NPM package name) to a normalized library name that will be mounted on browser `window`.
+
+  ```JSON
+  {
+    "@blueprintjs/core": ["Blueprint", "Core"],
+    "@blueprintjs/icons": ["Blueprint", "Icons"],
+    "axios": "Axios",
+    ...
+  }
+  ```
 
 Package.json Input Parameters
 ---

--- a/misk/web/@misk/dev/externals.js
+++ b/misk/web/@misk/dev/externals.js
@@ -1,24 +1,8 @@
-export interface IInExternal {
-  [key: string]: string|string[]
-}
-
-export interface IOutExternal {
-  [key: string]: {
-    amd: string
-    commonjs: string
-    commonjs2: string
-    root: string|string[]
-  }
-}
-
 /**
- * 
- * @param inExternals : IExternal
- * 
  * Create Webpack compatible externals object with compatible entries for amd, commonjs, commonjs2, root
  */
-export const makeExternals = (inExternals: IInExternal) : IOutExternal => {
-  const outExternals: IOutExternal = {}
+const makeExternals = (inExternals) => {
+  const outExternals = {}
   Object.keys(inExternals).map((pkg) => {
     outExternals[pkg] = {
       amd: pkg,
@@ -30,7 +14,7 @@ export const makeExternals = (inExternals: IInExternal) : IOutExternal => {
   return outExternals
 }
 
-export const vendorExternals = makeExternals({
+const vendorExternals = makeExternals({
   "@blueprintjs/core": ["Blueprint", "Core"],
   "@blueprintjs/icons": ["Blueprint", "Icons"],
   "axios": "Axios",
@@ -51,6 +35,8 @@ export const vendorExternals = makeExternals({
   "styled-components": "StyledComponents"
 })
 
-export const miskExternals = makeExternals({
+const miskExternals = makeExternals({
   "@misk/components": ["Misk", "Components"]
 })
+
+module.exports = { makeExternals, vendorExternals, miskExternals }

--- a/misk/web/@misk/dev/index.js
+++ b/misk/web/@misk/dev/index.js
@@ -1,4 +1,5 @@
-const MiskWebpackConfigBase = require("./webpack.config.base")
+const miskTabWebpackBuilder = require("./webpack.config.tab")
+const { makeExternals, vendorExternals, miskExternals } = require("./externals")
 module.exports = {
-  MiskWebpackConfigBase
+  miskTabWebpackBuilder, makeExternals, vendorExternals, miskExternals
 }

--- a/misk/web/@misk/dev/package.json
+++ b/misk/web/@misk/dev/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@misk/dev",
-  "version": "0.0.22",
+  "version": "0.0.25",
   "description": "Microservice Kontainer Development Libraries",
   "author": "Square/Misk Authors (https://github.com/square/misk/graphs/contributors)",
   "repository": {
@@ -34,8 +34,5 @@
     "webpack-cli": "^3.1.0",
     "webpack-dev-server": "^3.1.7",
     "webpack-merge": "^4.1.4"
-  },
-  "devDependencies": {
-    "@misk/common": "^0.0.30"
   }
 }

--- a/misk/web/@misk/dev/webpack.config.tab.js
+++ b/misk/web/@misk/dev/webpack.config.tab.js
@@ -1,4 +1,4 @@
-const MiskCommon = require('@misk/common')
+const { vendorExternals, miskExternals } = require('./externals')
 const CopyWebpackPlugin = require('copy-webpack-plugin')
 const HTMLWebpackPlugin = require('html-webpack-plugin')
 const path = require('path')
@@ -80,7 +80,7 @@ module.exports = (env, argv, otherConfigFields = {}) => {
       .concat(env !== 'production'
       ? [new webpack.HotModuleReplacementPlugin()]
       : [DefinePluginConfig]),
-    externals: { ...MiskCommon.vendorExternals, ...MiskCommon.miskExternals }
+    externals: { ...vendorExternals, ...miskExternals }
   }
   
   return merge(baseConfigFields, otherConfigFields)

--- a/misk/web/tabs/config/package.json
+++ b/misk/web/tabs/config/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "misk-tab-admin-config",
+  "name": "misktab-config",
   "version": "0.0.2",
   "main": "src/index.ts",
   "repository": "git@github.com:square/misk.git",
@@ -12,15 +12,15 @@
     "test": "jest --coverage"
   },
   "dependencies": {
-    "@misk/common": "^0.0.30",
-    "@misk/components": "^0.0.20",
+    "@misk/common": "^0.0.31",
+    "@misk/components": "^0.0.21",
     "@misk/tabs": "^0.0.1",
     "gray-matter": "^4.0.1",
     "js-yaml": "^3.12.0",
     "json2yaml": "^1.1.0"
   },
   "devDependencies": {
-    "@misk/dev": "^0.0.22",
+    "@misk/dev": "^0.0.25",
     "@misk/tslint": "^0.0.3"
   },
   "miskTabWebpack": {

--- a/misk/web/tabs/config/webpack.config.js
+++ b/misk/web/tabs/config/webpack.config.js
@@ -1,7 +1,7 @@
-const { MiskWebpackConfigBase } = require("@misk/dev")
+const { miskTabWebpackBuilder } = require("@misk/dev")
 const path = require('path')
 const miskTabWebpack = require(path.join(process.cwd(), "package.json")).miskTabWebpack
-module.exports = MiskWebpackConfigBase(process.env.NODE_ENV, {
+module.exports = miskTabWebpackBuilder(process.env.NODE_ENV, {
   "dirname": __dirname,
   miskTabWebpack
 })

--- a/misk/web/tabs/config/yarn.lock
+++ b/misk/web/tabs/config/yarn.lock
@@ -66,9 +66,9 @@
     skeleton-css "^2.0.4"
     styled-components "^3.4.2"
 
-"@misk/common@^0.0.30":
-  version "0.0.30"
-  resolved "https://registry.yarnpkg.com/@misk/common/-/common-0.0.30.tgz#f47570ac6fdb09e4201048c0fe543bd4fe65f93e"
+"@misk/common@^0.0.31":
+  version "0.0.31"
+  resolved "https://registry.yarnpkg.com/@misk/common/-/common-0.0.31.tgz#feff4a350500ec30f728e74e82f546efadaeef8f"
   dependencies:
     "@blueprintjs/core" "^3.3.0"
     "@blueprintjs/icons" "^3.0.0"
@@ -91,15 +91,15 @@
     skeleton-css "^2.0.4"
     styled-components "^3.4.2"
 
-"@misk/components@^0.0.20":
-  version "0.0.20"
-  resolved "https://registry.yarnpkg.com/@misk/components/-/components-0.0.20.tgz#de2ecca4dc001309b25f8aecaa8635f910748d45"
+"@misk/components@^0.0.21":
+  version "0.0.21"
+  resolved "https://registry.yarnpkg.com/@misk/components/-/components-0.0.21.tgz#ce9f23fb1f2d0b9a3d0eaa4a8c3433ec6780e2ce"
   dependencies:
-    "@misk/common" "^0.0.30"
+    "@misk/common" "^0.0.31"
 
-"@misk/dev@^0.0.22":
-  version "0.0.22"
-  resolved "https://registry.yarnpkg.com/@misk/dev/-/dev-0.0.22.tgz#438a3bb39022d50a272a621e89742ca4fb72c1be"
+"@misk/dev@^0.0.25":
+  version "0.0.25"
+  resolved "https://registry.yarnpkg.com/@misk/dev/-/dev-0.0.25.tgz#efdf4e112d865c1f8413a58ffde5e0223b4e4739"
   dependencies:
     "@types/node" "^10.9.4"
     "@types/react" "^16.4.13"

--- a/misk/web/tabs/loader/package.json
+++ b/misk/web/tabs/loader/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "misk-tab-admin-wrapper",
+  "name": "misktab-loader",
   "version": "0.0.2",
   "main": "src/index.ts",
   "repository": "git@github.com:square/misk.git",
@@ -12,12 +12,12 @@
     "test": "jest --coverage"
   },
   "dependencies": {
-    "@misk/common": "^0.0.30",
-    "@misk/components": "^0.0.20",
+    "@misk/common": "^0.0.31",
+    "@misk/components": "^0.0.21",
     "@misk/tabs": "^0.0.1"
   },
   "devDependencies": {
-    "@misk/dev": "^0.0.22",
+    "@misk/dev": "^0.0.25",
     "@misk/tslint": "^0.0.3"
   },
   "miskTabWebpack": {

--- a/misk/web/tabs/loader/webpack.config.js
+++ b/misk/web/tabs/loader/webpack.config.js
@@ -1,7 +1,7 @@
-const { MiskWebpackConfigBase } = require("@misk/dev")
+const { miskTabWebpackBuilder } = require("@misk/dev")
 const path = require('path')
 const miskTabWebpack = require(path.join(process.cwd(), "package.json")).miskTabWebpack
-module.exports = MiskWebpackConfigBase(process.env.NODE_ENV, {
+module.exports = miskTabWebpackBuilder(process.env.NODE_ENV, {
   "dirname": __dirname,
   miskTabWebpack
 })

--- a/misk/web/tabs/loader/yarn.lock
+++ b/misk/web/tabs/loader/yarn.lock
@@ -66,9 +66,9 @@
     skeleton-css "^2.0.4"
     styled-components "^3.4.2"
 
-"@misk/common@^0.0.30":
-  version "0.0.30"
-  resolved "https://registry.yarnpkg.com/@misk/common/-/common-0.0.30.tgz#f47570ac6fdb09e4201048c0fe543bd4fe65f93e"
+"@misk/common@^0.0.31":
+  version "0.0.31"
+  resolved "https://registry.yarnpkg.com/@misk/common/-/common-0.0.31.tgz#feff4a350500ec30f728e74e82f546efadaeef8f"
   dependencies:
     "@blueprintjs/core" "^3.3.0"
     "@blueprintjs/icons" "^3.0.0"
@@ -91,15 +91,15 @@
     skeleton-css "^2.0.4"
     styled-components "^3.4.2"
 
-"@misk/components@^0.0.20":
-  version "0.0.20"
-  resolved "https://registry.yarnpkg.com/@misk/components/-/components-0.0.20.tgz#de2ecca4dc001309b25f8aecaa8635f910748d45"
+"@misk/components@^0.0.21":
+  version "0.0.21"
+  resolved "https://registry.yarnpkg.com/@misk/components/-/components-0.0.21.tgz#ce9f23fb1f2d0b9a3d0eaa4a8c3433ec6780e2ce"
   dependencies:
-    "@misk/common" "^0.0.30"
+    "@misk/common" "^0.0.31"
 
-"@misk/dev@^0.0.22":
-  version "0.0.22"
-  resolved "https://registry.yarnpkg.com/@misk/dev/-/dev-0.0.22.tgz#438a3bb39022d50a272a621e89742ca4fb72c1be"
+"@misk/dev@^0.0.25":
+  version "0.0.25"
+  resolved "https://registry.yarnpkg.com/@misk/dev/-/dev-0.0.25.tgz#efdf4e112d865c1f8413a58ffde5e0223b4e4739"
   dependencies:
     "@types/node" "^10.9.4"
     "@types/react" "^16.4.13"


### PR DESCRIPTION
Relies on #438 merging

Moves all Webpack externals code from `@misk/common` to `@misk/dev` to eliminate the circular dependency the exists between `@misk/common` and `@misk/dev`. Tabs and other Misk packages updated with the changes.

[CLOSES #437]