### PR TITLE
Increase ServiceManager wait time to 60s

### DIFF
--- a/misk-testing/src/main/kotlin/misk/testing/MiskTestExtension.kt
+++ b/misk-testing/src/main/kotlin/misk/testing/MiskTestExtension.kt
@@ -53,7 +53,7 @@ internal class MiskTestExtension : BeforeEachCallback, AfterEachCallback {
 
     override fun beforeEach(context: ExtensionContext) {
       if (context.startService()) {
-        serviceManager.startAsync().awaitHealthy(20, TimeUnit.SECONDS)
+        serviceManager.startAsync().awaitHealthy(60, TimeUnit.SECONDS)
       }
     }
   }


### PR DESCRIPTION
This allows test services to pull remote docker images, which may take
awhile. This is obviously far from an exact science, but works in
practice.