### PR TITLE
Compose multiple docker containers together in a test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ jdk:
 install:
   - docker pull squareup/misk-web &
   - docker pull vitess/base &
-  - docker pull zookeeper:3.5.4-beta &
   - docker pull pafortin/goaws &
 
 script:

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -6,7 +6,7 @@ ext.dep = [
   "conscrypt": "org.conscrypt:conscrypt-openjdk-uber:1.1.4",
   "curatorFramework": "org.apache.curator:curator-framework:4.0.1",
   "datasourceProxy": "net.ttddyy:datasource-proxy:1.4.9",
-  "docker": "com.github.docker-java:docker-java:3.0.14",
+  "docker": "com.github.docker-java:docker-java:3.1.0-rc-5",
   "gcpCloudStorage": "com.google.cloud:google-cloud-storage:1.15.0",
   "gcpDatastore": "com.google.cloud:google-cloud-datastore:1.26.0",
   "gcpKms": "com.google.apis:google-api-services-cloudkms:v1-rev30-1.23.0",

--- a/misk-testing/build.gradle
+++ b/misk-testing/build.gradle
@@ -27,6 +27,7 @@ junitPlatform {
 }
 
 dependencies {
+  compile dep.docker
   compile dep.junitApi
   compile dep.junitParams
   compile dep.junitEngine

--- a/misk-testing/src/main/kotlin/misk/containers/Containers.kt
+++ b/misk-testing/src/main/kotlin/misk/containers/Containers.kt
@@ -1,0 +1,205 @@
+package misk.containers
+
+import com.github.dockerjava.api.DockerClient
+import com.github.dockerjava.api.command.CreateContainerCmd
+import com.github.dockerjava.api.exception.NotFoundException
+import com.github.dockerjava.api.model.Frame
+import com.github.dockerjava.core.DockerClientBuilder
+import com.github.dockerjava.core.async.ResultCallbackTemplate
+import com.github.dockerjava.core.command.PullImageResultCallback
+import com.github.dockerjava.core.command.WaitContainerResultCallback
+import com.github.dockerjava.netty.NettyDockerCmdExecFactory
+import misk.logging.getLogger
+import java.util.concurrent.atomic.AtomicBoolean
+
+/**
+ * A [Container] creates a Docker container for testing.
+ *
+ * Tests provide a lambda to build a [CreateContainerCmd]. The lambda must set
+ * [CreateContainerCmd.withName] and [CreateContainerCmd.withImage]. All other fields are
+ * optional. The [Composer] takes care of setting up the network.
+ *
+ * See [Composer] for an example.
+ */
+data class Container(val createCmd: CreateContainerCmd.() -> Unit)
+
+/**
+ * [Composer] composes many [Container]s together to use in a unit test.
+ *
+ * The [Container]s are networked using a dedicated Docker network. Tests need to expose ports
+ * in order for the test to communicate with the containers over 127.0.0.1.
+ *
+ * The following example composes Kafka and Zookeeper containers for testing. Kafka is exposed
+ * to the jUnit test via 127.0.0.1:9102. In this example, Zookeeper is not exposed to the test.
+ *
+ * ```
+ *     val zkContainer = Container {
+ *       this
+ *         .withImage("confluentinc/cp-zookeeper")
+ *         .withName("zookeeper")
+ *         .withEnv("ZOOKEEPER_CLIENT_PORT=2181")
+ *     }
+ *     val kafka = Container {
+ *       this
+ *         .withImage("confluentinc/cp-kafka"
+ *         .withName("kafka")
+ *         .withExposedPorts(ExposedPort.tcp(port))
+ *         .withPortBindings(Ports().apply {
+ *           bind(ExposedPort.tcp(9102), Ports.Binding.bindPort(9102))
+ *         })
+ *         .withEnv(
+ *           "KAFKA_ZOOKEEPER_CONNECT=zookeeper:2181",
+ *           "KAFKA_ADVERTISED_LISTENERS=PLAINTEXT://localhost:9102")
+ *         }
+ *     val composer = Composer("e-kafka", zkContainer, kafka)
+ *     composer.start()
+ * ```
+ */
+class Composer(private val name: String, private vararg val containers: Container) {
+
+  private val network = DockerNetwork("$name-net",
+      docker)
+  private val containerIds = mutableMapOf<String, String>()
+  private val running = AtomicBoolean(false)
+
+  fun start() {
+    if (!running.compareAndSet(false, true)) return
+    Runtime.getRuntime().addShutdownHook(Thread { stop() })
+
+    network.start()
+
+    for (container in containers) {
+      val name = container.name()
+      val create = docker.createContainerCmd("todo").apply(container.createCmd)
+      require(create.image != "todo") {
+        "must provide an image for container ${create.name}"
+      }
+
+      docker.listContainersCmd()
+          .withShowAll(true)
+          .withLabelFilter(mapOf("name" to name))
+          .exec()
+          .forEach {
+            log.info { "removing previous $name container with id ${it.id}" }
+            docker.removeContainerCmd(it.id).exec()
+          }
+
+      log.info { "pulling ${create.image} for $name container" }
+
+      val imageParts = create.image!!.split(":")
+      docker.pullImageCmd(imageParts[0])
+          .withTag(imageParts.getOrElse(1) { "latest" })
+          .exec(PullImageResultCallback()).awaitCompletion()
+
+      log.info { "starting $name container" }
+
+      val id = create
+          .withNetworkMode(network.id())
+          .withLabels(mapOf("name" to name))
+          .withTty(true)
+          .exec()
+          .id
+      containerIds[name] = id
+
+      docker.startContainerCmd(id).exec()
+      docker.logContainerCmd(id)
+          .withStdErr(true)
+          .withStdOut(true)
+          .withFollowStream(true)
+          .withSince(0)
+          .exec(LogContainerResultCallback())
+          .awaitStarted()
+
+      log.info { "started $name; container id=$id" }
+    }
+  }
+
+  private fun Container.name(): String {
+    val create = docker.createContainerCmd("todo").apply(createCmd)
+    require(!create.name.isNullOrBlank()) {
+      "must provide a name for the container"
+    }
+    return "$name/${create.name}"
+  }
+
+  fun stop() {
+    if (!running.compareAndSet(true, false)) return
+
+    for (container in containers) {
+      val name = container.name()
+      val id = containerIds[name]!!
+      log.info { "killing $name with container id $id" }
+      docker.removeContainerCmd(id).withForce(true).exec()
+
+      try {
+        log.info { "waiting for $name to terminate" }
+        docker.waitContainerCmd(id).exec(
+            GracefulWaitContainerResultCallback()).awaitCompletion()
+      } catch (th: Throwable) {
+        log.error(th) { "could not kill $name with container id $id" }
+      }
+
+      log.info { "killed $name with container id $id" }
+    }
+
+    network.stop()
+  }
+
+  private class LogContainerResultCallback : ResultCallbackTemplate<LogContainerResultCallback, Frame>() {
+    override fun onNext(item: Frame) {
+      String(item.payload).trim().split('\r', '\n').filter { it.isNotBlank() }.forEach {
+        log.info(it)
+      }
+    }
+  }
+
+  private class GracefulWaitContainerResultCallback : WaitContainerResultCallback() {
+    override fun onError(throwable: Throwable?) {
+      // this is ok, just meant that the container already terminated before we tried to wait
+      if (throwable is NotFoundException) {
+        return
+      }
+      super.onError(throwable)
+    }
+  }
+
+  private companion object {
+    private val log = getLogger<Composer>()
+    private val docker: DockerClient = DockerClientBuilder.getInstance()
+        .withDockerCmdExecFactory(NettyDockerCmdExecFactory())
+        .build()
+  }
+}
+
+private class DockerNetwork(private val name: String, private val docker: DockerClient) {
+
+  private lateinit var networkId: String
+
+  fun id(): String {
+    return networkId
+  }
+
+  fun start() {
+    log.info { "creating $name network" }
+
+    docker.listNetworksCmd().withNameFilter(name).exec().forEach {
+      log.info { "removing previous $name network with id ${it.id}" }
+      docker.removeNetworkCmd(it.id).exec()
+    }
+    networkId = docker.createNetworkCmd()
+        .withName(name)
+        .withCheckDuplicate(true)
+        .exec()
+        .id
+  }
+
+  fun stop() {
+    log.info { "removing $name network with id $networkId" }
+    docker.removeNetworkCmd(networkId).exec()
+  }
+
+  companion object {
+    private val log = getLogger<DockerNetwork>()
+  }
+}
+

--- a/misk-zookeeper/src/test/kotlin/misk/clustering/zookeeper/EmbeddedZookeeper.kt
+++ b/misk-zookeeper/src/test/kotlin/misk/clustering/zookeeper/EmbeddedZookeeper.kt
@@ -1,90 +1,43 @@
 package misk.clustering.zookeeper
 
-import com.github.dockerjava.api.DockerClient
-import com.github.dockerjava.api.exception.NotFoundException
 import com.github.dockerjava.api.model.ExposedPort
-import com.github.dockerjava.api.model.Frame
 import com.github.dockerjava.api.model.Ports
-import com.github.dockerjava.core.DockerClientBuilder
-import com.github.dockerjava.core.async.ResultCallbackTemplate
-import com.github.dockerjava.core.command.WaitContainerResultCallback
-import com.github.dockerjava.netty.NettyDockerCmdExecFactory
-import misk.logging.getLogger
-import java.util.concurrent.atomic.AtomicBoolean
+import misk.containers.Composer
+import misk.containers.Container
 
 class EmbeddedZookeeper(val basePort: Int) {
-  private lateinit var containerId: String
-  private val running = AtomicBoolean(false)
 
-  fun start() {
-    if (!running.compareAndSet(false, true)) return
+  private val composer: Composer
 
+  init {
     val clientPort = ExposedPort.tcp(CLIENT_PORT)
     val peerPort = ExposedPort.tcp(PEER_PORT)
     val leaderPort = ExposedPort.tcp(LEADER_PORT)
     val cmd = arrayOf("zkServer.sh", "start-foreground")
+    val container = Container {
+      this
+          .withImage("zookeeper:3.5.4-beta")
+          .withName("zookeeper")
+          .withCmd(cmd.toList())
+          .withExposedPorts(clientPort, peerPort, leaderPort)
+          .withPortBindings(Ports().apply {
+            bind(clientPort, Ports.Binding.bindPort(basePort))
+            bind(peerPort, Ports.Binding.bindPort(basePort + 1))
+            bind(leaderPort, Ports.Binding.bindPort(basePort + 2))
+          })
+    }
+    composer = Composer("e-zk", container)
+  }
 
-    log.info { "starting zookeeper with ${cmd.joinToString(" ")}" }
-
-    // NB(mmihic): curator is only compatible with 3.5.X
-    containerId = docker.createContainerCmd("zookeeper:3.5.4-beta")
-        .withCmd(cmd.toList())
-        .withExposedPorts(clientPort, peerPort, leaderPort)
-        .withPortBindings(Ports().apply {
-          bind(clientPort, Ports.Binding.bindPort(basePort))
-          bind(peerPort, Ports.Binding.bindPort(basePort + 1))
-          bind(leaderPort, Ports.Binding.bindPort(basePort + 2))
-        })
-        .withTty(true)
-        .exec()
-        .id
-
-    Runtime.getRuntime().addShutdownHook(Thread { stop() })
-
-    docker.startContainerCmd(containerId).exec()
-    docker.logContainerCmd(containerId)
-        .withStdErr(true)
-        .withStdOut(true)
-        .withFollowStream(true)
-        .withSince(0)
-        .exec(LogContainerResultCallback())
-        .awaitStarted()
-
-    log.info { "started zookeeper; container id=$containerId" }
+  fun start() {
+    composer.start()
   }
 
   fun stop() {
-    if (!running.compareAndSet(true, false)) return
-
-    log.info { "killing zookeeper with container id $containerId" }
-    docker.removeContainerCmd(containerId).withForce(true).exec()
-
-    try {
-      log.info { "waiting for zookeeper service to terminate" }
-      docker.waitContainerCmd(containerId).exec(WaitContainerResultCallback()).awaitCompletion()
-    } catch (e: NotFoundException) {
-      // this is ok, just meant that the container already terminated before we tried to wait
-    } catch (th: Throwable) {
-      log.error(th) { "could not kill zookeeper with container id $containerId" }
-    }
-
-    log.info { "killed zookeeper with container id $containerId" }
-  }
-
-  class LogContainerResultCallback : ResultCallbackTemplate<LogContainerResultCallback, Frame>() {
-    override fun onNext(item: Frame) {
-      String(item.payload).trim().split('\r', '\n').filter { it.isNotBlank() }.forEach {
-        log.info(it)
-      }
-    }
+    composer.stop()
   }
 
   companion object {
-    private val log = getLogger<EmbeddedZookeeper>()
-    private val docker: DockerClient = DockerClientBuilder.getInstance()
-        .withDockerCmdExecFactory(NettyDockerCmdExecFactory())
-        .build()
-
     const val PEER_PORT = 2888
     const val LEADER_PORT = 3888
     const val CLIENT_PORT = 2181


### PR DESCRIPTION
This allows multiple docker containers to communicate with each other in
a test. This was originally prototyped in an internal SQ repo for kafka
and zk. I'll be moving that code into misk shortly. For now just upgrade
the existing EmbeddedZookeeper to use it.