### PR TITLE
Make cluster fakes more convenient for tests

### DIFF
--- a/misk/src/main/kotlin/misk/clustering/fake/FakeCluster.kt
+++ b/misk/src/main/kotlin/misk/clustering/fake/FakeCluster.kt
@@ -26,7 +26,9 @@ class FakeCluster internal constructor(
   constructor(resourceMapper: ExplicitClusterResourceMapper) :
       this(resourceMapper, DefaultCluster(self) { resourceMapper })
 
-  constructor() : this(ExplicitClusterResourceMapper())
+  constructor() : this(ExplicitClusterResourceMapper().apply {
+    setDefaultMapping(self)
+  })
 
   override fun watch(watch: ClusterWatch) {
     waitFor {

--- a/misk/src/main/kotlin/misk/clustering/fake/lease/FakeLeaseManager.kt
+++ b/misk/src/main/kotlin/misk/clustering/fake/lease/FakeLeaseManager.kt
@@ -5,21 +5,24 @@ import misk.clustering.lease.Lease
 import misk.clustering.lease.LeaseManager
 import javax.inject.Singleton
 
-/** A [FakeLeaseManager] provides explicit control over leases for the purposes of testing */
+/**
+ * A [FakeLeaseManager] provides explicit control over leases for the purposes of testing. By
+ * default a lease is considered held, but it can be explicitly marked as not held if desired
+ */
 @Singleton
 class FakeLeaseManager : LeaseManager {
-  private val heldLeases = newConcurrentHashSet<String>()
+  private val leasesHeldElsewhere = newConcurrentHashSet<String>()
 
   override fun requestLease(name: String): Lease = FakeLease(name, this)
 
-  fun isLeaseHeld(name: String) = heldLeases.contains(name)
+  fun isLeaseHeld(name: String) = !leasesHeldElsewhere.contains(name)
 
   fun markLeaseHeld(name: String) {
-    heldLeases.add(name)
+    leasesHeldElsewhere.remove(name)
   }
 
-  fun markLeaseReleased(name: String) {
-    heldLeases.remove(name)
+  fun markLeaseHeldElsewhere(name: String) {
+    leasesHeldElsewhere.add(name)
   }
 
   internal class FakeLease(

--- a/misk/src/test/kotlin/misk/clustering/fake/FakeClusterTest.kt
+++ b/misk/src/test/kotlin/misk/clustering/fake/FakeClusterTest.kt
@@ -27,6 +27,9 @@ internal class FakeClusterTest {
   }
 
   @Test fun clusterUsesExplicitResourceMapping() {
+    // By default all resources should be owned by us
+    assertThat(cluster.resourceMapper["my-object"]).isEqualTo(FakeCluster.self)
+
     cluster.resourceMapper.setDefaultMapping(Cluster.Member("zork", "192.168.12.0"))
     cluster.resourceMapper.addMapping("my-object", Cluster.Member("bork", "192.168.12.1"))
 

--- a/misk/src/test/kotlin/misk/clustering/fake/FakeLeaseManagerTest.kt
+++ b/misk/src/test/kotlin/misk/clustering/fake/FakeLeaseManagerTest.kt
@@ -21,15 +21,17 @@ internal class FakeLeaseManagerTest {
   @Test fun leaseRespectsAuthority() {
     val lease = leaseManager.requestLease("my-lease")
     val otherLease = leaseManager.requestLease("my-other-lease")
+
+    // leases are held by the current process by default
+    assertThat(lease.checkHeld()).isTrue()
+    assertThat(otherLease.checkHeld()).isTrue()
+
+    leaseManager.markLeaseHeldElsewhere("my-lease")
     assertThat(lease.checkHeld()).isFalse()
-    assertThat(otherLease.checkHeld()).isFalse()
+    assertThat(otherLease.checkHeld()).isTrue()
 
     leaseManager.markLeaseHeld("my-lease")
     assertThat(lease.checkHeld()).isTrue()
-    assertThat(otherLease.checkHeld()).isFalse()
-
-    leaseManager.markLeaseReleased("my-lease")
-    assertThat(lease.checkHeld()).isFalse()
-    assertThat(otherLease.checkHeld()).isFalse()
+    assertThat(otherLease.checkHeld()).isTrue()
   }
 }


### PR DESCRIPTION
1. All resources map to the current cluster member
2. All leases are owned by default