### PR TITLE
SchemaValidator read default value of the column

### DIFF
--- a/misk-hibernate/src/main/kotlin/misk/hibernate/SchemaValidator.kt
+++ b/misk-hibernate/src/main/kotlin/misk/hibernate/SchemaValidator.kt
@@ -136,11 +136,8 @@ internal class SchemaValidator {
       "Database table \"${dbTable.name}\" is missing columns ${hibernateOnly.map { it.name }} found in hibernate \"${hibernateTable.name}\""
     }
 
-    // TODO (maacosta) how strict should we be here? If `DEFAULT NULL` column exists in the Db and hibernate
-    //                does not know about it hibernate can still do writes to db. However if we are going to do
-    //                lookups on this column it might not work. Do we look at queries?.
-    validate(dbOnly.isEmpty()) {
-      "Hibernate entity \"${hibernateTable.name}\" is missing columns ${dbOnly.map { it.name }} expected in table \"${dbTable.name}\""
+    validate(dbOnly.isEmpty() || dbOnly.all { it.hasDefaultValue || it.nullable }) {
+      "Hibernate entity \"${hibernateTable.name}\" is missing columns ${dbOnly.filter { !(it.hasDefaultValue || it.nullable) }.map { it.name }} expected in table \"${dbTable.name}\""
     }
 
     for ((dbColumn, hibernateColumn) in intersectionPairs) {

--- a/misk-hibernate/src/main/kotlin/misk/hibernate/SchemaValidator.kt
+++ b/misk-hibernate/src/main/kotlin/misk/hibernate/SchemaValidator.kt
@@ -61,8 +61,9 @@ internal class SchemaValidator {
 
       while (columnResultSet.next()) {
         columns += ColumnDeclaration(
-            columnResultSet.getString("COLUMN_NAME"),
-            columnResultSet.getString("IS_NULLABLE") == "YES")
+            name = columnResultSet.getString("COLUMN_NAME"),
+            nullable = columnResultSet.getString("IS_NULLABLE") == "YES",
+            hasDefaultValue = columnResultSet.getString("COLUMN_DEF")?.isNotBlank() ?: false)
       }
       schemaTables += TableDeclaration(tableName, columns)
     }
@@ -80,7 +81,8 @@ internal class SchemaValidator {
       val columns = mutableListOf<ColumnDeclaration>()
       while (columnsIt.hasNext()) {
         val column = columnsIt.next() as Column
-        columns += ColumnDeclaration(column.name, column.isNullable)
+        columns += ColumnDeclaration(column.name, column.isNullable,
+            column.defaultValue?.isNotBlank() ?: false)
       }
 
       hibernateTables += TableDeclaration(tableName, columns)
@@ -136,7 +138,7 @@ internal class SchemaValidator {
 
     // TODO (maacosta) how strict should we be here? If `DEFAULT NULL` column exists in the Db and hibernate
     //                does not know about it hibernate can still do writes to db. However if we are going to do
-    //                lookups on this column it might not work.. do we look at queries?.
+    //                lookups on this column it might not work. Do we look at queries?.
     validate(dbOnly.isEmpty()) {
       "Hibernate entity \"${hibernateTable.name}\" is missing columns ${dbOnly.map { it.name }} expected in table \"${dbTable.name}\""
     }
@@ -157,8 +159,8 @@ internal class SchemaValidator {
     }
 
     // We have that the hibernate column only needs to be null if the database is null.
-    // It's okay if hibernate is more strict.
-    validate(dbColumn.nullable || !hibernateColumn.nullable) {
+    // It's okay if hibernate is more strict. However, we shouldn't care that much if the column has a default value
+    validate(dbColumn.nullable || !hibernateColumn.nullable || dbColumn.hasDefaultValue) {
       "Column ${dbColumn.name} is NOT NULL in database but ${hibernateColumn.name} is nullable in hibernate"
     }
   }
@@ -279,7 +281,8 @@ internal data class TableDeclaration(
 
 internal data class ColumnDeclaration(
   override val name: String,
-  val nullable: Boolean
+  val nullable: Boolean,
+  val hasDefaultValue: Boolean
 ) : Declaration()
 
 internal data class Message(

--- a/misk-hibernate/src/test/kotlin/misk/hibernate/SchemaValidatorTest.kt
+++ b/misk-hibernate/src/test/kotlin/misk/hibernate/SchemaValidatorTest.kt
@@ -126,7 +126,7 @@ class SchemaValidatorTest {
   fun findMissingColumnsInHibernate() {
     assertThat(schemaValidationErrorMessage).contains(
         "Hibernate entity \"missing_columns_table\" is missing columns " +
-            "[tbl4_string_column_database, tbl4_int_column_database] " +
+            "[tbl4_string_column_database] " +
             "expected in table \"missing_columns_table\"")
   }
 

--- a/misk-hibernate/src/test/resources/misk/hibernate/schemavalidation-migrations/v1__schemavalidation.sql
+++ b/misk-hibernate/src/test/resources/misk/hibernate/schemavalidation-migrations/v1__schemavalidation.sql
@@ -5,5 +5,7 @@ CREATE TABLE `quoted_basic_table`(
   `tbl1_bin_nullable` VARBINARY(255),
   `tbl1_string` VARCHAR(255) NOT NULL,
   `tbl1_int` INT NOT NULL DEFAULT 0,
-  `tbl1_bin` VARBINARY(255) NOT NULL
+  `tbl1_bin` VARBINARY(255) NOT NULL,
+  `created_at` timestamp(3) NOT NULL DEFAULT NOW(3),
+  `updated_at` timestamp(3) NOT NULL DEFAULT NOW(3) ON UPDATE NOW(3)
 )

--- a/misk-hibernate/src/test/resources/misk/hibernate/schemavalidation-migrations/v5__schemavalidation.sql
+++ b/misk-hibernate/src/test/resources/misk/hibernate/schemavalidation-migrations/v5__schemavalidation.sql
@@ -1,7 +1,8 @@
 CREATE TABLE nullable_mismatch_table (
   id BIGINT NOT NULL PRIMARY KEY AUTO_INCREMENT,
   tbl5_both_notnull INT NOT NULL DEFAULT 0,
-  tbl5_hibernate_null INT NOT NULL DEFAULT 0,
+  tbl5_hibernate_null INT NOT NULL,
+  tbl5_hibernate_null_default INT NOT NULL DEFAULT 0,
   tbl5_both_null INT DEFAULT NULL,
   tbl5_database_null INT DEFAULT NULL
 )


### PR DESCRIPTION
Changes: 

* SchemaValidator accepts nullable hibernate columns if the column has a default. This change is useful for fields that are set by Misk listeners, like `created_at` and `updated_at`.
* We should ignore fields that are unknown by Hibernate, that doesn't break the insertion or updates. This change is useful to avoid coupling between application deployments and database schema migrations.