### PR TITLE
Add graceful shutdown for jetty

### DIFF
--- a/misk/src/main/kotlin/misk/web/jetty/JettyService.kt
+++ b/misk/src/main/kotlin/misk/web/jetty/JettyService.kt
@@ -126,6 +126,8 @@ class JettyService @Inject internal constructor(
     server.addManaged(servletContextHandler)
     server.handler = servletContextHandler
 
+    server.stopAtShutdown = true
+
     server.start()
 
     logger.info {


### PR DESCRIPTION
Adds a shutdown hook, so when we get a SIGTERM (like from kubernetes) we try to clear connections instead of shutting down