### PR TITLE
Fix Recursive binding in Config Module

### DIFF
--- a/misk/src/test/kotlin/misk/config/MiskConfigTest.kt
+++ b/misk/src/test/kotlin/misk/config/MiskConfigTest.kt
@@ -40,6 +40,9 @@ class MiskConfigTest {
   @field:[Inject]
   lateinit var webConfig: WebConfig
 
+  @field:[Inject]
+  lateinit var nestedConfig: NestedConfig
+
   @Test
   fun configIsProperlyParsed() {
     assertThat(testConfig.web).isEqualTo(WebConfig(5678, 30_000))
@@ -131,5 +134,10 @@ class MiskConfigTest {
     // NB(mmihic): These are absolute paths, so we can only look at the end which is consistent
     assertThat(filesInDir[0]).endsWith("/overrides/override-test-app1.yaml")
     assertThat(filesInDir[1]).endsWith("/overrides/override-test-app2.yaml")
+  }
+
+  @Test
+  fun bindImmediateChildren() {
+    assertThat(nestedConfig.child_nested.nested_value).isEqualTo("nested value")
   }
 }

--- a/misk/src/test/kotlin/misk/config/TestConfig.kt
+++ b/misk/src/test/kotlin/misk/config/TestConfig.kt
@@ -9,8 +9,12 @@ data class TestConfig(
     val consumer_a: ConsumerConfig,
     val consumer_b: ConsumerConfig,
     val duration: DurationConfig,
+    val nested: NestedConfig,
     val action_exception_log_level: ActionExceptionLogLevelConfig
 ) : Config
 
 data class ConsumerConfig(val min_items: Int = 0, val max_items: Int) : Config
 data class DurationConfig(val interval: Duration) : Config
+
+data class NestedConfig(val child_nested: ChildNestedConfig) : Config
+data class ChildNestedConfig(val nested_value: String): Config

--- a/misk/src/test/resources/test_app-common.yaml
+++ b/misk/src/test/resources/test_app-common.yaml
@@ -14,3 +14,7 @@ duration:
 
 action_exception_log_level:
   client_error_level: INFO
+
+nested:
+  child_nested:
+    nested_value: nested value


### PR DESCRIPTION
The bindConfigClassRecursively method was attempthing to bind all child configs at any recursive depth but was creating a bad provider for configs beyond the second level.
This was missed by the test cases by only checking for 2 levels of nested configs.
We will only bind the immediate children of the service's config while still allowing nested configs at an arbitrary depth
Binding any children beyond the immediate children could lead to some ambiguity.