### PR TITLE
Lazy SessionFactory binding

### DIFF
--- a/misk-hibernate/src/main/kotlin/misk/hibernate/HibernateModule.kt
+++ b/misk-hibernate/src/main/kotlin/misk/hibernate/HibernateModule.kt
@@ -101,7 +101,7 @@ class HibernateModule(
     bind(transacterKey).toProvider(object : Provider<Transacter> {
       @com.google.inject.Inject(optional=true) val tracer: Tracer? = null
       override fun get(): RealTransacter = RealTransacter(
-          qualifier, sessionFactoryProvider.get(), config, tracer)
+          qualifier, sessionFactoryProvider, config, tracer)
     }).asSingleton()
 
     multibind<Service>().toProvider(object : Provider<SchemaMigratorService> {


### PR DESCRIPTION
Injecting a raw SessionFactory triggers an eager call to
SessionFactoryService.get() at injection time if you have a service that
(directly or indirectly) injects a Transacter. The SessionFactoryService
hasn't been started at that point which causes an IllegalStateException.
Using a Provider<SessionFactory> makes this call lazy which solves the
issue.