### PR TITLE
Support for testing Services with external deps

### DIFF
--- a/misk-testing/src/main/kotlin/misk/service/ServiceTestingModule.kt
+++ b/misk-testing/src/main/kotlin/misk/service/ServiceTestingModule.kt
@@ -1,0 +1,74 @@
+package misk.service
+
+import com.google.common.util.concurrent.Service
+import com.google.inject.Key
+import com.google.inject.Provider
+import misk.DependentService
+import misk.inject.KAbstractModule
+import javax.inject.Singleton
+import kotlin.reflect.KClass
+
+/**
+ * [ServiceTestingModule] provides additional help for testing service, notably allowing existing
+ * services to be bound with additional dependencies specifically required for testing. Typically
+ * used when a [Service] requires an external service (e.g. zookeeper, etcd, vitess, etc)
+ * that is being spun up within the test itself
+ */
+class ServiceTestingModule<T : Service> internal constructor(
+  private val wrappedServiceType: KClass<T>,
+  private val extraDependencies: Set<Key<*>>
+) : KAbstractModule() {
+
+  override fun configure() {
+    // Register a wrapper around the service with the service manager. The wrapper delegates
+    // to the underlying service for all calls except [DependentService.consumedKeys], which
+    // it overrides to extend the consumed service list with the extra dependencies
+    multibind<Service>().toProvider(ServiceWithTestDependenciesProvider(
+        getProvider(wrappedServiceType.java),
+        extraDependencies
+    ))
+
+    // Bind the wrapped service directly so that application code can inject it
+    bind(wrappedServiceType.java)
+  }
+
+  companion object {
+    /** @return A [Module] binding the service with extra dependencies */
+    fun <T : Service> withExtraDependencies(
+      wrappedServiceType: KClass<T>,
+      vararg extraDependencies: Key<*>
+    ): com.google.inject.Module =
+        ServiceTestingModule(wrappedServiceType, extraDependencies.toSet())
+
+    /** @return A [Module] binding the given service with extra dependencies */
+    inline fun <reified T : Service> withExtraDependencies(
+      vararg extraDependencies: Key<*>
+    ): com.google.inject.Module = withExtraDependencies(T::class, *extraDependencies)
+  }
+
+  /**
+   * The [ServiceWithTestDependencies] wraps the given service and adds additional test specific
+   * dependencies
+   */
+  @Singleton
+  private class ServiceWithTestDependencies internal constructor(
+    private val delegate: Service,
+    extraDependencies: Set<Key<*>>
+  ) : Service by delegate, DependentService {
+
+    private val delegateDependentService: DependentService? = delegate as? DependentService
+    private val baseConsumedKeys: Set<Key<*>> = delegateDependentService?.consumedKeys ?: setOf()
+
+    override val consumedKeys: Set<Key<*>> = baseConsumedKeys + extraDependencies
+    override val producedKeys: Set<Key<*>> = delegateDependentService?.producedKeys ?: setOf()
+  }
+
+  private class ServiceWithTestDependenciesProvider(
+    private val wrappedServiceProvider: Provider<out Service>,
+    private val extraDependencies: Set<Key<*>>
+  ) : Provider<ServiceWithTestDependencies> {
+    override fun get(): ServiceWithTestDependencies {
+      return ServiceWithTestDependencies(wrappedServiceProvider.get(), extraDependencies)
+    }
+  }
+}

--- a/misk-testing/src/test/kotlin/misk/service/ServiceTestingModuleTest.kt
+++ b/misk-testing/src/test/kotlin/misk/service/ServiceTestingModuleTest.kt
@@ -1,0 +1,108 @@
+package misk.service
+
+import com.google.common.util.concurrent.AbstractIdleService
+import com.google.common.util.concurrent.Service
+import com.google.common.util.concurrent.ServiceManager
+import com.google.inject.Guice
+import com.google.inject.Key
+import misk.DependentService
+import misk.MiskServiceModule
+import misk.inject.KAbstractModule
+import misk.inject.getInstance
+import misk.inject.keyOf
+import org.junit.jupiter.api.Test
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
+import javax.inject.Inject
+import javax.inject.Singleton
+
+internal class ServiceTestingModuleTest {
+  @Test fun serviceTestModuleAddsTestSpecificDependency() {
+    val injector = Guice.createInjector(object : KAbstractModule() {
+      override fun configure() {
+        install(MiskServiceModule())
+        multibind<Service>().to<LowestLevelService>()
+        install(ServiceTestingModule.withExtraDependencies<AppService>(
+            keyOf<ExternalServiceSpinupService>())
+        )
+        multibind<Service>().to<ExternalServiceSpinupService>()
+        bind<FakeExternalClient>().to<ExternalServiceSpinupService>()
+      }
+    })
+
+    val serviceManager = injector.getInstance<ServiceManager>()
+    serviceManager.startAsync()
+    serviceManager.awaitHealthy(2, TimeUnit.SECONDS)
+    serviceManager.stopAsync()
+    serviceManager.awaitStopped(2, TimeUnit.SECONDS)
+  }
+
+  /** A low level in process dependency that we always need */
+  @Singleton
+  class LowestLevelService : AbstractIdleService(), DependentService {
+    override val consumedKeys: Set<Key<*>> = setOf()
+    override val producedKeys: Set<Key<*>> = setOf(keyOf<LowestLevelService>())
+
+    val started = AtomicBoolean(false)
+
+    override fun startUp() {
+      started.set(true)
+    }
+
+    override fun shutDown() {}
+  }
+
+  /**
+   * Models an external client used by the app. Represents a dependency that is satisfied
+   * externally outside of tests, but that requires additional infrastructure to spin up during
+   * testing
+   */
+  interface FakeExternalClient {
+    fun confirmRunning()
+  }
+
+  /** The application service, with a dependency on another app service and an external service */
+  @Singleton
+  class AppService @Inject internal constructor(
+    private val lowestLevelService: LowestLevelService,
+    private val client: FakeExternalClient
+  ) : AbstractIdleService(), DependentService {
+
+    override val consumedKeys: Set<Key<*>> = setOf(keyOf<LowestLevelService>())
+    override val producedKeys: Set<Key<*>> = setOf()
+
+    override fun startUp() {
+      // Confirm the lowest level internal service was spun up first
+      check(lowestLevelService.started.get()) { "LowestLevelService was not started" }
+
+      // Confirm we can talk to the external service (in testing requires that we spin up
+      // another service before this one)
+      client.confirmRunning()
+    }
+
+    override fun shutDown() {}
+  }
+
+  /**
+   * Models a dependency normally satisfied through a client to an external, but for testing
+   * requires spinning up something in process
+   */
+  @Singleton
+  class ExternalServiceSpinupService : AbstractIdleService(), DependentService,
+      FakeExternalClient {
+    override val consumedKeys: Set<Key<*>> = setOf()
+    override val producedKeys: Set<Key<*>> = setOf(keyOf<ExternalServiceSpinupService>())
+
+    private val started = AtomicBoolean(false)
+
+    override fun confirmRunning() {
+      check(started.get()) { "ExternalService was not started" }
+    }
+
+    override fun startUp() {
+      started.set(true)
+    }
+
+    override fun shutDown() {}
+  }
+}


### PR DESCRIPTION
Occasionally a Service requires access to an external resource during
startup. When testing those Services, we often use another Service to
startup that external resource within a test (cf
StartVitessService and StartEtcdService). For the application Service to
work properly, the test service that starts the external resource needs
to run first to make the external resource available. The best way to do
this is to have the application Service specify the test Service as a
dependency via DependentService.consumedKeys. ServiceTestingModule
provides a mechanism for doing this - you install a ServiceTestingModule
withExtraDependencies to specify your test specific dependencies, and
the module binds a Service that combines the application Service
dependencies with the extra dependencies to ensure that test specific
Services start before the application Service.