### PR TITLE
Track jetty connection and thread pool metrics

### DIFF
--- a/misk/src/main/kotlin/misk/metrics/Histogram.kt
+++ b/misk/src/main/kotlin/misk/metrics/Histogram.kt
@@ -8,12 +8,10 @@ package misk.metrics
  *
  * A sample implementation can be found in PrometheusHistogram
  */
-
 interface Histogram {
+  /** records a new set of labels and accompanying duration */
+  fun record(duration: Double, vararg labelValues: String)
 
-    /** records a new set of labels and accompanying duration */
-    fun record(duration: Double, vararg labelValues: String)
-
-    /** returns the number of buckets */
-    fun count(vararg labelValues: String): Int
+  /** returns the number of buckets */
+  fun count(vararg labelValues: String): Int
 }

--- a/misk/src/main/kotlin/misk/metrics/HistogramRegistry.kt
+++ b/misk/src/main/kotlin/misk/metrics/HistogramRegistry.kt
@@ -9,12 +9,11 @@ package misk.metrics
  */
 
 interface HistogramRegistry {
-
-    /** Creates a new histogram */
-     fun newHistogram(
-             name: String,
-             help: String,
-             labelNames: List<String> = listOf(),
-             buckets: DoubleArray?
-     ): Histogram
+  /** Creates a new histogram */
+  fun newHistogram(
+    name: String,
+    help: String,
+    labelNames: List<String> = listOf(),
+    buckets: DoubleArray?
+  ): Histogram
 }

--- a/misk/src/main/kotlin/misk/prometheus/PrometheusHistogram.kt
+++ b/misk/src/main/kotlin/misk/prometheus/PrometheusHistogram.kt
@@ -3,14 +3,14 @@ package misk.prometheus
 import misk.metrics.Histogram
 
 class PrometheusHistogram constructor(
-    val histogram: io.prometheus.client.Histogram
-): Histogram {
+  val histogram: io.prometheus.client.Histogram
+) : Histogram {
 
-    override fun record(duration: Double, vararg labelValues: String) {
-        histogram.labels(*labelValues).observe(duration)
-    }
+  override fun record(duration: Double, vararg labelValues: String) {
+    histogram.labels(*labelValues).observe(duration)
+  }
 
-    override fun count(vararg labelValues: String): Int {
-        return histogram.labels(*labelValues).get().buckets.max()?.toInt() ?: 0
-    }
+  override fun count(vararg labelValues: String): Int {
+    return histogram.labels(*labelValues).get().buckets.max()?.toInt() ?: 0
+  }
 }

--- a/misk/src/main/kotlin/misk/prometheus/PrometheusHistogramRegistry.kt
+++ b/misk/src/main/kotlin/misk/prometheus/PrometheusHistogramRegistry.kt
@@ -4,17 +4,18 @@ import io.prometheus.client.CollectorRegistry
 import misk.metrics.HistogramRegistry
 import javax.inject.Inject
 
-class PrometheusHistogramRegistry: HistogramRegistry {
-        @Inject lateinit var collectorRegistry: CollectorRegistry
+class PrometheusHistogramRegistry : HistogramRegistry {
+  @Inject lateinit var collectorRegistry: CollectorRegistry
 
-        override fun newHistogram(
-                name: String,
-                help: String,
-                labelNames: List<String>,
-                buckets: DoubleArray?
-        ): PrometheusHistogram {
-            val builder =  io.prometheus.client.Histogram.build(name, help).labelNames(*labelNames.toTypedArray())
-            if (buckets != null) builder.buckets(*buckets)
-            return PrometheusHistogram(builder.register(collectorRegistry))
-        }
+  override fun newHistogram(
+    name: String,
+    help: String,
+    labelNames: List<String>,
+    buckets: DoubleArray?
+  ): PrometheusHistogram {
+    val builder =
+        io.prometheus.client.Histogram.build(name, help).labelNames(*labelNames.toTypedArray())
+    if (buckets != null) builder.buckets(*buckets)
+    return PrometheusHistogram(builder.register(collectorRegistry))
+  }
 }

--- a/misk/src/main/kotlin/misk/prometheus/PrometheusHistogramRegistryModule.kt
+++ b/misk/src/main/kotlin/misk/prometheus/PrometheusHistogramRegistryModule.kt
@@ -1,11 +1,9 @@
 package misk.prometheus
 
 import misk.inject.KAbstractModule
-import misk.metrics.Histogram
 import misk.metrics.HistogramRegistry
 
 class PrometheusHistogramRegistryModule : KAbstractModule() {
-
   override fun configure() {
     bind<HistogramRegistry>().to<PrometheusHistogramRegistry>()
   }

--- a/misk/src/main/kotlin/misk/web/jetty/ConnectionListener.kt
+++ b/misk/src/main/kotlin/misk/web/jetty/ConnectionListener.kt
@@ -1,0 +1,97 @@
+package misk.web.jetty
+
+import org.eclipse.jetty.io.Connection
+import org.eclipse.jetty.util.component.AbstractLifeCycle
+import java.util.Collections
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicLong
+
+internal class ConnectionListener(
+  protocol: String,
+  port: Int,
+  private val metrics: ConnectionMetrics
+) : AbstractLifeCycle(), Connection.Listener {
+
+  private val totalBytesReceived = AtomicLong()
+  private val totalBytesSent = AtomicLong()
+  private val totalMessagesReceived = AtomicLong()
+  private val totalMessagesSent = AtomicLong()
+
+  private val connections = Collections.newSetFromMap(ConcurrentHashMap<ConnectionKey, Boolean>())
+  private val labels = ConnectionMetrics.forPort(protocol, port)
+
+  override fun onOpened(connection: Connection) {
+    connections.add(ConnectionKey(connection))
+    metrics.activeConnections.labels(*labels).inc()
+    metrics.acceptedConnections.labels(*labels).inc()
+  }
+
+  override fun onClosed(connection: Connection) {
+    // Force a refresh so that we gather the final stats on the connection
+    refreshMetrics()
+
+    if (connections.remove(ConnectionKey(connection))) {
+      metrics.activeConnections.labels(*labels).dec()
+    }
+  }
+
+  fun refreshMetrics() {
+    var bytesReceivedSnapshot = 0L
+    var bytesSentSnapshot = 0L
+    var messagesReceivedSnapshot = 0L
+    var messagesSentSnapshot = 0L
+
+    connections.forEach {
+      val bytesIn = it.connection.bytesIn
+      if (bytesIn > 0) bytesReceivedSnapshot += bytesIn
+
+      val bytesOut = it.connection.bytesOut
+      if (bytesOut > 0) bytesSentSnapshot += bytesOut
+
+      val messagesIn = it.connection.messagesIn
+      if (messagesIn > 0) messagesReceivedSnapshot += messagesIn
+
+      val messagesOut = it.connection.messagesOut
+      if (messagesOut > 0) messagesSentSnapshot += messagesOut
+
+      val connectionDuration = System.currentTimeMillis() - it.connection.createdTimeStamp
+      metrics.connectionDurations.labels(*labels).observe(connectionDuration.toDouble())
+    }
+
+    // Compute any diffs with the last time we took a snapshot, and apply those diffs
+    // to the counter
+    val bytesReceivedDiff =
+        bytesReceivedSnapshot - totalBytesReceived.getAndSet(bytesReceivedSnapshot)
+    val bytesSentDiff =
+        bytesSentSnapshot - totalBytesSent.getAndSet(bytesSentSnapshot)
+    val messagesReceivedDiff =
+        messagesReceivedSnapshot - totalMessagesReceived.getAndSet(messagesReceivedSnapshot)
+    val messagesSentDiff =
+        messagesSentSnapshot - totalMessagesSent.getAndSet(messagesSentSnapshot)
+
+    if (bytesSentDiff > 0) {
+      metrics.bytesSent.labels(*labels).inc(bytesSentDiff.toDouble())
+    }
+
+    if (bytesReceivedDiff > 0) {
+      metrics.bytesReceived.labels(*labels).inc(bytesReceivedDiff.toDouble())
+    }
+
+    if (messagesSentDiff > 0) {
+      metrics.messagesSent.labels(*labels).inc(messagesSentDiff.toDouble())
+    }
+
+    if (messagesReceivedSnapshot > 0) {
+      metrics.messagesReceived.labels(*labels).inc(messagesReceivedDiff.toDouble())
+    }
+  }
+
+  private class ConnectionKey(val connection: Connection) {
+    override fun equals(other: Any?): Boolean {
+      return (other as? ConnectionKey)?.connection === connection
+    }
+
+    override fun hashCode() = System.identityHashCode(connection)
+  }
+
+}

--- a/misk/src/main/kotlin/misk/web/jetty/ConnectionMetrics.kt
+++ b/misk/src/main/kotlin/misk/web/jetty/ConnectionMetrics.kt
@@ -1,0 +1,53 @@
+package misk.web.jetty
+
+import com.google.common.annotations.VisibleForTesting
+import misk.metrics.Metrics
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+internal class ConnectionMetrics @Inject internal constructor(metrics: Metrics) {
+  val acceptedConnections = metrics.counter(
+      "jetty_connections_total",
+      "total number of connections accepted by jetty",
+      labels
+  )
+  val connectionDurations = metrics.summary(
+      "jetty_connection_duration_ms",
+      "average duration a incoming jetty connection is held open (in ms)",
+      labels
+  )
+  val activeConnections = metrics.gauge(
+      "jetty_connections_active",
+      "number of currently active connections in jetty",
+      labels
+  )
+  val bytesReceived = metrics.counter(
+      "jetty_bytes_recvd_total",
+      "total count of bytes received by jetty",
+      labels
+  )
+  val bytesSent = metrics.counter(
+      "jetty_bytes_sent_total",
+      "total count of bytes sent through jetty",
+      labels
+  )
+  val messagesReceived = metrics.counter(
+      "jetty_msgs_recvd_total",
+      "total count of HTTP messages received by jetty",
+      labels
+  )
+  val messagesSent = metrics.counter(
+      "jetty_msgs_sent_total",
+      "total count of HTTP messages sent by jetty",
+      labels
+  )
+
+  companion object {
+    @VisibleForTesting internal val labels = listOf("protocol", "port")
+
+    fun forPort(protocol: String, port: Int): Array<String> {
+      return arrayOf(protocol, port.toString())
+    }
+  }
+}

--- a/misk/src/main/kotlin/misk/web/jetty/JettyConnectionMetricsCollector.kt
+++ b/misk/src/main/kotlin/misk/web/jetty/JettyConnectionMetricsCollector.kt
@@ -1,0 +1,35 @@
+package misk.web.jetty
+
+import com.google.common.util.concurrent.AbstractScheduledService
+import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.TimeUnit
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+internal class JettyConnectionMetricsCollector @Inject internal constructor(
+  private val metrics: ConnectionMetrics
+) : AbstractScheduledService() {
+  private val listeners = CopyOnWriteArrayList<ConnectionListener>()
+
+  fun newConnectionListener(protocol: String, port: Int): ConnectionListener {
+    val listener = ConnectionListener(protocol, port, metrics)
+    listeners.add(listener)
+    return listener
+  }
+
+  fun refreshMetrics() {
+    listeners.forEach { it.refreshMetrics() }
+  }
+
+  override fun scheduler(): Scheduler =
+      Scheduler.newFixedRateSchedule(REFRESH_RATE_MS, REFRESH_RATE_MS, TimeUnit.MILLISECONDS)
+
+  override fun runOneIteration() {
+    refreshMetrics()
+  }
+
+  companion object {
+    const val REFRESH_RATE_MS = 500L
+  }
+}

--- a/misk/src/main/kotlin/misk/web/jetty/JettyThreadPoolMetricsCollector.kt
+++ b/misk/src/main/kotlin/misk/web/jetty/JettyThreadPoolMetricsCollector.kt
@@ -1,0 +1,22 @@
+package misk.web.jetty
+
+import com.google.common.util.concurrent.AbstractScheduledService
+import java.util.concurrent.TimeUnit
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+internal class JettyThreadPoolMetricsCollector @Inject internal constructor(
+  private val metrics: ThreadPoolMetrics
+) : AbstractScheduledService() {
+  override fun scheduler(): Scheduler =
+      Scheduler.newFixedDelaySchedule(REFRESH_RATE_MS, REFRESH_RATE_MS, TimeUnit.MILLISECONDS)
+
+  override fun runOneIteration() {
+    metrics.refresh()
+  }
+
+  companion object {
+    const val REFRESH_RATE_MS = 500L
+  }
+}

--- a/misk/src/main/kotlin/misk/web/jetty/ThreadPoolMetrics.kt
+++ b/misk/src/main/kotlin/misk/web/jetty/ThreadPoolMetrics.kt
@@ -1,0 +1,49 @@
+package misk.web.jetty
+
+import misk.metrics.Metrics
+import org.eclipse.jetty.util.thread.QueuedThreadPool
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+internal class ThreadPoolMetrics @Inject internal constructor(
+  metrics: Metrics,
+  private val threadPool: QueuedThreadPool
+) {
+  val utilization = metrics.gauge(
+      "jetty_thread_pool_utilization",
+      "current utilization of the jetty thread pool compared to the current pool size"
+  )
+
+  val utilizationMax = metrics.gauge(
+      "jetty_thread_pool_utilization_max",
+      "current utilization of the jetty thread pool compared to the max pool size"
+  )
+
+  val busyThreads = metrics.gauge(
+      "jetty_thread_pool_busy",
+      "current number of busy threads"
+  )
+
+  val size = metrics.gauge(
+      "jetty_thread_pool_size",
+      "current number of threads in the jetty thread pool"
+  )
+
+  val queuedJobs = metrics.gauge(
+      "jetty_thread_pool_queued_jobs",
+      "number of jobs queued in the jetty thread pool"
+  )
+
+  fun refresh() {
+    utilization.set(ratio(threadPool.busyThreads.toDouble(), threadPool.threads.toDouble()))
+    utilizationMax.set(ratio(threadPool.busyThreads.toDouble(), threadPool.maxThreads.toDouble()))
+    size.set(threadPool.threads.toDouble())
+    busyThreads.set(threadPool.busyThreads.toDouble())
+    queuedJobs.set(threadPool.queueSize.toDouble())
+  }
+
+  private fun ratio(numerator: Double, denominator: Double) =
+      if (denominator.isNaN() || denominator.isInfinite() || denominator == 0.0) Double.NaN
+      else numerator / denominator
+}

--- a/misk/src/test/kotlin/misk/web/JettyServiceMetricsTest.kt
+++ b/misk/src/test/kotlin/misk/web/JettyServiceMetricsTest.kt
@@ -1,0 +1,155 @@
+package misk.web
+
+import com.google.inject.util.Modules
+import com.squareup.moshi.Moshi
+import misk.inject.KAbstractModule
+import misk.moshi.adapter
+import misk.testing.MiskTest
+import misk.testing.MiskTestModule
+import misk.web.actions.WebAction
+import misk.web.actions.WebActionEntry
+import misk.web.jetty.ConnectionMetrics
+import misk.web.jetty.JettyConnectionMetricsCollector
+import misk.web.jetty.JettyService
+import misk.web.jetty.ThreadPoolMetrics
+import misk.web.mediatype.MediaTypes
+import okhttp3.HttpUrl
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.data.Percentage
+import org.eclipse.jetty.util.thread.QueuedThreadPool
+import org.junit.jupiter.api.Test
+import javax.inject.Inject
+
+@MiskTest(startService = true)
+internal class JettyServiceMetricsTest {
+  @MiskTestModule val module = TestModule()
+
+  @Inject lateinit var jettyService: JettyService
+  @Inject lateinit var connectionMetrics: ConnectionMetrics
+  @Inject lateinit var connectionMetricsCollector: JettyConnectionMetricsCollector
+  @Inject lateinit var moshi: Moshi
+
+  @Test fun connectionMetrics() {
+    val httpClient = OkHttpClient()
+    val request = Request.Builder()
+        .get()
+        .url(serverUrlBuilder().encodedPath("/hello").build())
+        .build()
+
+    val response = httpClient.newCall(request).execute()
+    assertThat(response.code()).isEqualTo(200)
+    assertThat(response.body()?.string()).isEqualTo("hi!")
+
+    connectionMetricsCollector.refreshMetrics()
+
+    val labels = ConnectionMetrics.forPort("http", 0) // It's the configured port not the actual
+    assertThat(connectionMetrics.acceptedConnections.labels(*labels).get()).isEqualTo(1.0)
+    assertThat(connectionMetrics.activeConnections.labels(*labels).get()).isEqualTo(1.0)
+    assertThat(connectionMetrics.bytesReceived.labels(*labels).get()).isEqualTo(120.0)
+    assertThat(connectionMetrics.bytesSent.labels(*labels).get()).isEqualTo(118.0)
+    assertThat(connectionMetrics.messagesReceived.labels(*labels).get()).isEqualTo(1.0)
+    assertThat(connectionMetrics.messagesSent.labels(*labels).get()).isEqualTo(1.0)
+
+    // Force close the okhttp connection
+    httpClient.connectionPool().evictAll()
+
+    // Wait for the active connections to go to zero. This is done by another thread (and we can't
+    // control it) so we need to do a spin wait on time out
+    val timeout = System.currentTimeMillis() + 5000
+    while (System.currentTimeMillis() < timeout &&
+        connectionMetrics.activeConnections.labels(*labels).get() != 0.0) {
+      Thread.sleep(500)
+    }
+
+    assertThat(System.currentTimeMillis()).isLessThan(timeout)
+
+    // Active connections should have dropped to zero, all other metrics should remain the same
+    assertThat(connectionMetrics.acceptedConnections.labels(*labels).get()).isEqualTo(1.0)
+    assertThat(connectionMetrics.activeConnections.labels(*labels).get()).isEqualTo(0.0)
+    assertThat(connectionMetrics.bytesReceived.labels(*labels).get()).isEqualTo(120.0)
+    assertThat(connectionMetrics.bytesSent.labels(*labels).get()).isEqualTo(118.0)
+    assertThat(connectionMetrics.messagesReceived.labels(*labels).get()).isEqualTo(1.0)
+    assertThat(connectionMetrics.messagesSent.labels(*labels).get()).isEqualTo(1.0)
+
+    // Refresh metrics, make sure we don't double add
+    connectionMetricsCollector.refreshMetrics()
+    assertThat(connectionMetrics.acceptedConnections.labels(*labels).get()).isEqualTo(1.0)
+    assertThat(connectionMetrics.activeConnections.labels(*labels).get()).isEqualTo(0.0)
+    assertThat(connectionMetrics.bytesReceived.labels(*labels).get()).isEqualTo(120.0)
+    assertThat(connectionMetrics.bytesSent.labels(*labels).get()).isEqualTo(118.0)
+    assertThat(connectionMetrics.messagesReceived.labels(*labels).get()).isEqualTo(1.0)
+    assertThat(connectionMetrics.messagesSent.labels(*labels).get()).isEqualTo(1.0)
+  }
+
+  @Test fun threadPoolMetrics() {
+    val httpClient = OkHttpClient()
+    val request = Request.Builder()
+        .get()
+        .url(serverUrlBuilder().encodedPath("/current-pool-metrics").build())
+        .build()
+
+    val adapter = moshi.adapter<PoolMetricsResponse>()
+    val response = httpClient.newCall(request).execute()
+    assertThat(response.code()).isEqualTo(200)
+
+    val metrics = adapter.fromJson(response.body()?.string()!!)!!
+    assertThat(metrics.queuedJobs).isEqualTo(0.0)
+    assertThat(metrics.size).isEqualTo(10.0)
+    assertThat(metrics.utilization).isCloseTo(0.5, Percentage.withPercentage(10.0))
+    assertThat(metrics.utilization_max).isCloseTo(0.5, Percentage.withPercentage(10.0))
+  }
+
+  internal class HelloAction : WebAction {
+    @Get("/hello")
+    @ResponseContentType(MediaTypes.TEXT_PLAIN_UTF8)
+    fun hi(): String {
+      return "hi!"
+    }
+  }
+
+  data class PoolMetricsResponse(
+    val queuedJobs: Double,
+    val size: Double,
+    val utilization: Double,
+    val utilization_max: Double
+  )
+
+  internal class CurrentPoolMetricsAction : WebAction {
+    @Inject lateinit var threadPoolMetrics: ThreadPoolMetrics
+
+    @Get("/current-pool-metrics")
+    @ResponseContentType(MediaTypes.APPLICATION_JSON)
+    fun getCurrentPoolMetrics(): PoolMetricsResponse {
+      threadPoolMetrics.refresh()
+
+      return PoolMetricsResponse(
+          queuedJobs = threadPoolMetrics.queuedJobs.get(),
+          size = threadPoolMetrics.size.get(),
+          utilization = threadPoolMetrics.utilization.get(),
+          utilization_max = threadPoolMetrics.utilizationMax.get()
+      )
+    }
+  }
+
+  internal class TestModule : KAbstractModule() {
+    override fun configure() {
+      install(Modules.override(WebTestingModule()).with(
+          object: KAbstractModule() {
+            override fun configure() {
+              bind<QueuedThreadPool>().toInstance(QueuedThreadPool(
+                  10, 10 // Fixed # of threads
+              ))
+            }
+          }
+      ))
+      multibind<WebActionEntry>().toInstance(WebActionEntry<HelloAction>())
+      multibind<WebActionEntry>().toInstance(WebActionEntry<CurrentPoolMetricsAction>())
+    }
+  }
+
+  private fun serverUrlBuilder(): HttpUrl.Builder {
+    return jettyService.httpServerUrl.newBuilder()
+  }
+}


### PR DESCRIPTION
* jetty_connections_total    - total # of connections accepted
* jetty_connections_active   - current # of open connections
* jetty_bytes_recvd_total    - total # of bytes received
* jetty_bytes_sent_total     - total # of bytes sent
* jetty_msgs_recvd_total     - total # of messages received
* jetty_msgs_sent_total      - total # of messages sent
* jetty_thread_pool_size     - current # of threads in the jetty pool
* jetty_thread_pool_busy     - current # of busy threads
* jetty_thread_pool_utilization - % utilization of the pool
* jetty_thread_pool_utilization_max - % utilization relative to the max
pool size