### PR TITLE
Remove coroutines experimental flag from Gradle

### DIFF
--- a/misk/build.gradle
+++ b/misk/build.gradle
@@ -1,11 +1,6 @@
 import org.junit.platform.console.options.Details
 
 apply plugin: 'kotlin'
-kotlin {
-  experimental {
-    coroutines 'enable'
-  }
-}
 apply plugin: 'org.junit.platform.gradle.plugin'
 apply plugin: "com.vanniktech.maven.publish"
 


### PR DESCRIPTION
- No longer needed to run `WebProxyActionTest`
- Causing errors in Groovy syntax checks in IntelliJ