### PR TITLE
Make GlobalTracer registration idempotent

### DIFF
--- a/misk-jaeger/src/main/kotlin/misk/tracing/backends/jaeger/JaegerTracingService.kt
+++ b/misk-jaeger/src/main/kotlin/misk/tracing/backends/jaeger/JaegerTracingService.kt
@@ -10,7 +10,13 @@ import javax.inject.Singleton
 internal class JaegerTracingService @Inject internal constructor(
   private val tracer: Tracer
 ) : AbstractIdleService() {
-  override fun startUp() = GlobalTracer.register(tracer)
+  override fun startUp() {
+    // In case startUp is called multiple times, ensure tracer is only registered once
+    if (!GlobalTracer.isRegistered()) {
+      GlobalTracer.register(tracer)
+    }
+  }
+
   override fun shutDown() {
   }
 }


### PR DESCRIPTION
When testing, the GlobalTracer was getting registered multiple times, causing the tests to fail.