### PR TITLE
Fix Kotlin Deprecation Warnings in misk-zipkin

### DIFF
--- a/misk/src/main/kotlin/misk/security/ssl/PemComboFile.kt
+++ b/misk/src/main/kotlin/misk/security/ssl/PemComboFile.kt
@@ -1,5 +1,6 @@
 package misk.security.ssl
 
+import com.google.common.base.CharMatcher
 import okio.Buffer
 import okio.BufferedSource
 import okio.ByteString
@@ -63,7 +64,7 @@ data class PemComboFile(
             privateKeys += decodeBase64Until(lines,
                 Regex("-+END PRIVATE KEY-+"))
           }
-          line.isBlank() -> {
+          CharMatcher.whitespace().matchesAllOf(line) -> {
             // This is ok, just keep going
           }
           else -> throw IOException("unexpected line: $line")

--- a/misk/src/main/kotlin/misk/tokens/FakeTokenGenerator.kt
+++ b/misk/src/main/kotlin/misk/tokens/FakeTokenGenerator.kt
@@ -19,7 +19,7 @@ internal class FakeTokenGenerator : TokenGenerator {
 
     val unpaddedLength = effectiveLabel.length + suffix.length
     val rawResult = when {
-      unpaddedLength < length -> effectiveLabel + "0".repeat(length - unpaddedLength) + suffix
+      unpaddedLength < length -> effectiveLabel + suffix.padStart(length - effectiveLabel.length, '0')
       suffix.length <= length -> effectiveLabel.substring(0, length - suffix.length) + suffix
       else -> suffix.substring(suffix.length - length) // Possible collision.
     }

--- a/misk/src/main/kotlin/misk/web/extractors/PathPatternParameterExtractor.kt
+++ b/misk/src/main/kotlin/misk/web/extractors/PathPatternParameterExtractor.kt
@@ -1,5 +1,6 @@
 package misk.web.extractors
 
+import com.google.common.base.CharMatcher
 import misk.web.PathParam
 import misk.web.PathPattern
 import misk.web.Request
@@ -22,7 +23,7 @@ object PathPatternParameterExtractorFactory : ParameterExtractor.Factory {
   ): ParameterExtractor? {
     val pathParamAnnotation = parameter.findAnnotation<PathParam>() ?: return null
     val parameterName =
-        if (pathParamAnnotation.value.isBlank()) parameter.name
+        if (CharMatcher.whitespace().matchesAllOf(pathParamAnnotation.value)) parameter.name
         else pathParamAnnotation.value
 
     val patternIndex = pathPattern.variableNames.indexOf(parameterName)

--- a/misk/src/main/kotlin/misk/web/extractors/QueryStringParameterExtractor.kt
+++ b/misk/src/main/kotlin/misk/web/extractors/QueryStringParameterExtractor.kt
@@ -1,5 +1,6 @@
 package misk.web.extractors
 
+import com.google.common.base.CharMatcher
 import misk.web.PathPattern
 import misk.web.QueryParam
 import misk.web.Request
@@ -23,7 +24,7 @@ object QueryStringParameterExtractorFactory : ParameterExtractor.Factory {
   ): ParameterExtractor? {
     val queryParamAnnotation = parameter.findAnnotation<QueryParam>() ?: return null
     val parameterName =
-        if (queryParamAnnotation.value.isBlank()) parameter.name!!
+        if (CharMatcher.whitespace().matchesAllOf(queryParamAnnotation.value)) parameter.name!!
         else queryParamAnnotation.value
     val queryParamProcessor = QueryStringParameterProcessor(parameter)
 


### PR DESCRIPTION
```
e: warnings found and -Werror specified
w: /Users/aparadi/Development/cash/misk/misk/src/main/kotlin/misk/security/ssl/PemComboFile.kt: (66, 16): 'isBlank(): Boolean' is deprecated. This member is not fully supported by Kotlin compiler, so it may be absent or have different signature in next major version
w: /Users/aparadi/Development/cash/misk/misk/src/main/kotlin/misk/tokens/FakeTokenGenerator.kt: (22, 55): 'repeat(Int): String!' is deprecated. This member is not fully supported by Kotlin compiler, so it may be absent or have different signature in next major version
w: /Users/aparadi/Development/cash/misk/misk/src/main/kotlin/misk/web/extractors/PathPatternParameterExtractor.kt: (25, 39): 'isBlank(): Boolean' is deprecated. This member is not fully supported by Kotlin compiler, so it may be absent or have different signature in next major version
w: /Users/aparadi/Development/cash/misk/misk/src/main/kotlin/misk/web/extractors/QueryStringParameterExtractor.kt: (26, 40): 'isBlank(): Boolean' is deprecated. This member is not fully supported by Kotlin compiler, so it may be absent or have different signature in next major version

```