### PR TITLE
Partly transaction job queues

### DIFF
--- a/misk-aws/src/main/kotlin/misk/jobqueue/sqs/AwsSqsJobQueueModule.kt
+++ b/misk-aws/src/main/kotlin/misk/jobqueue/sqs/AwsSqsJobQueueModule.kt
@@ -11,6 +11,7 @@ import misk.cloud.aws.AwsRegion
 import misk.inject.KAbstractModule
 import misk.jobqueue.JobConsumer
 import misk.jobqueue.JobQueue
+import misk.jobqueue.TransactionalJobQueue
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
 
@@ -21,6 +22,7 @@ class AwsSqsJobQueueModule : KAbstractModule() {
     requireBinding(AwsRegion::class.java)
     bind<JobConsumer>().to<SqsJobConsumer>()
     bind<JobQueue>().to<SqsJobQueue>()
+    bind<TransactionalJobQueue>().to<SqsTransactionalJobQueue>()
     multibind<Service>().to<SqsJobConsumer>()
   }
 

--- a/misk-aws/src/main/kotlin/misk/jobqueue/sqs/SqsTransactionalJobQueue.kt
+++ b/misk-aws/src/main/kotlin/misk/jobqueue/sqs/SqsTransactionalJobQueue.kt
@@ -1,0 +1,46 @@
+package misk.jobqueue.sqs
+
+import misk.hibernate.Gid
+import misk.hibernate.Session
+import misk.jobqueue.JobQueue
+import misk.jobqueue.QueueName
+import misk.jobqueue.TransactionalJobQueue
+import misk.logging.getLogger
+import java.time.Duration
+import javax.inject.Inject
+import javax.inject.Singleton
+
+// Implements the TransactionalJobQueue interface by registering a post-commit hook that
+// forwards the message to SQS. It is not truly transactional, and is intended only for
+// development / staging while we build proper job forwarding from the replication stream,
+// but works so long as there is no application failure between the commit and the forward
+@Singleton
+internal class SqsTransactionalJobQueue @Inject internal constructor(
+  private val jobQueue: JobQueue
+): TransactionalJobQueue {
+  override fun enqueue(
+    session: Session,
+    queueName: QueueName,
+    body: String,
+    deliveryDelay: Duration?,
+    attributes: Map<String, String>
+  ) {
+    session.onPostCommit {
+      log.info { "forwarding to ${queueName.value}" }
+      jobQueue.enqueue(queueName, body, deliveryDelay, attributes)
+    }
+  }
+
+  override fun enqueue(
+    session: Session,
+    gid: Gid<*, *>,
+    queueName: QueueName,
+    body: String,
+    deliveryDelay: Duration?,
+    attributes: Map<String, String>
+  ) = enqueue(session, queueName, body, deliveryDelay, attributes)
+
+  companion object {
+    private val log = getLogger<SqsTransactionalJobQueue>()
+  }
+}

--- a/misk-aws/src/test/kotlin/misk/jobqueue/sqs/SqsJobQueueTest.kt
+++ b/misk-aws/src/test/kotlin/misk/jobqueue/sqs/SqsJobQueueTest.kt
@@ -183,9 +183,12 @@ internal class SqsJobQueueTest {
       it.acknowledge()
     }
 
-    subscription.close()
 
-    // Send 10 jobs, then wait a second to make sure none of them are delivered
+    // Close the subscription and wait for any currently outstanding long-polls to complete
+    subscription.close()
+    Thread.sleep(1001)
+
+    // Send 10 jobs, then wait again for the long-poll to complete make sure none of them are delivered
     for (i in (0 until 10)) {
       queue.enqueue(queueName, "this is job $i", attributes = mapOf("index" to i.toString()))
     }

--- a/misk-hibernate/src/main/kotlin/misk/hibernate/PostCommitHookFailedException.kt
+++ b/misk-hibernate/src/main/kotlin/misk/hibernate/PostCommitHookFailedException.kt
@@ -1,0 +1,12 @@
+package misk.hibernate
+
+/**
+ * [PostCommitHookFailedException] is raised when a code run as part of a post-commit hook
+ * fails. Because post-commit hooks are run after the transaction is committed, failure in these
+ * hooks does not cause the transaction to rollback, and applications may need to differentiate
+ * the two cases (exception occurred and caused the transaction to rollback, exception
+ * occurred during a post-commit hook
+ *
+ */
+class PostCommitHookFailedException(cause: Throwable) : Exception(cause) {
+}

--- a/misk-hibernate/src/main/kotlin/misk/hibernate/Session.kt
+++ b/misk-hibernate/src/main/kotlin/misk/hibernate/Session.kt
@@ -9,10 +9,25 @@ interface Session {
    * @throws IllegalStateException when save is called on a read only session.
    */
   fun <T : DbEntity<T>> save(entity: T): Id<T>
+
   fun <T : DbEntity<T>> load(id: Id<T>, type: KClass<T>): T
   fun shards(): Set<Shard>
   fun <T> target(shard: Shard, function: () -> T): T
   fun <T> useConnection(work: (Connection) -> T): T
+
+  /**
+   * Registers a hook that fires after the session transaction commits. Post-commit hooks cannot
+   * affect the disposition of the transaction; if a post-commit hook fails, the failure
+   * will be logged but not propagated to the application, as the transaction will have already
+   * committed
+   */
+  fun onPostCommit(work: () -> Unit)
+
+  /**
+   * Registers a hook that fires before the session's transaction commits. Failures in a pre-commit
+   * hook will cause the transaction to be rolled back.
+   */
+  fun onPreCommit(work: () -> Unit)
 }
 
 inline fun <reified T : DbEntity<T>> Session.load(id: Id<T>): T = load(id, T::class)

--- a/misk-hibernate/src/main/kotlin/misk/hibernate/Transacter.kt
+++ b/misk-hibernate/src/main/kotlin/misk/hibernate/Transacter.kt
@@ -32,6 +32,7 @@ interface Transacter {
 }
 
 fun Transacter.shards() = transaction { it.shards() }
+
 fun <T> Transacter.transaction(shard: Shard, lambda: (session: Session) -> T) =
     transaction { it.target(shard) { lambda(it) } }
 

--- a/misk-jobqueue/build.gradle
+++ b/misk-jobqueue/build.gradle
@@ -38,6 +38,7 @@ dependencies {
   compile dep.guice
   compile dep.guiceMultibindings
   compile project(':misk')
+  compile project(':misk-hibernate')
 
   testCompile project(':misk-testing')
 }

--- a/misk-jobqueue/src/main/kotlin/misk/jobqueue/TransactionalJobQueue.kt
+++ b/misk-jobqueue/src/main/kotlin/misk/jobqueue/TransactionalJobQueue.kt
@@ -1,0 +1,57 @@
+package misk.jobqueue
+
+import misk.hibernate.Gid
+import misk.hibernate.Session
+import java.time.Duration
+
+/**
+ * A [TransactionalJobQueue] supports enqueueing messages atomically in conjunction with
+ * making local database updates. With the transactional job queue, messages are written to
+ * a spooling table that is on the same database shard as the application's database entities,
+ * then forwards the messages asynchronously to the actual queueing system. Two variants
+ * of the [enqueue] operation exist - one which writes to the application's main shard, and
+ * another which writes to the shard on which a given entity group exists. Applications
+ * will typically use tbe second variant, writing jobs to the local shard in the context
+ * of a transaction that modifies the contents of an entity group.
+ */
+interface TransactionalJobQueue {
+  /**
+   * Enqueues a job to the database shard associated with the given entity group. Will
+   * throw an exception if the session is associated with a different entity group.
+   * @param session The database session to use in writing the job
+   * @param gid The id of the entity group with which the job should be associated
+   * @param queueName the name of the queue on which to place the job
+   * @param body The body of the job; can be any arbitrary string - it is up to the enqueuer and
+   * consumer to agree on the format of the body
+   * @param deliveryDelay If specified, the job will only become visible to the consumer after
+   * the provided duration. Used for jobs that should delay processing for a period of time.
+   * @param attributes Arbitrary contextual attributes associated with the job
+   */
+  fun enqueue(
+    session: Session,
+    gid: Gid<*, *>,
+    queueName: QueueName,
+    body: String,
+    deliveryDelay: Duration? = null,
+    attributes: Map<String, String> = mapOf()
+  )
+
+  /**
+   * Enqueues a job to the primary (unaffiliated) database shard . Will throw an exception if the
+   * session is associated with an entity group.
+   * @param session The database session to use in writing the job
+   * @param queueName the name of the queue on which to place the job
+   * @param body The body of the job; can be any arbitrary string - it is up to the enqueuer and
+   * consumer to agree on the format of the body
+   * @param deliveryDelay If specified, the job will only become visible to the consumer after
+   * the provided duration. Used for jobs that should delay processing for a period of time.
+   * @param attributes Arbitrary contextual attributes associated with the job
+   */
+  fun enqueue(
+    session: Session,
+    queueName: QueueName,
+    body: String,
+    deliveryDelay: Duration? = null,
+    attributes: Map<String, String> = mapOf()
+  )
+}


### PR DESCRIPTION
Enough of a transactional job queue to unblock development and initial staging testing. Honors transaction demarcations, but isn't resilient to process failures occurring after the local database commits.