### PR TITLE
Make ConfigResources a Binding / Travis Fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ cache:
   directories:
     - $HOME/.gradle/caches/
     - $HOME/.gradle/wrapper/
+    - $HOME/misk/web/*/*/lib
 
 services:
   - mysql

--- a/misk/src/main/kotlin/misk/config/ConfigAdminAction.kt
+++ b/misk/src/main/kotlin/misk/config/ConfigAdminAction.kt
@@ -2,8 +2,8 @@ package misk.config
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.dataformat.yaml.YAMLMapper
+import misk.config.ConfigAdminAction.Companion.generateConfigResources
 import misk.environment.Environment
-import misk.security.authz.Unauthenticated
 import misk.web.Get
 import misk.web.RequestContentType
 import misk.web.ResponseContentType
@@ -11,33 +11,24 @@ import misk.web.actions.WebAction
 import misk.web.mediatype.MediaTypes
 import misk.web.metadata.AdminDashboardAccess
 import javax.inject.Inject
+import javax.inject.Qualifier
 import javax.inject.Singleton
 
 @Singleton
-class ConfigAdminAction : WebAction {
-  @Inject @AppName lateinit var appName: String
-  @Inject lateinit var environment: Environment
-
+class ConfigAdminAction @Inject constructor(
+  val optionalBinder: OptionalBinder
+) : WebAction {
   @Get("/api/config/all")
   @RequestContentType(MediaTypes.APPLICATION_JSON)
   @ResponseContentType(MediaTypes.APPLICATION_JSON)
-  // TODO(adrw) create new @AdminDashboard annotation because this will fail since there is no @Access
-  // @AdminDashboard will then be able to be picked up by skim
   @AdminDashboardAccess
   fun getAll(): Response {
     // TODO(mmihic): Need to figure out how to get the overrides.
-    val rawYamlFiles = MiskConfig.loadConfigYamlMap(appName, environment, listOf())
-    val effectiveConfigJsonString = MiskConfig.flattenYamlMap(rawYamlFiles).toString()
-    val effectiveConfigJsonNodeTree = ObjectMapper().readTree(effectiveConfigJsonString)
-    val effectiveConfigYaml = YAMLMapper().writeValueAsString(effectiveConfigJsonNodeTree).drop(4)
-    val yamlFiles = linkedMapOf<String, String?>("Effective Config" to effectiveConfigYaml)
-    rawYamlFiles.map { yamlFiles.put("classpath:/${it.key}", it.value) }
-
     // Regex to match on password values for password redaction in output
     val yamlFilesRegex = Regex("(?<=(password|passphrase): )([^\n]*)")
 
     return Response(
-        resources = redact(yamlFiles, yamlFilesRegex)
+        resources = redact(optionalBinder.resources, yamlFilesRegex)
     )
   }
 
@@ -51,5 +42,32 @@ class ConfigAdminAction : WebAction {
 
     fun redact(output: String, regex: Regex) =
         output.replace(regex, "████████")
+
+    fun generateConfigResources(appName: String, environment: Environment): Map<String, String?> {
+      val rawYamlFiles = MiskConfig.loadConfigYamlMap(appName, environment, listOf())
+      val effectiveConfigJsonString = MiskConfig.flattenYamlMap(rawYamlFiles).toString()
+      val effectiveConfigJsonNodeTree = ObjectMapper().readTree(effectiveConfigJsonString)
+      val effectiveConfigYaml = YAMLMapper().writeValueAsString(effectiveConfigJsonNodeTree).drop(4)
+      val yamlFiles = linkedMapOf<String, String?>("Effective Config" to effectiveConfigYaml)
+      rawYamlFiles.map { yamlFiles.put("classpath:/${it.key}", it.value) }
+      return yamlFiles
+    }
   }
+}
+
+@Qualifier
+@Target(AnnotationTarget.FIELD, AnnotationTarget.FUNCTION)
+annotation class ConfigResources
+
+/**
+ * https://github.com/google/guice/wiki/FrequentlyAskedQuestions#how-can-i-inject-optional-parameters-into-a-constructor
+ */
+@Singleton
+class OptionalBinder @Inject constructor(
+  @AppName val appName: String,
+  val environment: Environment
+) {
+  @com.google.inject.Inject(optional = true)
+  @ConfigResources
+  var resources: Map<String, String?> = generateConfigResources(appName, environment)
 }

--- a/misk/src/main/kotlin/misk/web/actions/ServiceMetadataAction.kt
+++ b/misk/src/main/kotlin/misk/web/actions/ServiceMetadataAction.kt
@@ -34,10 +34,11 @@ class ServiceMetadataAction @Inject constructor(
  */
 @Singleton
 class OptionalBinder @Inject constructor(
-  @AppName val appName: String
+  @AppName val appName: String,
+  val environment: Environment = Environment.fromEnvironmentVariable()
 ) {
   @com.google.inject.Inject(optional = true)
-  var serviceMetadata: ServiceMetadata = ServiceMetadata(appName, Environment.fromEnvironmentVariable(), "/_admin/")
+  var serviceMetadata: ServiceMetadata = ServiceMetadata(appName, environment, "/_admin/")
 }
 
 data class ServiceMetadata(


### PR DESCRIPTION
* Allows SkimConfig or other modules to override the default ConfigResources Map of `config file name` -> `YAML content` with an annotated Map<String,String?> binding with `@ConfigResources`
* Travis fixes to cache web builds for faster CI builds