### PR TITLE
[CLOSES #559] LocalDB Gradle Task

### DIFF
--- a/gradle/localdb.gradle
+++ b/gradle/localdb.gradle
@@ -1,0 +1,10 @@
+task localdb(type: Exec) {
+  // -Pdbport='3306': pass in a db port, it is default 3306
+  
+  def dbport = "3306"
+  if (project.hasProperty("dbport")) {
+    dbport = project.dbport
+  }
+
+  commandLine "sh", "-c", "docker run -d --rm --name ${new Date().format("YMD-HMS")}-mysql-57 -p ${dbport}:3306 -e MYSQL_ALLOW_EMPTY_PASSWORD=true mysql:5.7"
+}


### PR DESCRIPTION
* Common task for spinning up a local MySql:5.7 image for DB dependent services
* Default port of 3306 with optional override through `./gradlew localdb -Pdbport=####`
* [CLOSES #559] 
* Long term solution: #610