### PR TITLE
Use Guice bindings to check service singletons

### DIFF
--- a/misk-hibernate-testing/src/main/kotlin/misk/hibernate/HibernateTestingModule.kt
+++ b/misk-hibernate-testing/src/main/kotlin/misk/hibernate/HibernateTestingModule.kt
@@ -42,7 +42,7 @@ class HibernateTestingModule(
 
     bind(startVitessServiceKey).toProvider(Provider<StartVitessService> {
       StartVitessService(config = configProvider.get())
-    })
+    }).asSingleton()
 
     val moshiProvider = getProvider(Moshi::class.java)
     val okHttpClientProvider = getProvider(OkHttpClient::class.java)
@@ -68,6 +68,6 @@ class HibernateTestingModule(
           vitessScatterDetector = crossShardQueryDetectorProvider.get(),
           startUpStatements = startUpStatements,
           shutDownStatements = shutDownStatements)
-    })
+    }).asSingleton()
   }
 }

--- a/misk-hibernate-testing/src/main/kotlin/misk/jdbc/StartVitessService.kt
+++ b/misk-hibernate-testing/src/main/kotlin/misk/jdbc/StartVitessService.kt
@@ -127,7 +127,6 @@ class LogContainerResultCallback : ResultCallbackTemplate<LogContainerResultCall
   }
 }
 
-@Singleton
 internal class StartVitessService(val config: DataSourceConfig) : AbstractIdleService() {
   override fun startUp() {
     if (config.type != DataSourceType.VITESS) {

--- a/misk-hibernate-testing/src/main/kotlin/misk/jdbc/TruncateTablesService.kt
+++ b/misk-hibernate-testing/src/main/kotlin/misk/jdbc/TruncateTablesService.kt
@@ -10,9 +10,8 @@ import misk.hibernate.shards
 import misk.hibernate.transaction
 import misk.inject.toKey
 import misk.logging.getLogger
-import java.util.*
+import java.util.Locale
 import javax.inject.Provider
-import javax.inject.Singleton
 import kotlin.reflect.KClass
 
 private val logger = getLogger<TruncateTablesService>()
@@ -26,7 +25,6 @@ private val logger = getLogger<TruncateTablesService>()
  * We truncate _before_ tests because that way we always have a clean slate, even if a preceding
  * test wasn't able to clean up after itself.
  */
-@Singleton
 internal class TruncateTablesService(
   private val qualifier: KClass<out Annotation>,
   private val config: DataSourceConfig,

--- a/misk-testing/src/main/kotlin/misk/service/ServiceTestingModule.kt
+++ b/misk-testing/src/main/kotlin/misk/service/ServiceTestingModule.kt
@@ -5,6 +5,7 @@ import com.google.inject.Key
 import com.google.inject.Provider
 import misk.DependentService
 import misk.inject.KAbstractModule
+import misk.inject.asSingleton
 import javax.inject.Singleton
 import kotlin.reflect.KClass
 
@@ -26,7 +27,7 @@ class ServiceTestingModule<T : Service> internal constructor(
     multibind<Service>().toProvider(ServiceWithTestDependenciesProvider(
         getProvider(wrappedServiceType.java),
         extraDependencies
-    ))
+    )).asSingleton()
 
     // Bind the wrapped service directly so that application code can inject it
     bind(wrappedServiceType.java)
@@ -50,7 +51,6 @@ class ServiceTestingModule<T : Service> internal constructor(
    * The [ServiceWithTestDependencies] wraps the given service and adds additional test specific
    * dependencies
    */
-  @Singleton
   private class ServiceWithTestDependencies internal constructor(
     private val delegate: Service,
     extraDependencies: Set<Key<*>>

--- a/misk/src/test/kotlin/misk/MiskServiceModuleTest.kt
+++ b/misk/src/test/kotlin/misk/MiskServiceModuleTest.kt
@@ -4,6 +4,9 @@ import com.google.common.util.concurrent.AbstractIdleService
 import com.google.common.util.concurrent.Service
 import com.google.common.util.concurrent.ServiceManager
 import com.google.inject.Guice
+import com.google.inject.Provides
+import com.google.inject.Scopes
+import com.google.inject.Singleton
 import misk.inject.KAbstractModule
 import misk.inject.getInstance
 import org.assertj.core.api.Assertions.assertThat
@@ -33,17 +36,62 @@ internal class MiskServiceModuleTest {
     override fun shutDown() {}
   }
 
+  class ExplicitEagerSingletonService : AbstractIdleService() {
+    override fun startUp() {}
+    override fun shutDown() {}
+  }
+
+  class SingletonScopeService : AbstractIdleService() {
+    override fun startUp() {}
+    override fun shutDown() {}
+  }
+
+  class SingletonAnnotationService : AbstractIdleService() {
+    override fun startUp() {}
+    override fun shutDown() {}
+  }
+
+  class GoogleSingletonAnnotationService : AbstractIdleService() {
+    override fun startUp() {}
+    override fun shutDown() {}
+  }
+
+  class InstanceService : AbstractIdleService() {
+    override fun startUp() {}
+    override fun shutDown() {}
+  }
+
+  class ProvidesMethodService : AbstractIdleService() {
+    override fun startUp() {}
+    override fun shutDown() {}
+  }
+
   @Test fun detectsNonSingletonServices() {
     assertThat(assertFailsWith<com.google.inject.ProvisionException> {
       val injector = Guice.createInjector(
           MiskServiceModule(),
-          object: KAbstractModule() {
+          object : KAbstractModule() {
             override fun configure() {
+              // Should be recognized as singletons
               multibind<Service>().to<SingletonService1>()
               multibind<Service>().to<SingletonService2>()
+              multibind<Service>().to<ProvidesMethodService>()
+              multibind<Service>().toInstance(InstanceService())
+              multibind<Service>().to<ExplicitEagerSingletonService>().asEagerSingleton()
+              multibind<Service>().to<SingletonScopeService>()
+                  .`in`(Scopes.SINGLETON)
+              multibind<Service>().to<SingletonAnnotationService>()
+                  .`in`(com.google.inject.Singleton::class.java)
+              multibind<Service>().to<GoogleSingletonAnnotationService>()
+                  .`in`(com.google.inject.Singleton::class.java)
+
+              // Should be recognized as non-singletons
               multibind<Service>().to<NonSingletonService2>()
               multibind<Service>().to<NonSingletonService1>()
             }
+
+            @Provides @Singleton
+            fun providesSingletonService(): ProvidesMethodService = ProvidesMethodService()
           }
       )
 


### PR DESCRIPTION
Previously we were looking for explicitly @Singleton annotations on
bound Service classes. This misses bindings for classes that are not
annotated as @Singleton, but are nevertheless singletons as a result of
explicitly specifying a scope during binding or being bound as an
instance.