### PR TITLE
Test support for code using RepeatedTaskQueue

### DIFF
--- a/misk/src/main/kotlin/misk/concurrent/ExplicitReleaseBlockingQueue.kt
+++ b/misk/src/main/kotlin/misk/concurrent/ExplicitReleaseBlockingQueue.kt
@@ -18,11 +18,23 @@ class ExplicitReleaseBlockingQueue<T> internal constructor(
 ) : BlockingQueue<T> {
   constructor() : this(LinkedBlockingQueue<T>(), LinkedBlockingQueue<T>())
 
-  fun release(n: Int) {
+  /**
+   * releases up to n items from the pending queue, making them visible to [take], [poll], [peek],
+   * etc. This method does not "extend credit"; if n > number of pending items on the queue, every
+   * currently pending item is made visible, but any items added in the future continue to go
+   * onto the pending queue
+   *
+   * @return the number of items actually releases
+   */
+  fun release(n: Int) : Int {
+    var numReleased = 0
     for (i in (0 until n)) {
-      val e = pending.poll() ?: return
+      val e = pending.poll() ?: return numReleased
       visible.add(e)
+      numReleased ++
     }
+
+    return numReleased
   }
 
   override fun contains(element: T) = visible.contains(element)

--- a/misk/src/main/kotlin/misk/concurrent/ExplicitReleaseDelayQueue.kt
+++ b/misk/src/main/kotlin/misk/concurrent/ExplicitReleaseDelayQueue.kt
@@ -16,5 +16,5 @@ class ExplicitReleaseDelayQueue<T : Delayed> private constructor(
   )
 
   fun release(n: Int) = delegate.release(n)
-  fun peekPending() : T? = delegate.peekPending()
+  fun peekPending(): T? = delegate.peekPending()
 }

--- a/misk/src/main/kotlin/misk/tasks/DelayedTask.kt
+++ b/misk/src/main/kotlin/misk/tasks/DelayedTask.kt
@@ -6,10 +6,11 @@ import java.time.Instant
 import java.util.concurrent.Delayed
 import java.util.concurrent.TimeUnit
 
-internal class DelayedTask(
+/** A [DelayedTask] is a task that runs in  the future */
+class DelayedTask(
   internal val clock: Clock,
   internal val executionTime: Instant,
-  val task: () -> Result
+  internal val task: () -> Result
 ) : Delayed {
   override fun compareTo(other: Delayed): Int {
     val timeDiff = getDelay(TimeUnit.MILLISECONDS) - other.getDelay(

--- a/misk/src/test/kotlin/misk/tasks/RepeatedTaskQueueTest.kt
+++ b/misk/src/test/kotlin/misk/tasks/RepeatedTaskQueueTest.kt
@@ -1,6 +1,5 @@
 package misk.tasks
 
-import com.google.common.util.concurrent.MoreExecutors
 import com.google.common.util.concurrent.Service
 import com.google.inject.Provides
 import com.google.inject.util.Modules
@@ -19,7 +18,6 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import java.time.Duration
 import java.util.concurrent.CountDownLatch
-import java.util.concurrent.Executors
 import java.util.concurrent.PriorityBlockingQueue
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicReference
@@ -467,16 +465,8 @@ internal class RepeatedTaskQueueTest {
     }
 
     @Provides @Singleton
-    fun repeatedTaskQueue(
-      clock: FakeClock,
-      queue: ExplicitReleaseDelayQueue<DelayedTask>
-    ) = RepeatedTaskQueue(
-        "my-task-queue",
-        clock,
-        MoreExecutors.newDirectExecutorService(),
-        Executors.newSingleThreadExecutor(),
-        queue
-    )
+    fun repeatedTaskQueue(clock: FakeClock, queue: ExplicitReleaseDelayQueue<DelayedTask>) =
+        RepeatedTaskQueue("my-task-queue", clock, queue)
   }
 
   private fun waitForNextPendingTask(): DelayedTask =


### PR DESCRIPTION
Allows upstream module code to create RepeatedTaskQueues that are backed
by an ExplicitReleaseDelayQueue, which in turn allows writing tests that
deterministically release tasks for execution.