### PR TITLE
WebActionMetadata Endpoint

### DIFF
--- a/misk/src/main/kotlin/misk/config/ConfigAdminAction.kt
+++ b/misk/src/main/kotlin/misk/config/ConfigAdminAction.kt
@@ -19,7 +19,7 @@ class ConfigAdminAction : WebAction {
   @RequestContentType(MediaTypes.APPLICATION_JSON)
   @ResponseContentType(MediaTypes.APPLICATION_JSON)
   // TODO(adrw) create new @AdminDashboard annotation because this will fail since there is no @Access
-  // @AdminDashboard will then be able to be picked up by misq
+  // @AdminDashboard will then be able to be picked up by skim
   @Unauthenticated
   fun getAll(): Response {
     // TODO(mmihic): Need to figure out how to get the overrides.

--- a/misk/src/main/kotlin/misk/web/actions/AdminTabAction.kt
+++ b/misk/src/main/kotlin/misk/web/actions/AdminTabAction.kt
@@ -30,7 +30,6 @@ class AdminTabAction : WebAction {
   @RequestContentType(MediaTypes.APPLICATION_JSON)
   @ResponseContentType(MediaTypes.APPLICATION_JSON)
   @Unauthenticated
-  @Suppress("UNUSED_PARAMETER")
   fun getAll(): Response {
     return Response(adminTabs = registeredTabs)
   }

--- a/misk/src/main/kotlin/misk/web/actions/WebActionMetadata.kt
+++ b/misk/src/main/kotlin/misk/web/actions/WebActionMetadata.kt
@@ -1,0 +1,51 @@
+package misk.web.actions
+
+import misk.ApplicationInterceptor
+import misk.web.DispatchMechanism
+import misk.web.NetworkInterceptor
+import misk.web.PathPattern
+import misk.web.mediatype.MediaRange
+import okhttp3.MediaType
+import kotlin.reflect.KType
+
+data class WebActionMetadata(
+  val name: String,
+  val function: String,
+  val functionAnnotations: List<String>,
+  val requestMediaTypes: List<String>,
+  val responseMediaType: String?,
+  val parameterTypes: List<String>,
+  val returnType: String,
+  val pathPattern: String,
+  val applicationInterceptors: List<String>,
+  val networkInterceptors: List<String>,
+  val dispatchMechanism: DispatchMechanism
+)
+
+internal fun WebActionMetadata(
+  name: String,
+  function: Function<*>,
+  functionAnnotations: List<Annotation>,
+  acceptedMediaRanges: List<MediaRange>,
+  responseContentType: MediaType?,
+  parameterTypes: List<KType>,
+  returnType: KType,
+  pathPattern: PathPattern,
+  applicationInterceptors: List<ApplicationInterceptor>,
+  networkInterceptors: List<NetworkInterceptor>,
+  dispatchMechanism: DispatchMechanism
+) : WebActionMetadata {
+  return WebActionMetadata(
+      name = name,
+      function = function.toString(),
+      functionAnnotations = functionAnnotations.map { it.toString() },
+      requestMediaTypes = acceptedMediaRanges.map { it.toString() },
+      responseMediaType = responseContentType.toString(),
+      parameterTypes = parameterTypes.map { it.toString() },
+      returnType = returnType.toString(),
+      pathPattern = pathPattern.toString(),
+      applicationInterceptors = applicationInterceptors.map { it::class.qualifiedName.toString() },
+      networkInterceptors = networkInterceptors.map { it::class.qualifiedName.toString() },
+      dispatchMechanism = dispatchMechanism
+  )
+}

--- a/misk/src/main/kotlin/misk/web/actions/WebActionMetadataAction.kt
+++ b/misk/src/main/kotlin/misk/web/actions/WebActionMetadataAction.kt
@@ -1,0 +1,26 @@
+package misk.web.actions
+
+import misk.security.authz.Unauthenticated
+import misk.web.Get
+import misk.web.RequestContentType
+import misk.web.ResponseContentType
+import misk.web.jetty.WebActionsServlet
+import misk.web.mediatype.MediaTypes
+import javax.inject.Inject
+import javax.inject.Provider
+import javax.inject.Singleton
+
+@Singleton
+class WebActionMetadataAction : WebAction {
+  @Inject internal lateinit var servletProvider: Provider<WebActionsServlet>
+
+  @Get("/api/webactionmetadata")
+  @RequestContentType(MediaTypes.APPLICATION_JSON)
+  @ResponseContentType(MediaTypes.APPLICATION_JSON)
+  @Unauthenticated // TODO(adrw) add AccessAnnotation for AdminTab
+  fun getAll(): Response {
+    return Response(webActionMetadata = servletProvider.get().webActionsMetadata)
+  }
+
+  data class Response(val webActionMetadata: List<WebActionMetadata>)
+}

--- a/misk/src/main/kotlin/misk/web/actions/WebActionsAction.kt
+++ b/misk/src/main/kotlin/misk/web/actions/WebActionsAction.kt
@@ -1,2 +1,0 @@
-package misk.web.actions
-

--- a/misk/src/main/kotlin/misk/web/jetty/WebActionsServlet.kt
+++ b/misk/src/main/kotlin/misk/web/jetty/WebActionsServlet.kt
@@ -9,6 +9,7 @@ import misk.web.Request
 import misk.web.actions.WebAction
 import misk.web.actions.WebActionEntry
 import misk.web.actions.WebActionFactory
+import misk.web.actions.WebActionMetadata
 import misk.web.mediatype.MediaRange
 import misk.web.mediatype.MediaTypes
 import okhttp3.Headers
@@ -35,6 +36,8 @@ internal class WebActionsServlet @Inject constructor(
 ) : WebSocketServlet() {
 
   private val boundActions: MutableSet<BoundAction<out WebAction>> = mutableSetOf()
+
+  internal val webActionsMetadata: List<WebActionMetadata> by lazy { boundActions.map { it.metadata } }
 
   init {
     for (entry in webActionEntries) {

--- a/samples/urlshortener/src/main/kotlin/com/squareup/urlshortener/UrlShortenerServiceModule.kt
+++ b/samples/urlshortener/src/main/kotlin/com/squareup/urlshortener/UrlShortenerServiceModule.kt
@@ -5,9 +5,10 @@ import misk.environment.Environment
 import misk.inject.KAbstractModule
 import misk.web.AdminTabModule
 import misk.web.MiskWebModule
-import misk.web.actions.WebActionEntry
-import misk.web.proxy.WebProxyActionModule
 import misk.web.actions.AdminTabAction
+import misk.web.actions.WebActionEntry
+import misk.web.actions.WebActionMetadataAction
+import misk.web.proxy.WebProxyActionModule
 
 /** Binds all service dependencies including service-specific dependencies. */
 class UrlShortenerServiceModule : KAbstractModule() {
@@ -20,6 +21,7 @@ class UrlShortenerServiceModule : KAbstractModule() {
     // Add _admin installed tabs / forwarding mappings that don't have endpoints
     install(AdminTabModule(environment))
     multibind<WebActionEntry>().toInstance(WebActionEntry<AdminTabAction>())
+    multibind<WebActionEntry>().toInstance(WebActionEntry<WebActionMetadataAction>())
 
     install(WebProxyActionModule())
     multibind<WebActionEntry>().toInstance(WebActionEntry<CreateShortUrlWebAction>())


### PR DESCRIPTION
* New endpoint that returns metadata for bound webactions:

```Kotlin
  name: String,
  function: Function<*>,
  functionAnnotations: List<Annotation>,
  acceptedMediaRanges: List<MediaRange>,
  responseContentType: MediaType?,
  parameterTypes: List<KType>,
  returnType: KType,
  pathPattern: PathPattern,
  applicationInterceptors: List<ApplicationInterceptor>,
  networkInterceptors: List<NetworkInterceptor>,
  dispatchMechanism: DispatchMechanism
```
* Follow up WebActionMetadata Tab coming soon...