### PR TITLE
Fix java.lang.IllegalArgumentException in ConnectionListener

### DIFF
--- a/misk/src/main/kotlin/misk/web/jetty/ConnectionListener.kt
+++ b/misk/src/main/kotlin/misk/web/jetty/ConnectionListener.kt
@@ -90,7 +90,7 @@ internal class ConnectionListener(
       metrics.messagesSent.labels(*labels).inc(messagesSentDiff.toDouble())
     }
 
-    if (messagesReceivedSnapshot > 0) {
+    if (messagesReceivedDiff > 0) {
       metrics.messagesReceived.labels(*labels).inc(messagesReceivedDiff.toDouble())
     }
   }


### PR DESCRIPTION
Add check for messagesReceivedDiff instead of messagesReceivedSnapshot for jetty metrics collection