### PR TITLE
Remove Bundle Analyzer Running on Build

### DIFF
--- a/misk/web/@misk/common/package.json
+++ b/misk/web/@misk/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@misk/common",
-  "version": "0.0.54",
+  "version": "0.0.55",
   "description": "Microservice Kontainer Common Libraries, Externals, Styles",
   "author": "Square/Misk Authors (https://github.com/square/misk/graphs/contributors)",
   "main": "lib/web/@misk/common/common.js",
@@ -59,7 +59,7 @@
     "skeleton-css": "^2.0.4"
   },
   "devDependencies": {
-    "@misk/dev": "^0.0.53",
+    "@misk/dev": "^0.0.57",
     "@misk/tslint": "^0.0.8"
   },
   "miskCachedUrls": {

--- a/misk/web/@misk/common/webpack.config.js
+++ b/misk/web/@misk/common/webpack.config.js
@@ -1,6 +1,8 @@
 const path = require("path")
 const { BundleAnalyzerPlugin } = require("webpack-bundle-analyzer")
 
+const bundleAnalyzer = false
+
 module.exports = {
   name: "library",
   mode: "production",
@@ -31,13 +33,15 @@ module.exports = {
   resolve: {
     extensions: [".ts", ".tsx"]
   },
-  plugins: [
-    new BundleAnalyzerPlugin({
-      analyzerMode: "static",
-      reportFilename: "bundle-analyzer-report-common.html",
-      statsFilename: "bundle-analyzer-report-common.json",
-      generateStatsFile: true,
-      openAnalyzer: false
-    })
-  ]
+  plugins: bundleAnalyzer
+    ? [
+        new BundleAnalyzerPlugin({
+          analyzerMode: "static",
+          reportFilename: "bundle-analyzer-report-common.html",
+          statsFilename: "bundle-analyzer-report-common.json",
+          generateStatsFile: true,
+          openAnalyzer: false
+        })
+      ]
+    : []
 }

--- a/misk/web/@misk/common/webpack.config.static.js
+++ b/misk/web/@misk/common/webpack.config.static.js
@@ -1,6 +1,8 @@
 const path = require("path")
 const { BundleAnalyzerPlugin } = require("webpack-bundle-analyzer")
 
+const bundleAnalyzer = false
+
 module.exports = {
   name: "static",
   mode: "production",
@@ -20,13 +22,15 @@ module.exports = {
       }
     ]
   },
-  plugins: [
-    new BundleAnalyzerPlugin({
-      analyzerMode: "static",
-      reportFilename: "bundle-analyzer-report-static.html",
-      statsFilename: "bundle-analyzer-report-static.json",
-      generateStatsFile: true,
-      openAnalyzer: false
-    })
-  ]
+  plugins: bundleAnalyzer
+    ? [
+        new BundleAnalyzerPlugin({
+          analyzerMode: "static",
+          reportFilename: "bundle-analyzer-report-common.html",
+          statsFilename: "bundle-analyzer-report-common.json",
+          generateStatsFile: true,
+          openAnalyzer: false
+        })
+      ]
+    : []
 }

--- a/misk/web/@misk/common/webpack.config.vendors.js
+++ b/misk/web/@misk/common/webpack.config.vendors.js
@@ -1,6 +1,8 @@
 const path = require("path")
 const { BundleAnalyzerPlugin } = require("webpack-bundle-analyzer")
 
+const bundleAnalyzer = false
+
 module.exports = {
   name: "vendors",
   mode: "production",
@@ -20,13 +22,15 @@ module.exports = {
      */
     globalObject: "typeof window !== 'undefined' ? window : this"
   },
-  plugins: [
-    new BundleAnalyzerPlugin({
-      analyzerMode: "static",
-      reportFilename: "bundle-analyzer-report-vendors.html",
-      statsFilename: "bundle-analyzer-report-vendors.json",
-      generateStatsFile: true,
-      openAnalyzer: false
-    })
-  ]
+  plugins: bundleAnalyzer
+    ? [
+        new BundleAnalyzerPlugin({
+          analyzerMode: "static",
+          reportFilename: "bundle-analyzer-report-common.html",
+          statsFilename: "bundle-analyzer-report-common.json",
+          generateStatsFile: true,
+          openAnalyzer: false
+        })
+      ]
+    : []
 }

--- a/misk/web/@misk/common/yarn.lock
+++ b/misk/web/@misk/common/yarn.lock
@@ -230,10 +230,10 @@
     reflect-metadata "^0.1.12"
     tslib "^1.8.1"
 
-"@misk/dev@^0.0.53":
-  version "0.0.53"
-  resolved "https://registry.yarnpkg.com/@misk/dev/-/dev-0.0.53.tgz#1e60e63b4fd666830e743adc3947ebad2986f0cd"
-  integrity sha512-u6XfvQbdcI9GwoHUWWtWUULk9/S7wVfGt2unzq5ZXqfsmkuYC7pSmC35f9oYaYvtzSlc+pgIPX5SrcN8ZEGXKA==
+"@misk/dev@^0.0.57":
+  version "0.0.57"
+  resolved "https://registry.yarnpkg.com/@misk/dev/-/dev-0.0.57.tgz#83ccaed13a1fbd4a832694c9eb36e313b1b963fc"
+  integrity sha512-nK38CGJnAlr+D7sY+BSeNcILQSVLjHqZs6lyij+vm7AsLmsFVHDKVBXGh6y+L6nxF8TuwunhXe++k8oxkwn9zA==
   dependencies:
     "@types/lodash-es" "^4.17.1"
     "@types/node" "^10.11.7"

--- a/misk/web/@misk/components/package.json
+++ b/misk/web/@misk/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@misk/components",
-  "version": "0.0.70",
+  "version": "0.0.71",
   "description": "Microservice Kontainer Common Components",
   "author": "Square/Misk Authors (https://github.com/square/misk/graphs/contributors)",
   "main": "lib/web/@misk/components/components.js",
@@ -31,10 +31,10 @@
     "test": "echo no tests"
   },
   "dependencies": {
-    "@misk/common": "^0.0.53"
+    "@misk/common": "^0.0.55"
   },
   "devDependencies": {
-    "@misk/dev": "^0.0.53",
+    "@misk/dev": "^0.0.57",
     "@misk/tslint": "^0.0.8"
   }
 }

--- a/misk/web/@misk/components/webpack.config.js
+++ b/misk/web/@misk/components/webpack.config.js
@@ -2,6 +2,8 @@ const path = require("path")
 const MiskDev = require("@misk/dev")
 const { BundleAnalyzerPlugin } = require("webpack-bundle-analyzer")
 
+const bundleAnalyzer = false
+
 module.exports = {
   mode: "production",
   entry: {
@@ -35,14 +37,16 @@ module.exports = {
   resolve: {
     extensions: [".ts", ".tsx", ".js", ".jsx", ".json"]
   },
-  plugins: [
-    new BundleAnalyzerPlugin({
-      analyzerMode: "static",
-      reportFilename: "bundle-analyzer-report-components.html",
-      statsFilename: "bundle-analyzer-report-components.json",
-      generateStatsFile: true,
-      openAnalyzer: false
-    })
-  ],
+  plugins: bundleAnalyzer
+    ? [
+        new BundleAnalyzerPlugin({
+          analyzerMode: "static",
+          reportFilename: "bundle-analyzer-report-common.html",
+          statsFilename: "bundle-analyzer-report-common.json",
+          generateStatsFile: true,
+          openAnalyzer: false
+        })
+      ]
+    : [],
   externals: MiskDev.vendorExternals
 }

--- a/misk/web/@misk/components/yarn.lock
+++ b/misk/web/@misk/components/yarn.lock
@@ -230,17 +230,19 @@
     reflect-metadata "^0.1.12"
     tslib "^1.8.1"
 
-"@misk/common@^0.0.53":
-  version "0.0.53"
-  resolved "https://registry.yarnpkg.com/@misk/common/-/common-0.0.53.tgz#67a7d3c5a14244029d461bb416e32b4b3d22269c"
-  integrity sha512-uo2ceBOrVXOCgr++BpXPMks8PSz7oe2aE03T4Whs1TxEhu23fOrGnvUnt2qc+d5bOCOdCL9AlGbVmAAyngjJzg==
+"@misk/common@^0.0.55":
+  version "0.0.55"
+  resolved "https://registry.yarnpkg.com/@misk/common/-/common-0.0.55.tgz#967e54080fd43afade41d5f1347ab74800980071"
+  integrity sha512-kIGg8Zmo7u9rMNyrX99vtw+/fji4tagDm5Onj0H2nFnu5nCOWcB5rxThkFKl7Li3rJ0Ls1f0D/FhkB1VvqCI4g==
   dependencies:
     "@blueprintjs/core" "^3.7.0"
     "@blueprintjs/icons" "^3.2.0"
     "@emotion/core" "^10.0.0-beta.6"
     axios "^0.18.0"
     connected-react-router "^4.5.0"
+    create-emotion-styled "9.2.8"
     dayjs "^1.7.7"
+    emotion "^10.0.0-beta.6"
     history "^4.7.2"
     immutable "^4.0.0-rc.12"
     lodash-es "^4.17.11"
@@ -257,10 +259,10 @@
     redux-saga "^0.16.2"
     skeleton-css "^2.0.4"
 
-"@misk/dev@^0.0.53":
-  version "0.0.53"
-  resolved "https://registry.yarnpkg.com/@misk/dev/-/dev-0.0.53.tgz#1e60e63b4fd666830e743adc3947ebad2986f0cd"
-  integrity sha512-u6XfvQbdcI9GwoHUWWtWUULk9/S7wVfGt2unzq5ZXqfsmkuYC7pSmC35f9oYaYvtzSlc+pgIPX5SrcN8ZEGXKA==
+"@misk/dev@^0.0.57":
+  version "0.0.57"
+  resolved "https://registry.yarnpkg.com/@misk/dev/-/dev-0.0.57.tgz#83ccaed13a1fbd4a832694c9eb36e313b1b963fc"
+  integrity sha512-nK38CGJnAlr+D7sY+BSeNcILQSVLjHqZs6lyij+vm7AsLmsFVHDKVBXGh6y+L6nxF8TuwunhXe++k8oxkwn9zA==
   dependencies:
     "@types/lodash-es" "^4.17.1"
     "@types/node" "^10.11.7"

--- a/misk/web/@misk/dev/index.js
+++ b/misk/web/@misk/dev/index.js
@@ -1,7 +1,7 @@
 const createTabWebpack = require("./webpack.config.tab")
 const createPrettierConfig = require("./prettier.config.base")
-const vscodeExtensions = require('./vscode.extensions')
-const vscodeSettings = require('./vscode.settings')
+const vscodeExtensions = require("./vscode.extensions")
+const vscodeSettings = require("./vscode.settings")
 const {
   createExternals,
   vendorExternals,

--- a/misk/web/@misk/dev/package.json
+++ b/misk/web/@misk/dev/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@misk/dev",
-  "version": "0.0.56",
+  "version": "0.0.57",
   "description": "Microservice Kontainer Development Libraries",
   "author": "Square/Misk Authors (https://github.com/square/misk/graphs/contributors)",
   "main": "lib/web/@misk/dev/index.js",
@@ -9,9 +9,10 @@
     "url": "git@github.com:square/misk.git"
   },
   "scripts": {
-    "build": "mkdir -p lib/web/@misk/dev && cp package.json README.md index.js externals.js prettier.config.base.js tsconfig.base.json vscode.extensions.js vscode.settings.js webpack.config.tab.js lib/web/@misk/dev",
+    "build": "yarn run lint && mkdir -p lib/web/@misk/dev && cp *.{json,js,md} lib/web/@misk/dev",
     "clean": "rm -rf lib node_modules package-lock.json yarn.lock",
     "ci-build": "yarn clean && yarn build",
+    "lint": "../common/node_modules/prettier/bin-prettier.js --write --config prettier.config.js \"*.{md,css,sass,less,json,js,jsx,ts,tsx}\"",
     "prepare": "yarn ci-build"
   },
   "dependencies": {

--- a/misk/web/@misk/dev/vscode.extensions.js
+++ b/misk/web/@misk/dev/vscode.extensions.js
@@ -4,6 +4,6 @@ module.exports = () => {
     "eg2.tslint",
     "esbenp.prettier-vscode",
     "giladgray.theme-blueprint",
-    "timonwong.shellcheck",
+    "timonwong.shellcheck"
   ]
 }

--- a/misk/web/@misk/dev/webpack.config.tab.js
+++ b/misk/web/@misk/dev/webpack.config.tab.js
@@ -8,7 +8,7 @@ const { BundleAnalyzerPlugin } = require("webpack-bundle-analyzer")
 const merge = require("webpack-merge")
 
 module.exports = (env, argv, otherConfigFields = {}) => {
-  const { dirname, miskTab } = argv
+  const { dirname, miskTab, bundleAnalyzer = false } = argv
 
   if ("name" in miskTab && "port" in miskTab && "slug" in miskTab) {
     console.log("[MISK] Valid miskTab in package.json")
@@ -137,7 +137,9 @@ module.exports = (env, argv, otherConfigFields = {}) => {
     ].concat(
       env !== "production"
         ? [new webpack.HotModuleReplacementPlugin()]
-        : [BundleAnalyzerPluginConfig, DefinePluginConfig]
+        : [DefinePluginConfig].concat(
+            bundleAnalyzer ? [BundleAnalyzerPluginConfig] : []
+          )
     ),
     externals: { ...vendorExternals, ...miskExternals }
   }

--- a/misk/web/tabs/README.md
+++ b/misk/web/tabs/README.md
@@ -88,7 +88,7 @@
 
 ---
 
--
+- Full guide coming soon...
 
 ## Configuring the Misk Service
 
@@ -100,13 +100,13 @@
 
   ```Kotlin
   // Tab API Endpoints
-  multibind<WebActionEntry>().toInstance(WebActionEntry<ConfigAdminAction>())
+  multibind<WebActionEntry>().toInstance(WebActionEntry<TRexFoodAction>())
   // Show tab in menu
   multibind<DashboardTab, AdminDashboardTab>().toInstance(DashboardTab(
-        name = "Config",
+        name = "T-Rex Food Log",
         slug = "trexfoodlog",
         url_path_prefix = "/_admin/trexfoodlog/",
-        category = "Container Admin"
+        category = "Dinosaurs"
         ))
   // Wire up tab resources (static and web proxy dev-server)
   install(WebTabResourceModule(

--- a/misk/web/tabs/config/package.json
+++ b/misk/web/tabs/config/package.json
@@ -12,11 +12,11 @@
     "test": "echo no lint"
   },
   "dependencies": {
-    "@misk/common": "^0.0.54",
-    "@misk/components": "^0.0.70"
+    "@misk/common": "^0.0.55",
+    "@misk/components": "^0.0.71"
   },
   "devDependencies": {
-    "@misk/dev": "^0.0.53",
+    "@misk/dev": "^0.0.57",
     "@misk/tslint": "^0.0.8"
   },
   "miskTab": {

--- a/misk/web/tabs/config/yarn.lock
+++ b/misk/web/tabs/config/yarn.lock
@@ -230,37 +230,10 @@
     reflect-metadata "^0.1.12"
     tslib "^1.8.1"
 
-"@misk/common@^0.0.53":
-  version "0.0.53"
-  resolved "https://registry.yarnpkg.com/@misk/common/-/common-0.0.53.tgz#67a7d3c5a14244029d461bb416e32b4b3d22269c"
-  integrity sha512-uo2ceBOrVXOCgr++BpXPMks8PSz7oe2aE03T4Whs1TxEhu23fOrGnvUnt2qc+d5bOCOdCL9AlGbVmAAyngjJzg==
-  dependencies:
-    "@blueprintjs/core" "^3.7.0"
-    "@blueprintjs/icons" "^3.2.0"
-    "@emotion/core" "^10.0.0-beta.6"
-    axios "^0.18.0"
-    connected-react-router "^4.5.0"
-    dayjs "^1.7.7"
-    history "^4.7.2"
-    immutable "^4.0.0-rc.12"
-    lodash-es "^4.17.11"
-    react "^16.6.0"
-    react-dom "^16.6.0"
-    react-emotion "^10.0.0-beta.5"
-    react-helmet "^5.2.0"
-    react-hot-loader "^4.3.12"
-    react-redux "^5.1.0"
-    react-router "^4.3.1"
-    react-router-dom "^4.3.1"
-    react-transition-group "^2.5.0"
-    redux "^4.0.1"
-    redux-saga "^0.16.2"
-    skeleton-css "^2.0.4"
-
-"@misk/common@^0.0.54":
-  version "0.0.54"
-  resolved "https://registry.yarnpkg.com/@misk/common/-/common-0.0.54.tgz#88fbb4a886cfc52d4e10cddbda5bc5ba9256532c"
-  integrity sha512-1ZQeoLWBpR9QDjOmhkqT2DEaGMtVtdxfExJk7u+SD5O7x/cuDT7uXeVBvX54GU1fv+P0ewKfFcQq6AASZsL6eA==
+"@misk/common@^0.0.55":
+  version "0.0.55"
+  resolved "https://registry.yarnpkg.com/@misk/common/-/common-0.0.55.tgz#967e54080fd43afade41d5f1347ab74800980071"
+  integrity sha512-kIGg8Zmo7u9rMNyrX99vtw+/fji4tagDm5Onj0H2nFnu5nCOWcB5rxThkFKl7Li3rJ0Ls1f0D/FhkB1VvqCI4g==
   dependencies:
     "@blueprintjs/core" "^3.7.0"
     "@blueprintjs/icons" "^3.2.0"
@@ -286,17 +259,17 @@
     redux-saga "^0.16.2"
     skeleton-css "^2.0.4"
 
-"@misk/components@^0.0.70":
-  version "0.0.70"
-  resolved "https://registry.yarnpkg.com/@misk/components/-/components-0.0.70.tgz#466c0278ff0188ae16e17e78f0cbd8a981b239a9"
-  integrity sha512-6ujkHrh+QOjQrUU0JIOmNH3pADR4GCHX/Uqz4Qbqda45avEZQDK8aRdVS4Reclcb48c/kcmP25+GVlhcLXCGpQ==
+"@misk/components@^0.0.71":
+  version "0.0.71"
+  resolved "https://registry.yarnpkg.com/@misk/components/-/components-0.0.71.tgz#9be586d7acc30ed596538b7194be27781027796e"
+  integrity sha512-jQqdXkQPrOlUaVmo5sOPq/A7WxYAatkksOEdyMJfeKrzJag+ssCU1TBdlk4Yhn/FdeLzcss6g4U9MchrZn6wlw==
   dependencies:
-    "@misk/common" "^0.0.53"
+    "@misk/common" "^0.0.55"
 
-"@misk/dev@^0.0.53":
-  version "0.0.53"
-  resolved "https://registry.yarnpkg.com/@misk/dev/-/dev-0.0.53.tgz#1e60e63b4fd666830e743adc3947ebad2986f0cd"
-  integrity sha512-u6XfvQbdcI9GwoHUWWtWUULk9/S7wVfGt2unzq5ZXqfsmkuYC7pSmC35f9oYaYvtzSlc+pgIPX5SrcN8ZEGXKA==
+"@misk/dev@^0.0.57":
+  version "0.0.57"
+  resolved "https://registry.yarnpkg.com/@misk/dev/-/dev-0.0.57.tgz#83ccaed13a1fbd4a832694c9eb36e313b1b963fc"
+  integrity sha512-nK38CGJnAlr+D7sY+BSeNcILQSVLjHqZs6lyij+vm7AsLmsFVHDKVBXGh6y+L6nxF8TuwunhXe++k8oxkwn9zA==
   dependencies:
     "@types/lodash-es" "^4.17.1"
     "@types/node" "^10.11.7"

--- a/misk/web/tabs/example/package.json
+++ b/misk/web/tabs/example/package.json
@@ -12,11 +12,11 @@
     "test": "echo no lint"
   },
   "dependencies": {
-    "@misk/common": "^0.0.54",
-    "@misk/components": "^0.0.70"
+    "@misk/common": "^0.0.55",
+    "@misk/components": "^0.0.71"
   },
   "devDependencies": {
-    "@misk/dev": "^0.0.53",
+    "@misk/dev": "^0.0.57",
     "@misk/tslint": "^0.0.8"
   },
   "miskTab": {

--- a/misk/web/tabs/example/yarn.lock
+++ b/misk/web/tabs/example/yarn.lock
@@ -230,37 +230,10 @@
     reflect-metadata "^0.1.12"
     tslib "^1.8.1"
 
-"@misk/common@^0.0.53":
-  version "0.0.53"
-  resolved "https://registry.yarnpkg.com/@misk/common/-/common-0.0.53.tgz#67a7d3c5a14244029d461bb416e32b4b3d22269c"
-  integrity sha512-uo2ceBOrVXOCgr++BpXPMks8PSz7oe2aE03T4Whs1TxEhu23fOrGnvUnt2qc+d5bOCOdCL9AlGbVmAAyngjJzg==
-  dependencies:
-    "@blueprintjs/core" "^3.7.0"
-    "@blueprintjs/icons" "^3.2.0"
-    "@emotion/core" "^10.0.0-beta.6"
-    axios "^0.18.0"
-    connected-react-router "^4.5.0"
-    dayjs "^1.7.7"
-    history "^4.7.2"
-    immutable "^4.0.0-rc.12"
-    lodash-es "^4.17.11"
-    react "^16.6.0"
-    react-dom "^16.6.0"
-    react-emotion "^10.0.0-beta.5"
-    react-helmet "^5.2.0"
-    react-hot-loader "^4.3.12"
-    react-redux "^5.1.0"
-    react-router "^4.3.1"
-    react-router-dom "^4.3.1"
-    react-transition-group "^2.5.0"
-    redux "^4.0.1"
-    redux-saga "^0.16.2"
-    skeleton-css "^2.0.4"
-
-"@misk/common@^0.0.54":
-  version "0.0.54"
-  resolved "https://registry.yarnpkg.com/@misk/common/-/common-0.0.54.tgz#88fbb4a886cfc52d4e10cddbda5bc5ba9256532c"
-  integrity sha512-1ZQeoLWBpR9QDjOmhkqT2DEaGMtVtdxfExJk7u+SD5O7x/cuDT7uXeVBvX54GU1fv+P0ewKfFcQq6AASZsL6eA==
+"@misk/common@^0.0.55":
+  version "0.0.55"
+  resolved "https://registry.yarnpkg.com/@misk/common/-/common-0.0.55.tgz#967e54080fd43afade41d5f1347ab74800980071"
+  integrity sha512-kIGg8Zmo7u9rMNyrX99vtw+/fji4tagDm5Onj0H2nFnu5nCOWcB5rxThkFKl7Li3rJ0Ls1f0D/FhkB1VvqCI4g==
   dependencies:
     "@blueprintjs/core" "^3.7.0"
     "@blueprintjs/icons" "^3.2.0"
@@ -286,17 +259,17 @@
     redux-saga "^0.16.2"
     skeleton-css "^2.0.4"
 
-"@misk/components@^0.0.70":
-  version "0.0.70"
-  resolved "https://registry.yarnpkg.com/@misk/components/-/components-0.0.70.tgz#466c0278ff0188ae16e17e78f0cbd8a981b239a9"
-  integrity sha512-6ujkHrh+QOjQrUU0JIOmNH3pADR4GCHX/Uqz4Qbqda45avEZQDK8aRdVS4Reclcb48c/kcmP25+GVlhcLXCGpQ==
+"@misk/components@^0.0.71":
+  version "0.0.71"
+  resolved "https://registry.yarnpkg.com/@misk/components/-/components-0.0.71.tgz#9be586d7acc30ed596538b7194be27781027796e"
+  integrity sha512-jQqdXkQPrOlUaVmo5sOPq/A7WxYAatkksOEdyMJfeKrzJag+ssCU1TBdlk4Yhn/FdeLzcss6g4U9MchrZn6wlw==
   dependencies:
-    "@misk/common" "^0.0.53"
+    "@misk/common" "^0.0.55"
 
-"@misk/dev@^0.0.53":
-  version "0.0.53"
-  resolved "https://registry.yarnpkg.com/@misk/dev/-/dev-0.0.53.tgz#1e60e63b4fd666830e743adc3947ebad2986f0cd"
-  integrity sha512-u6XfvQbdcI9GwoHUWWtWUULk9/S7wVfGt2unzq5ZXqfsmkuYC7pSmC35f9oYaYvtzSlc+pgIPX5SrcN8ZEGXKA==
+"@misk/dev@^0.0.57":
+  version "0.0.57"
+  resolved "https://registry.yarnpkg.com/@misk/dev/-/dev-0.0.57.tgz#83ccaed13a1fbd4a832694c9eb36e313b1b963fc"
+  integrity sha512-nK38CGJnAlr+D7sY+BSeNcILQSVLjHqZs6lyij+vm7AsLmsFVHDKVBXGh6y+L6nxF8TuwunhXe++k8oxkwn9zA==
   dependencies:
     "@types/lodash-es" "^4.17.1"
     "@types/node" "^10.11.7"

--- a/misk/web/tabs/loader/package.json
+++ b/misk/web/tabs/loader/package.json
@@ -12,11 +12,11 @@
     "test": "echo no lint"
   },
   "dependencies": {
-    "@misk/common": "^0.0.54",
-    "@misk/components": "^0.0.70"
+    "@misk/common": "^0.0.55",
+    "@misk/components": "^0.0.71"
   },
   "devDependencies": {
-    "@misk/dev": "^0.0.53",
+    "@misk/dev": "^0.0.57",
     "@misk/tslint": "^0.0.8"
   },
   "miskTab": {

--- a/misk/web/tabs/loader/yarn.lock
+++ b/misk/web/tabs/loader/yarn.lock
@@ -230,37 +230,10 @@
     reflect-metadata "^0.1.12"
     tslib "^1.8.1"
 
-"@misk/common@^0.0.53":
-  version "0.0.53"
-  resolved "https://registry.yarnpkg.com/@misk/common/-/common-0.0.53.tgz#67a7d3c5a14244029d461bb416e32b4b3d22269c"
-  integrity sha512-uo2ceBOrVXOCgr++BpXPMks8PSz7oe2aE03T4Whs1TxEhu23fOrGnvUnt2qc+d5bOCOdCL9AlGbVmAAyngjJzg==
-  dependencies:
-    "@blueprintjs/core" "^3.7.0"
-    "@blueprintjs/icons" "^3.2.0"
-    "@emotion/core" "^10.0.0-beta.6"
-    axios "^0.18.0"
-    connected-react-router "^4.5.0"
-    dayjs "^1.7.7"
-    history "^4.7.2"
-    immutable "^4.0.0-rc.12"
-    lodash-es "^4.17.11"
-    react "^16.6.0"
-    react-dom "^16.6.0"
-    react-emotion "^10.0.0-beta.5"
-    react-helmet "^5.2.0"
-    react-hot-loader "^4.3.12"
-    react-redux "^5.1.0"
-    react-router "^4.3.1"
-    react-router-dom "^4.3.1"
-    react-transition-group "^2.5.0"
-    redux "^4.0.1"
-    redux-saga "^0.16.2"
-    skeleton-css "^2.0.4"
-
-"@misk/common@^0.0.54":
-  version "0.0.54"
-  resolved "https://registry.yarnpkg.com/@misk/common/-/common-0.0.54.tgz#88fbb4a886cfc52d4e10cddbda5bc5ba9256532c"
-  integrity sha512-1ZQeoLWBpR9QDjOmhkqT2DEaGMtVtdxfExJk7u+SD5O7x/cuDT7uXeVBvX54GU1fv+P0ewKfFcQq6AASZsL6eA==
+"@misk/common@^0.0.55":
+  version "0.0.55"
+  resolved "https://registry.yarnpkg.com/@misk/common/-/common-0.0.55.tgz#967e54080fd43afade41d5f1347ab74800980071"
+  integrity sha512-kIGg8Zmo7u9rMNyrX99vtw+/fji4tagDm5Onj0H2nFnu5nCOWcB5rxThkFKl7Li3rJ0Ls1f0D/FhkB1VvqCI4g==
   dependencies:
     "@blueprintjs/core" "^3.7.0"
     "@blueprintjs/icons" "^3.2.0"
@@ -286,17 +259,17 @@
     redux-saga "^0.16.2"
     skeleton-css "^2.0.4"
 
-"@misk/components@^0.0.70":
-  version "0.0.70"
-  resolved "https://registry.yarnpkg.com/@misk/components/-/components-0.0.70.tgz#466c0278ff0188ae16e17e78f0cbd8a981b239a9"
-  integrity sha512-6ujkHrh+QOjQrUU0JIOmNH3pADR4GCHX/Uqz4Qbqda45avEZQDK8aRdVS4Reclcb48c/kcmP25+GVlhcLXCGpQ==
+"@misk/components@^0.0.71":
+  version "0.0.71"
+  resolved "https://registry.yarnpkg.com/@misk/components/-/components-0.0.71.tgz#9be586d7acc30ed596538b7194be27781027796e"
+  integrity sha512-jQqdXkQPrOlUaVmo5sOPq/A7WxYAatkksOEdyMJfeKrzJag+ssCU1TBdlk4Yhn/FdeLzcss6g4U9MchrZn6wlw==
   dependencies:
-    "@misk/common" "^0.0.53"
+    "@misk/common" "^0.0.55"
 
-"@misk/dev@^0.0.53":
-  version "0.0.53"
-  resolved "https://registry.yarnpkg.com/@misk/dev/-/dev-0.0.53.tgz#1e60e63b4fd666830e743adc3947ebad2986f0cd"
-  integrity sha512-u6XfvQbdcI9GwoHUWWtWUULk9/S7wVfGt2unzq5ZXqfsmkuYC7pSmC35f9oYaYvtzSlc+pgIPX5SrcN8ZEGXKA==
+"@misk/dev@^0.0.57":
+  version "0.0.57"
+  resolved "https://registry.yarnpkg.com/@misk/dev/-/dev-0.0.57.tgz#83ccaed13a1fbd4a832694c9eb36e313b1b963fc"
+  integrity sha512-nK38CGJnAlr+D7sY+BSeNcILQSVLjHqZs6lyij+vm7AsLmsFVHDKVBXGh6y+L6nxF8TuwunhXe++k8oxkwn9zA==
   dependencies:
     "@types/lodash-es" "^4.17.1"
     "@types/node" "^10.11.7"


### PR DESCRIPTION
* Remove Bundle Analyzer running by default but leave it as an option for debugging large compiled code bundle sizes
* It was taking too much time for builds inside Docker