### PR TITLE
Improved Docker Web Builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,12 @@ jdk:
   - oraclejdk8
   - oraclejdk9
 
-before_script:
-  - docker pull vitess/base
-  - docker pull zookeeper:3.5.4-beta
-  - docker pull pafortin/goaws
+# Run Docker Pulls in parallel, esp for vitess/base with size > 1GB
+install:
+  - docker pull squareup/misk-web &
+  - docker pull vitess/base &
+  - docker pull zookeeper:3.5.4-beta &
+  - docker pull pafortin/goaws &
 
 script:
   - ./gradlew test
@@ -16,11 +18,12 @@ script:
 before_cache:
   - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
   - rm -fr $HOME/.gradle/caches/*/plugin-resolution/
+
 cache:
+  bundler: true
   directories:
     - $HOME/.gradle/caches/
     - $HOME/.gradle/wrapper/
-    - $HOME/misk/web/*/*/lib
 
 services:
   - mysql

--- a/docker/misk-web/CHANGELOG.md
+++ b/docker/misk-web/CHANGELOG.md
@@ -1,0 +1,4 @@
+squareup/misk-web Breaking Changelog
+===
+
+- 2018-11-05: `misk-web@^0.0.3` assumes `node_modules` installed centrally in `web/node_modules`. This will involve updating `tsconfig.json` in each tab.

--- a/docker/misk-web/Dockerfile
+++ b/docker/misk-web/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:alpine
 
-RUN apk add --no-cache tini python python2 alpine-sdk
+RUN apk add --no-cache tini
 
 WORKDIR /tmp/web/
 
@@ -8,13 +8,14 @@ WORKDIR /tmp/web/
 RUN yarn add \
     --pure-lockfile \
     --non-interactive \
+    --modules-folder /node_modules \
       @misk/common \
       @misk/components \
       @misk/dev \
       @misk/tslint \
-  && rm -rf /tmp/web/node_modules \
-  && yarn global add cross-env webpack webpack-cli webpack-dev-server
+  && yarn global add cross-env prettier webpack webpack-cli webpack-dev-server
 
+ENV NODE_PATH='/node_modules'
 COPY misk-web /bin/
 WORKDIR /web
 ENTRYPOINT ["/sbin/tini", "--"]

--- a/docker/misk-web/misk-web
+++ b/docker/misk-web/misk-web
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-function usage {
+usage() {
   cat << EOF
   Usage :: misk-web <opts>
 
@@ -17,16 +17,16 @@ function usage {
   -d    'start' webpack-dev-server on first found tab
         note: only run when docker container is mounted with a single tab
 
-  -i    'install' all dependencies
+  -g    'ci-build', same as '-b' but without linting for faster CI builds
+
+  -l    'lint' run Prettier linting
 
   -o    compute a md5 hash over the current directory and stores in .hash file
 
   -m    compute a md5 hash over the current directory and stores in .hash file, creates .hashdiff file if there is an existing hash
         exclude patterns: cachedUrls, lib, node_modules, .hash
 
-  -n    remove yarn.lock and node_modules
-
-  -r    'reinstall' all node_modules dependencies
+  -r    'refresh' local web/node_modules from Docker image /node_modules
 
   -w    overide location for web mount point
         default: '/web'
@@ -41,6 +41,7 @@ function usage {
 
   /web
     misk-build.sh
+    node_modules/
     tabs/
       tab1/
         package.json
@@ -50,7 +51,7 @@ function usage {
         package.json
       ...
 EOF
-  exit 0
+    exit 0
 }
 
 LABEL=""
@@ -58,70 +59,88 @@ CMD=""
 WEB="/web"
 HD="false"
 
-function hashDir {
-  tar --exclude="cachedUrls" --exclude="lib" --exclude="node_modules" --exclude=".DS_Store" --exclude=".hash" --exclude="yarn.lock" -cf - . | md5sum 2>&1
+hashDir() {
+    tar --exclude="cachedUrls" --exclude="lib" --exclude="node_modules" --exclude=".DS_Store" --exclude=".hash" --exclude="yarn.lock" -cf - . | md5sum 2>&1
 }
 
-function hashDiff {
-  newHash=$(hashDir | sed 's/[[:space:]]//g')
-  if [ -f .hash ]; then
-    oldHash=$(sed 's/[[:space:]]//g' < .hash)
-    if [ "$oldHash" = "$newHash" ]; then
-      echo "${oldHash} ${newHash} false"
+hashDiff() {
+    newHash=$(hashDir | sed 's/[[:space:]]//g')
+    if [ -f .hash ]; then
+        oldHash=$(sed 's/[[:space:]]//g' < .hash)
+        if [ "$oldHash" = "$newHash" ]; then
+            echo "${oldHash} ${newHash} false"
+        else
+            echo "${oldHash} ${newHash} true"
+        fi
+        
     else
-      echo "${oldHash} ${newHash} true"
+        echo "${newHash} true"
     fi
-
-  else 
-    echo "${newHash} true"
-  fi
 }
 
-function runCmd {
-  echo "[RUNCMD]: ${WEB}/*/* $LABEL HD: $HD CMD: $CMD"
-  for dir in ${WEB}/*/* ; do
-    dir=${dir%*/}
-    if [ -d $dir ]; then
-      cd $dir
-      if [ "$HD" = "true" ]; then
-        diffResult=$(hashDiff)
-        echo "[HASH DIFF] $dir $diffResult"
-        # Run command if hashdiff is different
-        echo "$LABEL $dir" && echo "$diffResult" | grep -Fq "true" && $CMD
-        # Run command anyways if there is no lib directory
-        [ ! -d $dir/lib ] && echo "$LABEL $dir" && $CMD
-      else
-        # Run command if no hashdiff check required
-        echo "$LABEL $dir" && $CMD
-      fi
-      # Update hash after every command
-      hashDir | tee .hash
-    fi
-  done
+stashNodeModules() {
+    # Remove any previous node_modules links or directories
+    rm ./node_modules
+    # Link to cached node_modules in Docker image
+    ln -s /node_modules .
 }
 
-function reset {
-  LABEL=""
-  CMD=""
-  HD="false"
+restoreNodeModules() {
+    # Install local web/node_modules if not already present, not in CI environments
+    [ ! -d ${WEB}/node_modules ] && ! printenv | grep -q "CI" && echo "[REFRESH] Updating local web/node_modules/ from Docker image" && cp -r /node_modules ${WEB}/node_modules
+    # Relink back to web/node_modules
+    ln -s ${WEB}/node_modules .
 }
 
-while getopts "h?abcdiomnrwxz:" opt; do
-  case "$opt" in
-    h|\?)   usage && exit 0   ;;
-    a)      LABEL="[BUILD ALL]" && CMD='yarn ci-build' && runCmd && reset   ;;
-    b)      LABEL="[BUILD]" && HD="true" && CMD='yarn ci-build' && runCmd && reset   ;;
-    c)      LABEL="[CLEAN]" && CMD='yarn clean' && runCmd && reset    ;;
-    d)      LABEL="[DEV]" && CMD='yarn start' && runCmd && reset   ;;
-    i)      LABEL="[INSTALL]" && CMD='yarn install' && runCmd && reset    ;;
-    o)      LABEL="[MD5 HASH]" && CMD='hashDir | tee .hash' && runCmd && reset   ;;
-    m)      LABEL="[MD5 HASHDIFF]" && CMD='hashDiff' && runCmd && reset   ;;
-    n)      LABEL="[RM NODE_MODULES]" && CMD='rm yarn.lock && rm -rf node_modules' && runCmd && reset   ;;
-    r)      LABEL="[REINSTALL]" && CMD='yarn reinstall' && runCmd && reset    ;;
-    w)      LABEL="[ALT WEB LOCATION]" && WEB="${OPTARG}" && reset    ;;
-    x)      LABEL="[HD=\"true\"]" && HD="true"    ;;
-    z)      LABEL="[CMD]" && CMD="${OPTARG}" && runCmd && reset   ;;
-  esac
+runCmd() {
+    echo "[RUNCMD]: ${WEB}/*/* $LABEL HD: '$HD' CMD: '$CMD'"
+    
+    for dir in ${WEB}/*/* ; do
+        dir=${dir%*/}
+        if [ -d $dir ] && [ "$dir" = "${dir%"node_modules"*}" ]; then
+            cd $dir || continue
+            if [ "$HD" = "true" ]; then
+                diffResult=$(hashDiff)
+                echo "[HASH DIFF] $dir $diffResult"
+                stashNodeModules
+                # Run command if hashdiff is different
+                echo "$LABEL $dir" && echo "$diffResult" | grep -Fq "true" && $CMD
+                # Run command anyways if there is no lib directory
+                [ ! -d $dir/lib ] && echo "$LABEL $dir" && $CMD
+            else
+                stashNodeModules
+                # Run command if no hashdiff check required
+                echo "$LABEL $dir" && $CMD
+            fi
+            restoreNodeModules
+            # Update hash after every command
+            hashDir | tee .hash
+        fi
+    done
+}
+
+reset() {
+    LABEL=""
+    CMD=""
+    HD="false"
+}
+
+while getopts "h?abcdglomrwxz:" opt; do
+    case "$opt" in
+        h|\?)   usage && exit 0   ;;
+        a)      LABEL="[BUILD ALL]" && CMD='yarn build' && runCmd && reset   ;;
+        b)      LABEL="[BUILD]" && HD="true" && CMD='yarn build' && runCmd && reset   ;;
+        c)      LABEL="[CLEAN]" && CMD='yarn clean' && runCmd && reset    ;;
+        d)      LABEL="[DEV]" && CMD='yarn start' && runCmd && reset   ;;
+        g)      LABEL="[CI-BUILD]" && HD="true" && CMD='yarn ci-build' && runCmd && reset   ;;
+        l)      LABEL="[LINT]" && CMD='yarn run lint' && runCmd && reset  ;;
+        o)      LABEL="[MD5 HASH]" && CMD='hashDir | tee .hash' && runCmd && reset   ;;
+        m)      LABEL="[MD5 HASHDIFF]" && CMD='hashDiff' && runCmd && reset   ;;
+        r)      restoreNodeModules && reset    ;;
+        w)      LABEL="[ALT WEB LOCATION]" && WEB="${OPTARG}" && reset    ;;
+        x)      LABEL="[HD=\"true\"]" && HD="true"    ;;
+        z)      LABEL="[CMD]" && CMD="${OPTARG}" && runCmd && reset   ;;
+    esac
 done
 
 exit 0

--- a/gradle/web.gradle
+++ b/gradle/web.gradle
@@ -1,5 +1,7 @@
 import groovy.json.JsonSlurper
 
+def dockerMiskWebVersion = "0.0.3"
+
 task web(type: Exec) {
   // -Pcmd='-d': pass in argument to misk-web shell script in Docker container
   // -Ptabs='tabs/config, tabs/example': spins up parallel Docker containers with the following paths as volumes
@@ -19,7 +21,7 @@ task web(type: Exec) {
     return packageJson.miskTab.port
   }
 
-  def generateDockerRunCommand = { service, project, projectPath, path, cmd, daemon="-d", image = "squareup/misk-web:0.0.2" ->
+  def generateDockerRunCommand = { service, project, projectPath, path, cmd, daemon="-d", image = "squareup/misk-web:${dockerMiskWebVersion}" ->
     def containerName = "${generateDockerContainerName(service, project, path)}"
     def port = ""
     if (path.startsWith("/tabs")) {
@@ -38,7 +40,7 @@ task web(type: Exec) {
   if (project.hasProperty("cmd")) {
     cmd = project.cmd
   } else {
-    cmd = "-b"
+    cmd = "-g"
   }
 
   def dockerd = ""

--- a/misk/build.gradle
+++ b/misk/build.gradle
@@ -9,6 +9,7 @@ kotlin {
 }
 apply plugin: 'org.junit.platform.gradle.plugin'
 apply plugin: 'com.vanniktech.maven.publish'
+apply from: rootProject.file("gradle/localdb.gradle")
 apply from: rootProject.file("gradle/web.gradle")
 
 compileKotlin {

--- a/misk/web/@misk/common/package.json
+++ b/misk/web/@misk/common/package.json
@@ -18,14 +18,11 @@
     "url": "git@github.com:square/misk.git"
   },
   "scripts": {
-    "build:lib": "yarn run lib",
-    "build": "yarn run lib",
+    "build": "yarn run lint && yarn run lib",
     "clean": "rm -rf cachedUrls lib",
-    "dev": "yarn run lib; yarn run updateDevCache",
-    "dist": "yarn run lib",
-    "docker-build": "yarn run refresh; node node_modules/webpack/bin/webpack.js --config webpack.config.js && node node_modules/webpack/bin/webpack.js --config webpack.config.static.js && node node_modules/webpack/bin/webpack.js --config webpack.config.vendors.js",
-    "ci-build": "yarn install && yarn clean && yarn build",
-    "lib": "yarn run refresh; yarn run lint && webpack --config webpack.config.js && webpack --config webpack.config.static.js && webpack --config webpack.config.vendors.js",
+    "dev": "yarn run build; yarn run updateDevCache",
+    "ci-build": "yarn run clean && yarn run lib",
+    "lib": "yarn run refresh; webpack --config webpack.config.js && webpack --config webpack.config.static.js && webpack --config webpack.config.vendors.js",
     "lint": "prettier --write --config prettier.config.js \"./src/**/*.{md,css,sass,less,json,js,jsx,ts,tsx}\"",
     "prepare": "yarn run lint && yarn run test && yarn run lib",
     "refresh": "node refreshCachedUrls.js",

--- a/misk/web/@misk/common/tsconfig.json
+++ b/misk/web/@misk/common/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "./node_modules/@misk/dev/tsconfig.base",
+  "extends": "../../node_modules/@misk/dev/tsconfig.base",
   "compilerOptions": {
     "outDir": "./lib/web/@misk/common"
   }

--- a/misk/web/@misk/components/package.json
+++ b/misk/web/@misk/components/package.json
@@ -17,13 +17,11 @@
     "url": "git@github.com:square/misk.git"
   },
   "scripts": {
-    "build": "yarn run lib",
-    "build:lib": "yarn run lib",
+    "build": "yarn run lint && yarn run lib",
     "clean": "rm -rf lib",
-    "dev": "yarn run lib; yarn run updateDevCache",
-    "dist": "yarn run lib",
-    "ci-build": "yarn install && yarn clean && yarn build",
-    "lib": "yarn run lint && webpack",
+    "dev": "yarn run build; yarn run updateDevCache",
+    "ci-build": "yarn run clean && yarn run lib",
+    "lib": "webpack",
     "lint": "prettier --write --config prettier.config.js \"./src/**/*.{md,css,sass,less,json,js,jsx,ts,tsx}\"",
     "prepare": "yarn run lint && yarn run test && yarn run lib",
     "reinstall": "rm -rf node_modules && yarn install",

--- a/misk/web/@misk/components/tsconfig.json
+++ b/misk/web/@misk/components/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "./node_modules/@misk/dev/tsconfig.base",
+  "extends": "../../node_modules/@misk/dev/tsconfig.base",
   "compilerOptions": {
     "outDir": "./lib/web/@misk/components"
   }

--- a/misk/web/@misk/dev/README.md
+++ b/misk/web/@misk/dev/README.md
@@ -15,9 +15,9 @@ Create a `tsconfig.json` file in the repo root directory with the following:
 
 ```JSON
   {
-    "extends": "./node_modules/@misk/dev/tsconfig.base",
+    "extends": "../../node_modules/@misk/dev/tsconfig.base",
     "compilerOptions": {
-        "outDir": "./dist"
+      "outDir": "./lib/web/_tab/{tabname}"
     }
   }
 ```

--- a/misk/web/@misk/dev/package.json
+++ b/misk/web/@misk/dev/package.json
@@ -9,11 +9,12 @@
     "url": "git@github.com:square/misk.git"
   },
   "scripts": {
-    "build": "yarn run lint && mkdir -p lib/web/@misk/dev && cp *.{json,js,md} lib/web/@misk/dev",
+    "build": "yarn run lint && yarn run lib",
     "clean": "rm -rf lib node_modules package-lock.json yarn.lock",
-    "ci-build": "yarn clean && yarn build",
-    "lint": "../common/node_modules/prettier/bin-prettier.js --write --config prettier.config.js \"*.{md,css,sass,less,json,js,jsx,ts,tsx}\"",
-    "prepare": "yarn ci-build"
+    "ci-build": "yarn run clean && yarn run lib",
+    "lib": "mkdir -p lib/web/@misk/dev && cp *.json *.js *.md lib/web/@misk/dev",
+    "lint": "prettier --write --config prettier.config.js \"*.{md,css,sass,less,json,js,jsx,ts,tsx}\"",
+    "prepare": "yarn run ci-build"
   },
   "dependencies": {
     "@types/lodash-es": "^4.17.1",

--- a/misk/web/@misk/tslint/package.json
+++ b/misk/web/@misk/tslint/package.json
@@ -11,8 +11,8 @@
   "scripts": {
     "build": "mkdir -p lib/web/@misk/tslint && cp package.json README.md tslint.base.json lib/web/@misk/tslint",
     "clean": "rm -rf lib node_modules package-lock.json yarn.lock",
-    "ci-build": "yarn clean && yarn build",
-    "prepare": "yarn ci-build"
+    "ci-build": "yarn run clean && yarn run build",
+    "prepare": "yarn run ci-build"
   },
   "dependencies": {
     "tslint": "^5.11.0",

--- a/misk/web/tabs/config/package.json
+++ b/misk/web/tabs/config/package.json
@@ -3,13 +3,14 @@
   "version": "0.0.3",
   "main": "src/index.ts",
   "scripts": {
-    "build": "yarn run lint && cross-env NODE_ENV=production webpack",
+    "build": "yarn run lint && yarn run lib",
     "clean": "rm -rf lib",
-    "ci-build": "yarn install && yarn clean && yarn build",
+    "ci-build": "yarn run clean && yarn run lib",
+    "lib": "cross-env NODE_ENV=production webpack",
     "lint": "prettier --write --config prettier.config.js \"./src/**/*.{md,css,sass,less,json,js,jsx,ts,tsx}\"",
-    "reinstall": "rm -rf node_modules && yarn install",
+    "reinstall": "rm -rf node_modules && yarn run install",
     "start": "yarn run lint && cross-env NODE_ENV=development webpack-dev-server",
-    "test": "echo no lint"
+    "test": "echo no test"
   },
   "dependencies": {
     "@misk/common": "^0.0.59",

--- a/misk/web/tabs/config/tsconfig.json
+++ b/misk/web/tabs/config/tsconfig.json
@@ -1,6 +1,6 @@
 {
-    "extends": "./node_modules/@misk/dev/tsconfig.base",
-    "compilerOptions": {
-        "outDir": "./lib/web/_tab/config"
-    }
+  "extends": "../../node_modules/@misk/dev/tsconfig.base",
+  "compilerOptions": {
+    "outDir": "./lib/web/_tab/config"
+  }
 }

--- a/misk/web/tabs/example/package.json
+++ b/misk/web/tabs/example/package.json
@@ -3,13 +3,14 @@
   "version": "0.0.3",
   "main": "src/index.ts",
   "scripts": {
-    "build": "yarn run lint && cross-env NODE_ENV=production webpack",
+    "build": "yarn run lint && yarn run lib",
     "clean": "rm -rf lib",
-    "ci-build": "yarn install && yarn clean && yarn build",
+    "ci-build": "yarn run clean && yarn run lib",
+    "lib": "cross-env NODE_ENV=production webpack",
     "lint": "prettier --write --config prettier.config.js \"./src/**/*.{md,css,sass,less,json,js,jsx,ts,tsx}\"",
-    "reinstall": "rm -rf node_modules && yarn install",
+    "reinstall": "rm -rf node_modules && yarn run install",
     "start": "yarn run lint && cross-env NODE_ENV=development webpack-dev-server",
-    "test": "echo no lint"
+    "test": "echo no test"
   },
   "dependencies": {
     "@misk/common": "^0.0.59",

--- a/misk/web/tabs/example/tsconfig.json
+++ b/misk/web/tabs/example/tsconfig.json
@@ -1,6 +1,6 @@
 {
-    "extends": "./node_modules/@misk/dev/tsconfig.base",
-    "compilerOptions": {
-        "outDir": "./lib/web/_tab/example"
-    }
+  "extends": "../../node_modules/@misk/dev/tsconfig.base",
+  "compilerOptions": {
+    "outDir": "./lib/web/_tab/example"
+  }
 }

--- a/misk/web/tabs/loader/package.json
+++ b/misk/web/tabs/loader/package.json
@@ -3,13 +3,14 @@
   "version": "0.0.3",
   "main": "src/index.ts",
   "scripts": {
-    "build": "yarn run lint && cross-env NODE_ENV=production webpack",
+    "build": "yarn run lint && yarn run lib",
     "clean": "rm -rf lib",
-    "ci-build": "yarn install && yarn clean && yarn build",
+    "ci-build": "yarn run clean && yarn run lib",
+    "lib": "cross-env NODE_ENV=production webpack",
     "lint": "prettier --write --config prettier.config.js \"./src/**/*.{md,css,sass,less,json,js,jsx,ts,tsx}\"",
-    "reinstall": "rm -rf node_modules && yarn install",
+    "reinstall": "rm -rf node_modules && yarn run install",
     "start": "yarn run lint && cross-env NODE_ENV=development webpack-dev-server",
-    "test": "echo no lint"
+    "test": "echo no test"
   },
   "dependencies": {
     "@misk/common": "^0.0.59",

--- a/misk/web/tabs/loader/tsconfig.json
+++ b/misk/web/tabs/loader/tsconfig.json
@@ -1,6 +1,6 @@
 {
-    "extends": "./node_modules/@misk/dev/tsconfig.base",
-    "compilerOptions": {
-        "outDir": "./lib/web/_tab/loader"
-    }
+  "extends": "../../node_modules/@misk/dev/tsconfig.base",
+  "compilerOptions": {
+    "outDir": "./lib/web/_tab/loader"
   }
+}


### PR DESCRIPTION
* Docker Web Build Cut significantly by having all tabs and `@misk` packages build off of the Docker image's `node_modules` instead of re-installing for each package
* New Docker Image: `misk-web@0.0.3`
* Travis CI updated to run `docker pull` in parallel
* Net improvement: build times cut by over 60%
  * Old Build: 55 mins 33 sec [Build Log](https://travis-ci.org/square/misk/builds/451368794)
  * New Build: 21 mins 47 sec [Build Log](https://travis-ci.org/square/misk/builds/451531611)