### PR TITLE
Don't bind RedisConfig in RedisModule

### DIFF
--- a/misk-redis/src/main/kotlin/misk/redis/RedisModule.kt
+++ b/misk-redis/src/main/kotlin/misk/redis/RedisModule.kt
@@ -6,9 +6,8 @@ import com.google.inject.Singleton
 import misk.inject.KAbstractModule
 import redis.clients.jedis.Jedis
 
-class RedisModule(val config: RedisConfig): KAbstractModule() {
+class RedisModule : KAbstractModule() {
   override fun configure() {
-    bind<RedisConfig>().toInstance(config)
     multibind<Service>().to<RedisService>()
   }
 


### PR DESCRIPTION
RedisConfig will already be bound if it's present in the service's config.