### PR TITLE
Use native junit task in Gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,6 +10,7 @@ if (rootProject.file("repositories.gradle").exists()) {
 }
 
 subprojects {
+  apply plugin: "java"
   buildscript {
     repositories {
       mavenCentral()
@@ -27,7 +28,6 @@ subprojects {
 
     dependencies {
       classpath dep.kotlinGradlePlugin
-      classpath 'org.junit.platform:junit-platform-gradle-plugin:1.0.2'
       classpath 'com.github.jengelman.gradle.plugins:shadow:2.0.2'
       classpath 'com.vanniktech:gradle-maven-publish-plugin:0.4.0'
     }
@@ -43,6 +43,17 @@ subprojects {
           }
         }
       }
+    }
+  }
+  dependencies {
+    testImplementation dep.junitApi
+    testRuntimeOnly dep.junitEngine
+  }
+  test {
+    useJUnitPlatform()
+    testLogging {
+      events "started", "passed", "skipped", "failed"
+      exceptionFormat = 'full'
     }
   }
 }

--- a/misk-aws/build.gradle
+++ b/misk-aws/build.gradle
@@ -1,7 +1,4 @@
-import org.junit.platform.console.options.Details
-
 apply plugin: 'kotlin'
-apply plugin: 'org.junit.platform.gradle.plugin'
 apply plugin: "com.vanniktech.maven.publish"
 
 compileKotlin {
@@ -20,10 +17,6 @@ compileTestKotlin {
 sourceSets {
   main.java.srcDirs += 'src/main/kotlin/'
   test.java.srcDirs += 'src/test/kotlin/'
-}
-
-junitPlatform {
-  details Details.VERBOSE
 }
 
 dependencies {

--- a/misk-eventrouter/build.gradle
+++ b/misk-eventrouter/build.gradle
@@ -1,7 +1,4 @@
-import org.junit.platform.console.options.Details
-
 apply plugin: 'kotlin'
-apply plugin: 'org.junit.platform.gradle.plugin'
 apply plugin: "com.vanniktech.maven.publish"
 
 compileKotlin {
@@ -20,10 +17,6 @@ compileTestKotlin {
 sourceSets {
   main.java.srcDirs += 'src/main/kotlin/'
   test.java.srcDirs += 'src/test/kotlin/'
-}
-
-junitPlatform {
-  details Details.VERBOSE
 }
 
 dependencies {

--- a/misk-events/build.gradle
+++ b/misk-events/build.gradle
@@ -1,5 +1,3 @@
-import org.junit.platform.console.options.Details
-
 buildscript {
   dependencies {
     classpath dep.kotlinNoArgPlugin
@@ -8,7 +6,6 @@ buildscript {
 
 apply plugin: 'kotlin'
 apply plugin: 'kotlin-jpa'
-apply plugin: 'org.junit.platform.gradle.plugin'
 apply plugin: "com.vanniktech.maven.publish"
 
 compileKotlin {
@@ -27,10 +24,6 @@ compileTestKotlin {
 sourceSets {
   main.java.srcDirs += 'src/main/kotlin/'
   test.java.srcDirs += 'src/test/kotlin/'
-}
-
-junitPlatform {
-  details Details.VERBOSE
 }
 
 dependencies {

--- a/misk-gcp-testing/build.gradle
+++ b/misk-gcp-testing/build.gradle
@@ -1,7 +1,4 @@
-import org.junit.platform.console.options.Details
-
 apply plugin: 'kotlin'
-apply plugin: 'org.junit.platform.gradle.plugin'
 apply plugin: "com.vanniktech.maven.publish"
 
 compileKotlin {
@@ -20,10 +17,6 @@ compileTestKotlin {
 sourceSets {
   main.java.srcDirs += 'src/main/kotlin/'
   test.java.srcDirs += 'src/test/kotlin/'
-}
-
-junitPlatform {
-  details Details.VERBOSE
 }
 
 dependencies {

--- a/misk-gcp/build.gradle
+++ b/misk-gcp/build.gradle
@@ -1,7 +1,4 @@
-import org.junit.platform.console.options.Details
-
 apply plugin: 'kotlin'
-apply plugin: 'org.junit.platform.gradle.plugin'
 apply plugin: "com.vanniktech.maven.publish"
 
 compileKotlin {
@@ -20,10 +17,6 @@ compileTestKotlin {
 sourceSets {
   main.java.srcDirs += 'src/main/kotlin/'
   test.java.srcDirs += 'src/test/kotlin/'
-}
-
-junitPlatform {
-  details Details.VERBOSE
 }
 
 dependencies {

--- a/misk-grpc-tests/build.gradle
+++ b/misk-grpc-tests/build.gradle
@@ -1,5 +1,3 @@
-import org.junit.platform.console.options.Details
-
 buildscript {
   dependencies {
     classpath dep.protobufGradlePlugin
@@ -7,7 +5,6 @@ buildscript {
 }
 
 apply plugin: 'kotlin'
-apply plugin: 'org.junit.platform.gradle.plugin'
 apply plugin: "com.vanniktech.maven.publish"
 apply plugin: 'java'
 apply plugin: 'com.google.protobuf'
@@ -52,10 +49,6 @@ sourceSets {
   main.java.srcDirs += 'build/generated/source/proto/main/grpc'
   main.java.srcDirs += 'build/generated/source/proto/main/java'
   test.java.srcDirs += 'src/test/kotlin/'
-}
-
-junitPlatform {
-  details Details.VERBOSE
 }
 
 dependencies {

--- a/misk-hibernate-testing/build.gradle
+++ b/misk-hibernate-testing/build.gradle
@@ -1,7 +1,4 @@
-import org.junit.platform.console.options.Details
-
 apply plugin: 'kotlin'
-apply plugin: 'org.junit.platform.gradle.plugin'
 apply plugin: "com.vanniktech.maven.publish"
 
 compileKotlin {
@@ -20,10 +17,6 @@ compileTestKotlin {
 sourceSets {
   main.java.srcDirs += 'src/main/kotlin/'
   test.java.srcDirs += 'src/test/kotlin/'
-}
-
-junitPlatform {
-  details Details.VERBOSE
 }
 
 dependencies {

--- a/misk-hibernate/build.gradle
+++ b/misk-hibernate/build.gradle
@@ -1,5 +1,3 @@
-import org.junit.platform.console.options.Details
-
 buildscript {
   dependencies {
     classpath dep.kotlinNoArgPlugin
@@ -8,7 +6,6 @@ buildscript {
 
 apply plugin: 'kotlin'
 apply plugin: 'kotlin-jpa'
-apply plugin: 'org.junit.platform.gradle.plugin'
 apply plugin: "com.vanniktech.maven.publish"
 
 compileKotlin {
@@ -27,10 +24,6 @@ compileTestKotlin {
 sourceSets {
   main.java.srcDirs += 'src/main/kotlin/'
   test.java.srcDirs += 'src/test/kotlin/'
-}
-
-junitPlatform {
-  details Details.VERBOSE
 }
 
 dependencies {

--- a/misk-jaeger/build.gradle
+++ b/misk-jaeger/build.gradle
@@ -1,7 +1,4 @@
-import org.junit.platform.console.options.Details
-
 apply plugin: 'kotlin'
-apply plugin: 'org.junit.platform.gradle.plugin'
 apply plugin: "com.vanniktech.maven.publish"
 
 compileKotlin {
@@ -20,10 +17,6 @@ compileTestKotlin {
 sourceSets {
   main.java.srcDirs += 'src/main/kotlin/'
   test.java.srcDirs += 'src/test/kotlin/'
-}
-
-junitPlatform {
-  details Details.VERBOSE
 }
 
 dependencies {

--- a/misk-jobqueue/build.gradle
+++ b/misk-jobqueue/build.gradle
@@ -1,5 +1,3 @@
-import org.junit.platform.console.options.Details
-
 buildscript {
   dependencies {
     classpath dep.kotlinNoArgPlugin
@@ -8,7 +6,6 @@ buildscript {
 
 apply plugin: 'kotlin'
 apply plugin: 'kotlin-jpa'
-apply plugin: 'org.junit.platform.gradle.plugin'
 apply plugin: "com.vanniktech.maven.publish"
 
 compileKotlin {
@@ -27,10 +24,6 @@ compileTestKotlin {
 sourceSets {
   main.java.srcDirs += 'src/main/kotlin/'
   test.java.srcDirs += 'src/test/kotlin/'
-}
-
-junitPlatform {
-  details Details.VERBOSE
 }
 
 dependencies {

--- a/misk-metrics-digester/build.gradle
+++ b/misk-metrics-digester/build.gradle
@@ -1,7 +1,4 @@
-import org.junit.platform.console.options.Details
-
 apply plugin: 'kotlin'
-apply plugin: 'org.junit.platform.gradle.plugin'
 apply plugin: "com.vanniktech.maven.publish"
 
 compileKotlin {
@@ -22,10 +19,6 @@ sourceSets {
     test.java.srcDirs += 'src/test/kotlin/'
 }
 
-junitPlatform {
-    details Details.VERBOSE
-}
- 
 dependencies {
     compile dep.tracingJaeger
     compile project(':misk')

--- a/misk-prometheus/build.gradle
+++ b/misk-prometheus/build.gradle
@@ -1,7 +1,4 @@
-import org.junit.platform.console.options.Details
-
 apply plugin: 'kotlin'
-apply plugin: 'org.junit.platform.gradle.plugin'
 apply plugin: "com.vanniktech.maven.publish"
 
 compileKotlin {
@@ -20,10 +17,6 @@ compileTestKotlin {
 sourceSets {
   main.java.srcDirs += 'src/main/kotlin/'
   test.java.srcDirs += 'src/test/kotlin/'
-}
-
-junitPlatform {
-  details Details.VERBOSE
 }
 
 dependencies {

--- a/misk-testing/build.gradle
+++ b/misk-testing/build.gradle
@@ -1,7 +1,4 @@
-import org.junit.platform.console.options.Details
-
 apply plugin: 'kotlin'
-apply plugin: 'org.junit.platform.gradle.plugin'
 apply plugin: "com.vanniktech.maven.publish"
 
 compileKotlin {
@@ -20,10 +17,6 @@ compileTestKotlin {
 sourceSets {
   main.java.srcDirs += 'src/main/kotlin/'
   test.java.srcDirs += 'src/test/kotlin/'
-}
-
-junitPlatform {
-  details Details.VERBOSE
 }
 
 dependencies {

--- a/misk-zipkin/build.gradle
+++ b/misk-zipkin/build.gradle
@@ -1,7 +1,4 @@
-import org.junit.platform.console.options.Details
-
 apply plugin: 'kotlin'
-apply plugin: 'org.junit.platform.gradle.plugin'
 apply plugin: "com.vanniktech.maven.publish"
 
 compileKotlin {
@@ -20,10 +17,6 @@ compileTestKotlin {
 sourceSets {
   main.java.srcDirs += 'src/main/kotlin/'
   test.java.srcDirs += 'src/test/kotlin/'
-}
-
-junitPlatform {
-  details Details.VERBOSE
 }
 
 dependencies {

--- a/misk-zookeeper/build.gradle
+++ b/misk-zookeeper/build.gradle
@@ -1,5 +1,3 @@
-import org.junit.platform.console.options.Details
-
 buildscript {
   dependencies {
     classpath dep.kotlinNoArgPlugin
@@ -8,7 +6,6 @@ buildscript {
 
 apply plugin: 'kotlin'
 apply plugin: 'kotlin-jpa'
-apply plugin: 'org.junit.platform.gradle.plugin'
 apply plugin: "com.vanniktech.maven.publish"
 
 compileKotlin {
@@ -27,10 +24,6 @@ compileTestKotlin {
 sourceSets {
   main.java.srcDirs += 'src/main/kotlin/'
   test.java.srcDirs += 'src/test/kotlin/'
-}
-
-junitPlatform {
-  details Details.VERBOSE
 }
 
 dependencies {

--- a/misk/build.gradle
+++ b/misk/build.gradle
@@ -1,12 +1,9 @@
-import org.junit.platform.console.options.Details
-
 apply plugin: 'kotlin'
 kotlin {
   experimental {
     coroutines 'enable'
   }
 }
-apply plugin: 'org.junit.platform.gradle.plugin'
 apply plugin: 'com.vanniktech.maven.publish'
 apply from: rootProject.file("gradle/localdb.gradle")
 apply from: "https://raw.githubusercontent.com/square/misk-web/master/gradle/web.gradle"
@@ -37,10 +34,6 @@ sourceSets {
 }
 
 jar.dependsOn web
-
-junitPlatform {
-  details Details.VERBOSE
-}
 
 dependencies {
   compile dep.kotlinStdLib

--- a/samples/exemplar/build.gradle
+++ b/samples/exemplar/build.gradle
@@ -1,5 +1,4 @@
 apply plugin: 'kotlin'
-apply plugin: 'org.junit.platform.gradle.plugin'
 apply plugin: "com.vanniktech.maven.publish"
 apply plugin: 'com.github.johnrengelman.shadow'
 

--- a/samples/exemplarchat/build.gradle
+++ b/samples/exemplarchat/build.gradle
@@ -1,5 +1,4 @@
 apply plugin: 'kotlin'
-apply plugin: 'org.junit.platform.gradle.plugin'
 apply plugin: "com.vanniktech.maven.publish"
 apply plugin: 'com.github.johnrengelman.shadow'
 


### PR DESCRIPTION
The junit plugin has been deprecated since native support was introduced
in 4.6.

https://github.com/junit-team/junit5/issues/1317

Also add some logging options to make the logs more readable. By default
all the stdout is skipped. It can be enabled with --info