### PR TITLE
Don't upload artifacts for samples

### DIFF
--- a/samples/build.gradle
+++ b/samples/build.gradle
@@ -1,0 +1,10 @@
+// Don't upload samples subprojects
+uploadArchives {
+  onlyIf { false }
+}
+
+subprojects {
+    uploadArchives {
+      onlyIf { false }
+    }
+}

--- a/samples/exemplar/build.gradle
+++ b/samples/exemplar/build.gradle
@@ -1,4 +1,3 @@
-apply plugin: "com.vanniktech.maven.publish"
 apply plugin: 'com.github.johnrengelman.shadow'
 
 dependencies {
@@ -28,8 +27,4 @@ shadowJar {
 
 artifacts {
   archives shadowJar
-}
-
-uploadArchives {
-  it.onlyIf { false }
 }

--- a/samples/exemplarchat/build.gradle
+++ b/samples/exemplarchat/build.gradle
@@ -1,4 +1,3 @@
-apply plugin: "com.vanniktech.maven.publish"
 apply plugin: 'com.github.johnrengelman.shadow'
 
 dependencies {
@@ -32,8 +31,4 @@ shadowJar {
 
 artifacts {
   archives shadowJar
-}
-
-uploadArchives {
-  it.onlyIf { false }
 }


### PR DESCRIPTION
We were never uploading these anyways, but a previous change in
#691 accidentally forced all
subprojects into uploading. So we now we need to explicitly opt out for
samples.