### PR TITLE
AccessInterceptor Errors

### DIFF
--- a/misk/src/main/kotlin/misk/security/authz/AccessAnnotation.kt
+++ b/misk/src/main/kotlin/misk/security/authz/AccessAnnotation.kt
@@ -34,19 +34,19 @@ import kotlin.reflect.KClass
  * Finally we use multibindings to specify which services and roles are permitted:
  *
  * ```
- * multibind<AccessAnnotation>().toInstance(
- *  AccessAnnotation<PaleontologistAccess>(roles = listOf("paleontologist", "intern")))
+ * multibind<AccessAnnotationEntry>().toInstance(
+ *  AccessAnnotationEntry<PaleontologistAccess>(roles = listOf("paleontologist", "intern")))
  * ```
  */
-data class AccessAnnotation(
+data class AccessAnnotationEntry(
   val annotation: KClass<out Annotation>,
   val services: List<String> = listOf(),
   val roles: List<String> = listOf()
 )
 
-inline fun <reified T : Annotation> AccessAnnotation(
+inline fun <reified T : Annotation> AccessAnnotationEntry(
   services: List<String> = listOf(),
   roles: List<String> = listOf()
-): AccessAnnotation {
-  return AccessAnnotation(T::class, services, roles)
+): AccessAnnotationEntry {
+  return AccessAnnotationEntry(T::class, services, roles)
 }

--- a/misk/src/main/kotlin/misk/security/authz/AccessControlModule.kt
+++ b/misk/src/main/kotlin/misk/security/authz/AccessControlModule.kt
@@ -9,6 +9,6 @@ import misk.scope.ActionScopedProviderModule
 class AccessControlModule : ActionScopedProviderModule() {
   override fun configureProviders() {
     multibind<ApplicationInterceptor.Factory>().to<AccessInterceptor.Factory>()
-    newMultibinder<AccessAnnotation>()
+    newMultibinder<AccessAnnotationEntry>()
   }
 }

--- a/misk/src/main/kotlin/misk/web/actions/WebActionMetadataAction.kt
+++ b/misk/src/main/kotlin/misk/web/actions/WebActionMetadataAction.kt
@@ -1,7 +1,6 @@
 package misk.web.actions
 
 import misk.ApplicationInterceptor
-import misk.security.authz.Unauthenticated
 import misk.web.DispatchMechanism
 import misk.web.Get
 import misk.web.NetworkInterceptor

--- a/misk/src/test/kotlin/misk/web/actions/AuthenticationTest.kt
+++ b/misk/src/test/kotlin/misk/web/actions/AuthenticationTest.kt
@@ -5,10 +5,10 @@ import misk.client.HttpClientEndpointConfig
 import misk.client.HttpClientFactory
 import misk.inject.KAbstractModule
 import misk.scope.ActionScoped
-import misk.security.authz.AccessAnnotation
+import misk.security.authz.AccessAnnotationEntry
 import misk.security.authz.AccessControlModule
-import misk.security.authz.MiskCallerAuthenticator
 import misk.security.authz.FakeCallerAuthenticator
+import misk.security.authz.MiskCallerAuthenticator
 import misk.testing.MiskTest
 import misk.testing.MiskTestModule
 import misk.web.Get
@@ -102,10 +102,10 @@ class AuthenticationTest {
       multibind<WebActionEntry>().toInstance(WebActionEntry<CustomServiceAccessAction>())
       multibind<WebActionEntry>().toInstance(WebActionEntry<CustomRoleAccessAction>())
 
-      multibind<AccessAnnotation>().toInstance(
-          AccessAnnotation<CustomServiceAccess>(services = listOf("payments")))
-      multibind<AccessAnnotation>().toInstance(
-          AccessAnnotation<CustomRoleAccess>(roles = listOf("admin")))
+      multibind<AccessAnnotationEntry>().toInstance(
+          AccessAnnotationEntry<CustomServiceAccess>(services = listOf("payments")))
+      multibind<AccessAnnotationEntry>().toInstance(
+          AccessAnnotationEntry<CustomRoleAccess>(roles = listOf("admin")))
       multibind<MiskCallerAuthenticator>().to<FakeCallerAuthenticator>()
     }
   }


### PR DESCRIPTION
* Breaking change: Renamed `AccessAnnotation -> AccessAnnotationEntry`

* Helpful errors for >1 AccessAnnotations on a WebAction

```
Only one AccessAnnotation is permitted on a WebAction. Remove one from ShortUrlWebAction::follow():
 [AccessAnnotationEntry(annotation=class com.squareup.cashurlshortener.service.CashUrlshortenerOperatorAccess, services=[], roles=[casheng]), AccessAnnotationEntry(annotation=class misk.security.authz.Unauthenticated, services=[], roles=[])]

```

* Helpeful errors if WebAction is missing an AccessAnnotation

```
1) Error injecting constructor, java.lang.IllegalStateException: AccessInterceptor A) can't find an AccessAnnotation for this WebAction or B) can't find the related AccessAnnotationEntry multibinding.

A) ShortUrlWebAction::follow() must be annotated with one of the following AccessAnnotations that have a matching AccessAnnotationEntry:
   [class misk.security.authz.Authenticated, class misk.security.authz.Unauthenticated, class misk.web.metadata.AdminDashboardAccess, class com.squareup.cashurlshortener.service.CashUrlshortenerAdministratorAccess, class com.squareup.cashurlshortener.service.CashUrlshortenerOperatorAccess]

B) Add an AccessAnnotationEntry multibinding in a module for one of the annotations on ShortUrlWebAction::follow():
      [@misk.web.Get(pathPattern=/{token:[^/_]+}), @misk.web.ResponseContentType(value=application/json;charset=utf-8)]

   AccessAnnotationEntry Example Multibinding:
   multibind<AccessAnnotationEntry>().toInstance(
      AccessAnnotationEntry<{Access Class Simple Name}>(roles = ???, services = ???))
```

* Helpeful errors for AccessAnnotation missing AccessAnnotationEntry (note the filled in AccessAnnotation in the example multibinding)

```
1) Error injecting constructor, java.lang.IllegalStateException: AccessInterceptor A) can't find an AccessAnnotation for this WebAction or B) can't find the related AccessAnnotationEntry multibinding.

A) CreateShortUrlWebAction::createShortUrl() must be annotated with one of the following AccessAnnotations that have a matching AccessAnnotationEntry:
   [class misk.security.authz.Authenticated, class misk.security.authz.Unauthenticated, class misk.web.metadata.AdminDashboardAccess, class com.squareup.cashurlshortener.service.CashUrlshortenerAdministratorAccess]

B) Add an AccessAnnotationEntry multibinding in a module for one of the annotations on CreateShortUrlWebAction::createShortUrl():
      [@misk.web.Post(pathPattern=/create), @misk.web.RequestContentType(value=[application/json;charset=utf-8]), @misk.web.ResponseContentType(value=application/json;charset=utf-8), @com.squareup.cashurlshortener.service.CashUrlshortenerOperatorAccess()]

   AccessAnnotationEntry Example Multibinding:
   multibind<AccessAnnotationEntry>().toInstance(
     AccessAnnotationEntry<CashUrlshortenerOperatorAccess>(roles = ???, services = ???))
```

* [CLOSES #570]