### PR TITLE
Add TestingResourceLoaderModule

### DIFF
--- a/misk/src/main/kotlin/misk/resources/ResourceLoaderModule.kt
+++ b/misk/src/main/kotlin/misk/resources/ResourceLoaderModule.kt
@@ -12,3 +12,21 @@ class ResourceLoaderModule : KAbstractModule() {
     mapBinder.addBinding("memory:").to<MemoryResourceLoaderBackend>()
   }
 }
+
+/**
+ * Can be used instead of [ResourceLoaderModule] in tests to load filesystem: resources from the
+ * classpath instead.
+ *
+ * The files should be located at the same path within the classpath. For example, if loading
+ * filesystem:/etc/secrets/password.txt, the file must exist at
+ * src/test/resources/etc/secrets/password.txt
+ */
+class TestingResourceLoaderModule : KAbstractModule() {
+  override fun configure() {
+    val mapBinder = MapBinder.newMapBinder(
+        binder(), String::class.java, ResourceLoader.Backend::class.java)
+    mapBinder.addBinding("classpath:").toInstance(ClasspathResourceLoaderBackend)
+    mapBinder.addBinding("filesystem:").toInstance(ClasspathResourceLoaderBackend)
+    mapBinder.addBinding("memory:").to<MemoryResourceLoaderBackend>()
+  }
+}


### PR DESCRIPTION
Allows replacing ResourceLoaderModule in tests so filesystem: resources
are read from the classpath: instead. This allows tests to use a config
with a filesystem: resource and not rely on the underlying host
filesystem. A good example is an InjectorTest that verifies the guice
Injector can be created for the PRODUCTION enviornment.