### PR TITLE
Split MiskServiceModule into real and testing

### DIFF
--- a/misk-aws/src/test/kotlin/misk/jobqueue/sqs/SqsJobQueueTest.kt
+++ b/misk-aws/src/test/kotlin/misk/jobqueue/sqs/SqsJobQueueTest.kt
@@ -10,7 +10,7 @@ import com.amazonaws.services.sqs.model.CreateQueueRequest
 import com.google.common.util.concurrent.Service
 import com.google.inject.Provides
 import com.google.inject.util.Modules
-import misk.MiskServiceModule
+import misk.MiskTestingServiceModule
 import misk.cloud.aws.AwsRegion
 import misk.inject.KAbstractModule
 import misk.jobqueue.Job
@@ -228,7 +228,7 @@ internal class SqsJobQueueTest {
   class TestModule : KAbstractModule() {
     override fun configure() {
       multibind<Service>().to<DockerSqs.Service>()
-      install(MiskServiceModule())
+      install(MiskTestingServiceModule())
       install(MockTracingBackendModule())
       install(Modules.override(AwsSqsJobQueueModule()).with(SQSTestModule()))
     }

--- a/misk-eventrouter/src/test/kotlin/misk/eventrouter/EventRouterTest.kt
+++ b/misk-eventrouter/src/test/kotlin/misk/eventrouter/EventRouterTest.kt
@@ -1,7 +1,7 @@
 package misk.eventrouter
 
 import com.google.inject.util.Modules
-import misk.MiskServiceModule
+import misk.MiskTestingServiceModule
 import misk.testing.MiskTest
 import misk.testing.MiskTestModule
 import org.assertj.core.api.Assertions.assertThat
@@ -11,7 +11,7 @@ import javax.inject.Inject
 @MiskTest(startService = false)
 internal class EventRouterTest {
   @MiskTestModule
-  val module = Modules.combine(MiskServiceModule(),
+  val module = Modules.combine(MiskTestingServiceModule(),
       EventRouterTestingModule(distributed = true))
 
   @Inject lateinit var machineA: RealEventRouter

--- a/misk-grpc-tests/src/test/kotlin/misk/grpc/MiskClientProtocServerTest.kt
+++ b/misk-grpc-tests/src/test/kotlin/misk/grpc/MiskClientProtocServerTest.kt
@@ -1,7 +1,7 @@
 package misk.grpc
 
 import com.google.inject.util.Modules
-import misk.MiskServiceModule
+import misk.MiskTestingServiceModule
 import misk.grpc.miskclient.MiskGrpcClientModule
 import misk.grpc.protocserver.RouteGuideProtocServiceModule
 import misk.testing.MiskTest
@@ -19,7 +19,7 @@ class MiskClientProtocServerTest {
   val module = Modules.combine(
       MiskGrpcClientModule(),
       RouteGuideProtocServiceModule(),
-      MiskServiceModule())
+      MiskTestingServiceModule())
 
   @Inject lateinit var grpcClientProvider: Provider<GrpcClient>
 

--- a/misk-grpc-tests/src/test/kotlin/misk/grpc/ProtocClientProtocServerTest.kt
+++ b/misk-grpc-tests/src/test/kotlin/misk/grpc/ProtocClientProtocServerTest.kt
@@ -2,7 +2,7 @@ package misk.grpc
 
 import com.google.inject.util.Modules
 import io.grpc.ManagedChannel
-import misk.MiskServiceModule
+import misk.MiskTestingServiceModule
 import misk.grpc.protocclient.ProtocGrpcClientModule
 import misk.grpc.protocserver.RouteGuideProtocServiceModule
 import misk.testing.MiskTest
@@ -21,7 +21,7 @@ class ProtocClientProtocServerTest {
   val module = Modules.combine(
       ProtocGrpcClientModule(),
       RouteGuideProtocServiceModule(),
-      MiskServiceModule())
+      MiskTestingServiceModule())
 
   @Inject lateinit var channelProvider: Provider<ManagedChannel>
 

--- a/misk-hibernate-testing/src/test/kotlin/misk/jdbc/TruncateTablesServiceTest.kt
+++ b/misk-hibernate-testing/src/test/kotlin/misk/jdbc/TruncateTablesServiceTest.kt
@@ -2,7 +2,7 @@ package misk.jdbc
 
 import com.google.inject.util.Providers
 import com.squareup.moshi.Moshi
-import misk.MiskServiceModule
+import misk.MiskTestingServiceModule
 import misk.config.Config
 import misk.config.MiskConfig
 import misk.environment.Environment
@@ -120,7 +120,7 @@ internal class TruncateTablesServiceTest {
   class TestModule : KAbstractModule() {
     override fun configure() {
       bind<Environment>().toInstance(Environment.TESTING)
-      install(MiskServiceModule())
+      install(MiskTestingServiceModule())
 
       val config = MiskConfig.load<TestConfig>("test_truncatetables_app", Environment.TESTING)
       install(HibernateModule(

--- a/misk-hibernate/src/test/kotlin/misk/hibernate/BoxedStringColumnTest.kt
+++ b/misk-hibernate/src/test/kotlin/misk/hibernate/BoxedStringColumnTest.kt
@@ -1,6 +1,6 @@
 package misk.hibernate
 
-import misk.MiskServiceModule
+import misk.MiskTestingServiceModule
 import misk.config.Config
 import misk.config.MiskConfig
 import misk.jdbc.DataSourceConfig
@@ -83,7 +83,7 @@ class BoxedStringColumnTest {
 
   class TestModule : KAbstractModule() {
     override fun configure() {
-      install(MiskServiceModule())
+      install(MiskTestingServiceModule())
       install(EnvironmentModule(Environment.TESTING))
 
       val config = MiskConfig.load<RootConfig>("boxedstring", Environment.TESTING)

--- a/misk-hibernate/src/test/kotlin/misk/hibernate/ByteStringColumnTest.kt
+++ b/misk-hibernate/src/test/kotlin/misk/hibernate/ByteStringColumnTest.kt
@@ -1,6 +1,6 @@
 package misk.hibernate
 
-import misk.MiskServiceModule
+import misk.MiskTestingServiceModule
 import misk.config.Config
 import misk.config.MiskConfig
 import misk.environment.Environment
@@ -86,7 +86,7 @@ class ByteStringColumnTest {
 
   class TestModule : KAbstractModule() {
     override fun configure() {
-      install(MiskServiceModule())
+      install(MiskTestingServiceModule())
       install(EnvironmentModule(Environment.TESTING))
 
       val config = MiskConfig.load<RootConfig>("bytestringcolumn", Environment.TESTING)

--- a/misk-hibernate/src/test/kotlin/misk/hibernate/JsonColumnTest.kt
+++ b/misk-hibernate/src/test/kotlin/misk/hibernate/JsonColumnTest.kt
@@ -1,6 +1,6 @@
 package misk.hibernate
 
-import misk.MiskServiceModule
+import misk.MiskTestingServiceModule
 import misk.config.Config
 import misk.config.MiskConfig
 import misk.environment.Environment
@@ -45,7 +45,7 @@ class JsonColumnTest {
 
   class TestModule : KAbstractModule() {
     override fun configure() {
-      install(MiskServiceModule())
+      install(MiskTestingServiceModule())
       install(EnvironmentModule(Environment.TESTING))
 
       val config = MiskConfig.load<RootConfig>("jsoncolumn", Environment.TESTING)

--- a/misk-hibernate/src/test/kotlin/misk/hibernate/MoviesTestModule.kt
+++ b/misk-hibernate/src/test/kotlin/misk/hibernate/MoviesTestModule.kt
@@ -1,7 +1,7 @@
 package misk.hibernate
 
 import com.google.inject.util.Modules
-import misk.MiskServiceModule
+import misk.MiskTestingServiceModule
 import misk.config.Config
 import misk.config.MiskConfig
 import misk.jdbc.DataSourceConfig
@@ -23,7 +23,7 @@ class MoviesTestModule(
   override fun configure() {
     install(LogCollectorModule())
     install(
-        Modules.override(MiskServiceModule()).with(FakeClockModule(), MockTracingBackendModule()))
+        Modules.override(MiskTestingServiceModule()).with(FakeClockModule(), MockTracingBackendModule()))
     install(EnvironmentModule(Environment.TESTING))
 
     val config = MiskConfig.load<MoviesConfig>("moviestestmodule", Environment.TESTING)

--- a/misk-hibernate/src/test/kotlin/misk/hibernate/PrimitiveColumnsTest.kt
+++ b/misk-hibernate/src/test/kotlin/misk/hibernate/PrimitiveColumnsTest.kt
@@ -1,6 +1,6 @@
 package misk.hibernate
 
-import misk.MiskServiceModule
+import misk.MiskTestingServiceModule
 import misk.config.Config
 import misk.config.MiskConfig
 import misk.jdbc.DataSourceConfig
@@ -42,7 +42,7 @@ class PrimitiveColumnsTest {
 
   class TestModule : KAbstractModule() {
     override fun configure() {
-      install(MiskServiceModule())
+      install(MiskTestingServiceModule())
       install(EnvironmentModule(Environment.TESTING))
 
       val config = MiskConfig.load<RootConfig>("primitivecolumns", Environment.TESTING)

--- a/misk-hibernate/src/test/kotlin/misk/hibernate/ProtoColumnTest.kt
+++ b/misk-hibernate/src/test/kotlin/misk/hibernate/ProtoColumnTest.kt
@@ -1,6 +1,6 @@
 package misk.hibernate
 
-import misk.MiskServiceModule
+import misk.MiskTestingServiceModule
 import misk.config.Config
 import misk.config.MiskConfig
 import misk.environment.Environment
@@ -87,7 +87,7 @@ class ProtoColumnTest {
   }
   class TestModule : KAbstractModule() {
     override fun configure() {
-      install(MiskServiceModule())
+      install(MiskTestingServiceModule())
       install(EnvironmentModule(Environment.TESTING))
 
       val config = MiskConfig.load<RootConfig>("protocolumn", Environment.TESTING)

--- a/misk-hibernate/src/test/kotlin/misk/hibernate/SchemaMigratorTest.kt
+++ b/misk-hibernate/src/test/kotlin/misk/hibernate/SchemaMigratorTest.kt
@@ -4,7 +4,7 @@ import com.google.common.util.concurrent.AbstractIdleService
 import com.google.common.util.concurrent.Service
 import com.google.inject.Key
 import misk.DependentService
-import misk.MiskServiceModule
+import misk.MiskTestingServiceModule
 import misk.config.Config
 import misk.config.MiskConfig
 import misk.environment.Environment
@@ -59,7 +59,7 @@ internal class SchemaMigratorTest {
   @MiskTestModule
   val module = object : KAbstractModule() {
     override fun configure() {
-      install(MiskServiceModule())
+      install(MiskTestingServiceModule())
       multibind<Service>().to<DropTablesService>()
       multibind<Service>().toInstance(
           PingDatabaseService(Movies::class, config.data_source, defaultEnv))

--- a/misk-hibernate/src/test/kotlin/misk/hibernate/SchemaValidatorTest.kt
+++ b/misk-hibernate/src/test/kotlin/misk/hibernate/SchemaValidatorTest.kt
@@ -2,7 +2,7 @@ package misk.hibernate
 
 import com.google.common.util.concurrent.Service
 import com.google.inject.Key
-import misk.MiskServiceModule
+import misk.MiskTestingServiceModule
 import misk.config.Config
 import misk.config.MiskConfig
 import misk.environment.Environment
@@ -42,7 +42,7 @@ class SchemaValidatorTest {
 
   inner class TestModule : KAbstractModule() {
     override fun configure() {
-      install(MiskServiceModule())
+      install(MiskTestingServiceModule())
       val qualifier = ValidationDb::class
 
       val dataSourceService =

--- a/misk-testing/src/main/kotlin/misk/web/WebTestingModule.kt
+++ b/misk-testing/src/main/kotlin/misk/web/WebTestingModule.kt
@@ -1,7 +1,7 @@
 package misk.web
 
 import com.google.inject.Provides
-import misk.MiskServiceModule
+import misk.MiskTestingServiceModule
 import misk.environment.Environment
 import misk.environment.EnvironmentModule
 import misk.inject.KAbstractModule
@@ -29,7 +29,7 @@ class WebTestingModule(
 ) : KAbstractModule() {
   override fun configure() {
     install(EnvironmentModule(Environment.TESTING))
-    install(MiskServiceModule())
+    install(MiskTestingServiceModule())
     install(MiskWebModule())
   }
 

--- a/misk-testing/src/test/kotlin/misk/logging/LogCollectorTest.kt
+++ b/misk-testing/src/test/kotlin/misk/logging/LogCollectorTest.kt
@@ -2,7 +2,7 @@ package misk.logging
 
 import ch.qos.logback.classic.Level
 import com.google.inject.util.Modules
-import misk.MiskServiceModule
+import misk.MiskTestingServiceModule
 import misk.testing.MiskTest
 import misk.testing.MiskTestModule
 import org.assertj.core.api.Assertions.assertThat
@@ -13,7 +13,7 @@ import javax.inject.Inject
 class LogCollectorTest {
   @MiskTestModule
   val module = Modules.combine(
-      MiskServiceModule(),
+      MiskTestingServiceModule(),
       LogCollectorModule()
   )
 

--- a/misk-testing/src/test/kotlin/misk/service/ServiceTestingModuleTest.kt
+++ b/misk-testing/src/test/kotlin/misk/service/ServiceTestingModuleTest.kt
@@ -6,7 +6,7 @@ import com.google.common.util.concurrent.ServiceManager
 import com.google.inject.Guice
 import com.google.inject.Key
 import misk.DependentService
-import misk.MiskServiceModule
+import misk.MiskTestingServiceModule
 import misk.inject.KAbstractModule
 import misk.inject.getInstance
 import misk.inject.keyOf
@@ -20,7 +20,7 @@ internal class ServiceTestingModuleTest {
   @Test fun serviceTestModuleAddsTestSpecificDependency() {
     val injector = Guice.createInjector(object : KAbstractModule() {
       override fun configure() {
-        install(MiskServiceModule())
+        install(MiskTestingServiceModule())
         multibind<Service>().to<LowestLevelService>()
         install(ServiceTestingModule.withExtraDependencies<AppService>(
             keyOf<ExternalServiceSpinupService>())

--- a/misk-zookeeper/src/test/kotlin/misk/clustering/zookeeper/ZkLeaseTest.kt
+++ b/misk-zookeeper/src/test/kotlin/misk/clustering/zookeeper/ZkLeaseTest.kt
@@ -1,7 +1,7 @@
 package misk.clustering.zookeeper
 
 import com.google.inject.util.Modules
-import misk.MiskServiceModule
+import misk.MiskTestingServiceModule
 import misk.clustering.Cluster
 import misk.clustering.fake.FakeCluster
 import misk.testing.MiskTest
@@ -18,7 +18,7 @@ import javax.inject.Inject
 
 @MiskTest(startService = true)
 internal class ZkLeaseTest {
-  @MiskTestModule private val module = Modules.combine(MiskServiceModule(), ZkTestModule())
+  @MiskTestModule private val module = Modules.combine(MiskTestingServiceModule(), ZkTestModule())
 
   @Inject lateinit var cluster: FakeCluster
   @Inject lateinit var leaseManager: ZkLeaseManager

--- a/misk/src/test/kotlin/misk/MiskServiceModuleTest.kt
+++ b/misk/src/test/kotlin/misk/MiskServiceModuleTest.kt
@@ -69,7 +69,7 @@ internal class MiskServiceModuleTest {
   @Test fun detectsNonSingletonServices() {
     assertThat(assertFailsWith<com.google.inject.ProvisionException> {
       val injector = Guice.createInjector(
-          MiskServiceModule(),
+          MiskTestingServiceModule(),
           object : KAbstractModule() {
             override fun configure() {
               // Should be recognized as singletons

--- a/misk/src/test/kotlin/misk/client/ClientMetricsInterceptorTest.kt
+++ b/misk/src/test/kotlin/misk/client/ClientMetricsInterceptorTest.kt
@@ -4,7 +4,7 @@ import com.google.inject.Guice
 import com.google.inject.Injector
 import com.google.inject.Provides
 import com.google.inject.name.Names
-import misk.MiskServiceModule
+import misk.MiskTestingServiceModule
 import misk.metrics.Histogram
 import misk.inject.KAbstractModule
 import misk.inject.getInstance
@@ -107,7 +107,7 @@ internal class ClientMetricsInterceptorTest {
 
   class ClientModule(val jetty: JettyService) : KAbstractModule() {
     override fun configure() {
-      install(MiskServiceModule())
+      install(MiskTestingServiceModule())
       install(PrometheusHistogramRegistryModule())
       install(TypedHttpClientModule.create<Pinger>("pinger", Names.named("pinger")))
       multibind<ClientNetworkInterceptor.Factory>().to<ClientMetricsInterceptor.Factory>()

--- a/misk/src/test/kotlin/misk/client/HttpClientEnvoyTest.kt
+++ b/misk/src/test/kotlin/misk/client/HttpClientEnvoyTest.kt
@@ -5,7 +5,7 @@ import com.google.inject.Provides
 import com.google.inject.name.Named
 import com.google.inject.name.Names
 import helpers.protos.Dinosaur
-import misk.MiskServiceModule
+import misk.MiskTestingServiceModule
 import misk.inject.KAbstractModule
 import misk.testing.MiskTest
 import misk.testing.MiskTestModule
@@ -73,7 +73,7 @@ internal class HttpClientEnvoyTest {
 
   class TestModule : KAbstractModule() {
     override fun configure() {
-      install(MiskServiceModule())
+      install(MiskTestingServiceModule())
 
       bind<MockWebServerService>().toInstance(MockWebServerService("@socket"))
       multibind<Service>().to<MockWebServerService>()

--- a/misk/src/test/kotlin/misk/client/HttpClientEventListenerTest.kt
+++ b/misk/src/test/kotlin/misk/client/HttpClientEventListenerTest.kt
@@ -1,10 +1,8 @@
 package misk.client
 
 import com.google.inject.Guice
-import com.google.inject.Provides
 import helpers.protos.Dinosaur
-import junit.framework.TestListener
-import misk.MiskServiceModule
+import misk.MiskTestingServiceModule
 import misk.inject.KAbstractModule
 import misk.inject.getInstance
 import misk.testing.MiskTest
@@ -55,7 +53,7 @@ internal class HttpClientEventListenerTest {
   class ClientModule(val jetty: JettyService, val eventListener : TestEventListener)
     : KAbstractModule() {
     override fun configure() {
-      install(MiskServiceModule())
+      install(MiskTestingServiceModule())
       install(DinoClientModule(jetty))
       bind<EventListener.Factory>().to<TestEventListenerFactory>()
       bind<TestEventListener>().toInstance(eventListener)

--- a/misk/src/test/kotlin/misk/client/ProtoMessageHttpClientTest.kt
+++ b/misk/src/test/kotlin/misk/client/ProtoMessageHttpClientTest.kt
@@ -4,7 +4,7 @@ import com.google.inject.Guice
 import com.google.inject.Provides
 import com.google.inject.name.Names
 import helpers.protos.Dinosaur
-import misk.MiskServiceModule
+import misk.MiskTestingServiceModule
 import misk.inject.KAbstractModule
 import misk.inject.getInstance
 import misk.testing.MiskTest
@@ -77,7 +77,7 @@ class ProtoMessageHttpClientTest {
   // need to create the client module _after_ we start the services
   class ClientModule(val jetty: JettyService) : KAbstractModule() {
     override fun configure() {
-      install(MiskServiceModule())
+      install(MiskTestingServiceModule())
       install(HttpClientModule("dinosaur", Names.named("dinosaur")))
     }
 

--- a/misk/src/test/kotlin/misk/client/TypedHttpClientInterceptorTest.kt
+++ b/misk/src/test/kotlin/misk/client/TypedHttpClientInterceptorTest.kt
@@ -3,7 +3,7 @@ package misk.client
 import com.google.inject.Guice
 import helpers.protos.Dinosaur
 import misk.Action
-import misk.MiskServiceModule
+import misk.MiskTestingServiceModule
 import misk.inject.KAbstractModule
 import misk.inject.getInstance
 import misk.testing.MiskTest
@@ -125,7 +125,7 @@ internal class TypedHttpClientInterceptorTest {
 
   class ClientModule(val jetty: JettyService) : KAbstractModule() {
     override fun configure() {
-      install(MiskServiceModule())
+      install(MiskTestingServiceModule())
       install(DinoClientModule(jetty))
       multibind<ClientNetworkInterceptor.Factory>().to<ClientHeaderInterceptor.Factory>()
       multibind<ClientApplicationInterceptor.Factory>().to<ClientNameInterceptor.Factory>()

--- a/misk/src/test/kotlin/misk/client/TypedHttpClientTest.kt
+++ b/misk/src/test/kotlin/misk/client/TypedHttpClientTest.kt
@@ -5,7 +5,7 @@ import com.google.inject.Injector
 import com.google.inject.Provides
 import com.google.inject.name.Names
 import helpers.protos.Dinosaur
-import misk.MiskServiceModule
+import misk.MiskTestingServiceModule
 import misk.inject.KAbstractModule
 import misk.inject.getInstance
 import misk.testing.MiskTest
@@ -101,7 +101,7 @@ internal class TypedHttpClientTest {
 
   class ClientModule(val jetty: JettyService) : KAbstractModule() {
     override fun configure() {
-      install(MiskServiceModule())
+      install(MiskTestingServiceModule())
       install(TypedHttpClientModule.create<ReturnADinosaur>("dinosaur", Names.named("dinosaur")))
       install(
           TypedHttpClientModule.create<ReturnAProtoDinosaur>("protoDino", Names.named("protoDino")))

--- a/misk/src/test/kotlin/misk/clustering/fake/FakeClusterTest.kt
+++ b/misk/src/test/kotlin/misk/clustering/fake/FakeClusterTest.kt
@@ -1,7 +1,7 @@
 package misk.clustering.fake
 
 import com.google.inject.util.Modules
-import misk.MiskServiceModule
+import misk.MiskTestingServiceModule
 import misk.clustering.Cluster
 import misk.testing.MiskTest
 import misk.testing.MiskTestModule
@@ -12,7 +12,7 @@ import javax.inject.Inject
 @MiskTest(startService = true)
 internal class FakeClusterTest {
   @MiskTestModule val module = Modules.combine(
-      MiskServiceModule(),
+      MiskTestingServiceModule(),
       FakeClusterModule()
   )
 

--- a/misk/src/test/kotlin/misk/clustering/fake/FakeLeaseManagerTest.kt
+++ b/misk/src/test/kotlin/misk/clustering/fake/FakeLeaseManagerTest.kt
@@ -1,7 +1,7 @@
 package misk.clustering.fake
 
 import com.google.inject.util.Modules
-import misk.MiskServiceModule
+import misk.MiskTestingServiceModule
 import misk.clustering.fake.lease.FakeLeaseManager
 import misk.testing.MiskTest
 import misk.testing.MiskTestModule
@@ -12,7 +12,7 @@ import javax.inject.Inject
 @MiskTest(startService = true)
 internal class FakeLeaseManagerTest {
   @MiskTestModule val module = Modules.combine(
-      MiskServiceModule(),
+      MiskTestingServiceModule(),
       FakeClusterModule()
   )
 

--- a/misk/src/test/kotlin/misk/clustering/kubernetes/KubernetesClusterTest.kt
+++ b/misk/src/test/kotlin/misk/clustering/kubernetes/KubernetesClusterTest.kt
@@ -7,7 +7,7 @@ import io.kubernetes.client.models.V1ObjectMeta
 import io.kubernetes.client.models.V1Pod
 import io.kubernetes.client.models.V1PodStatus
 import io.kubernetes.client.util.Watches
-import misk.MiskServiceModule
+import misk.MiskTestingServiceModule
 import misk.clustering.Cluster
 import misk.clustering.ClusterHashRing
 import misk.clustering.DefaultCluster
@@ -26,7 +26,7 @@ import javax.inject.Inject
 @MiskTest(startService = true)
 internal class KubernetesClusterTest {
   @MiskTestModule val module: Module = Modules.combine(
-      MiskServiceModule(),
+      MiskTestingServiceModule(),
       object : KAbstractModule() {
         override fun configure() {
           install(KubernetesClusterModule())

--- a/misk/src/test/kotlin/misk/config/MiskConfigTest.kt
+++ b/misk/src/test/kotlin/misk/config/MiskConfigTest.kt
@@ -1,7 +1,6 @@
 package misk.config
 
 import com.google.inject.util.Modules
-import misk.MiskServiceModule
 import misk.environment.Environment
 import misk.environment.EnvironmentModule
 import misk.testing.MiskTest

--- a/misk/src/test/kotlin/misk/flags/FlagPropertiesTest.kt
+++ b/misk/src/test/kotlin/misk/flags/FlagPropertiesTest.kt
@@ -1,7 +1,7 @@
 package misk.flags
 
 import com.google.inject.name.Named
-import misk.MiskServiceModule
+import misk.MiskTestingServiceModule
 import misk.flags.memory.InMemoryFlagStore
 import misk.flags.memory.InMemoryFlagStoreModule
 import misk.inject.KAbstractModule
@@ -28,7 +28,7 @@ class FlagPropertiesTest {
   @MiskTestModule
   val testModule = object : KAbstractModule() {
     override fun configure() {
-      install(MiskServiceModule())
+      install(MiskTestingServiceModule())
       install(InMemoryFlagStoreModule())
       install(object : FlagsModule() {
         override fun configureFlags() {

--- a/misk/src/test/kotlin/misk/flags/FlagsTest.kt
+++ b/misk/src/test/kotlin/misk/flags/FlagsTest.kt
@@ -1,7 +1,7 @@
 package misk.flags
 
 import com.google.inject.name.Named
-import misk.MiskServiceModule
+import misk.MiskTestingServiceModule
 import misk.flags.memory.InMemoryFlagStore
 import misk.flags.memory.InMemoryFlagStoreModule
 import misk.inject.KAbstractModule
@@ -19,7 +19,7 @@ class FlagsTest {
   @MiskTestModule
   val testModule = object : KAbstractModule() {
     override fun configure() {
-      install(MiskServiceModule())
+      install(MiskTestingServiceModule())
       install(InMemoryFlagStoreModule())
       install(object : FlagsModule() {
         override fun configureFlags() {

--- a/misk/src/test/kotlin/misk/grpc/GrpcConnectivityTest.kt
+++ b/misk/src/test/kotlin/misk/grpc/GrpcConnectivityTest.kt
@@ -4,7 +4,7 @@ import com.google.inject.Guice
 import com.google.inject.Provides
 import com.squareup.protos.test.grpc.HelloReply
 import com.squareup.protos.test.grpc.HelloRequest
-import misk.MiskServiceModule
+import misk.MiskTestingServiceModule
 import misk.client.HttpClientEndpointConfig
 import misk.client.HttpClientModule
 import misk.client.HttpClientSSLConfig
@@ -108,7 +108,7 @@ class GrpcConnectivityTest {
   // _after_ we start the services
   class ClientModule(val jetty: JettyService) : KAbstractModule() {
     override fun configure() {
-      install(MiskServiceModule())
+      install(MiskTestingServiceModule())
       install(HttpClientModule("default"))
     }
 

--- a/misk/src/test/kotlin/misk/logging/LoggingTest.kt
+++ b/misk/src/test/kotlin/misk/logging/LoggingTest.kt
@@ -3,7 +3,7 @@ package misk.logging
 import ch.qos.logback.classic.Level
 import ch.qos.logback.classic.LoggerContext
 import com.google.inject.util.Modules
-import misk.MiskServiceModule
+import misk.MiskTestingServiceModule
 import misk.testing.MiskTest
 import misk.testing.MiskTestModule
 import org.assertj.core.api.Assertions.assertThat
@@ -16,7 +16,7 @@ import javax.inject.Inject
 @MiskTest(startService = true)
 class LoggingTest {
   @MiskTestModule
-  val testModule = Modules.combine(MiskServiceModule(), LogCollectorModule())
+  val testModule = Modules.combine(MiskTestingServiceModule(), LogCollectorModule())
 
   @Inject private lateinit var logCollector: LogCollector
 

--- a/misk/src/test/kotlin/misk/moshi/ByteStringAdapterTest.kt
+++ b/misk/src/test/kotlin/misk/moshi/ByteStringAdapterTest.kt
@@ -1,7 +1,7 @@
 package misk.moshi
 
 import com.squareup.moshi.Moshi
-import misk.MiskServiceModule
+import misk.MiskTestingServiceModule
 import misk.testing.MiskTest
 import misk.testing.MiskTestModule
 import okio.ByteString
@@ -13,7 +13,7 @@ import javax.inject.Inject
 @MiskTest(startService = false)
 internal class ByteStringAdapterTest {
   @MiskTestModule
-  val module = MiskServiceModule()
+  val module = MiskTestingServiceModule()
 
   @Inject
   lateinit var moshi: Moshi

--- a/misk/src/test/kotlin/misk/moshi/wire/WireMessageAdapterTest.kt
+++ b/misk/src/test/kotlin/misk/moshi/wire/WireMessageAdapterTest.kt
@@ -4,7 +4,7 @@ import com.squareup.moshi.Moshi
 import com.squareup.protos.test.parsing.Robot
 import com.squareup.protos.test.parsing.Shipment
 import com.squareup.protos.test.parsing.Warehouse
-import misk.MiskServiceModule
+import misk.MiskTestingServiceModule
 import misk.testing.MiskTest
 import misk.testing.MiskTestModule
 import okio.ByteString.Companion.encodeUtf8
@@ -17,7 +17,7 @@ import kotlin.test.assertFailsWith
 @MiskTest(startService = false)
 internal class WireMessageAdapterTest {
   @MiskTestModule
-  val module = MiskServiceModule()
+  val module = MiskTestingServiceModule()
 
   @Inject
   lateinit var moshi: Moshi

--- a/misk/src/test/kotlin/misk/resources/ResourceLoaderTest.kt
+++ b/misk/src/test/kotlin/misk/resources/ResourceLoaderTest.kt
@@ -1,7 +1,7 @@
 package misk.resources
 
 import com.google.inject.util.Modules
-import misk.MiskServiceModule
+import misk.MiskTestingServiceModule
 import misk.testing.MiskTest
 import misk.testing.MiskTestModule
 import misk.testing.TemporaryFolder
@@ -17,7 +17,7 @@ import kotlin.test.assertFailsWith
 @MiskTest
 class ResourceLoaderTest {
   @MiskTestModule
-  val module = Modules.combine(MiskServiceModule(), TemporaryFolderModule())
+  val module = Modules.combine(ResourceLoaderModule(), TemporaryFolderModule())
 
   @Inject lateinit var resourceLoader: ResourceLoader
   @Inject lateinit var tempFolder: TemporaryFolder

--- a/misk/src/test/kotlin/misk/security/ssl/PemComboFileTest.kt
+++ b/misk/src/test/kotlin/misk/security/ssl/PemComboFileTest.kt
@@ -1,6 +1,6 @@
 package misk.security.ssl
 
-import misk.MiskServiceModule
+import misk.MiskTestingServiceModule
 import misk.testing.MiskTest
 import misk.testing.MiskTestModule
 import org.assertj.core.api.Assertions.assertThat
@@ -10,7 +10,7 @@ import javax.inject.Inject
 @MiskTest
 internal class PemComboFileTest {
   @MiskTestModule
-  val module = MiskServiceModule()
+  val module = MiskTestingServiceModule()
 
   val clientComboPemPath = "classpath:/ssl/client_cert_key_combo.pem"
   val clientRsaComboPemPath = "classpath:/ssl/client_rsa_cert_key_combo.pem"

--- a/misk/src/test/kotlin/misk/security/ssl/SslLoaderTest.kt
+++ b/misk/src/test/kotlin/misk/security/ssl/SslLoaderTest.kt
@@ -1,6 +1,6 @@
 package misk.security.ssl
 
-import misk.MiskServiceModule
+import misk.MiskTestingServiceModule
 import misk.security.ssl.SslLoader.Companion.FORMAT_JCEKS
 import misk.security.ssl.SslLoader.Companion.FORMAT_PEM
 import misk.testing.MiskTest
@@ -13,7 +13,7 @@ import javax.inject.Inject
 @MiskTest
 internal class SslLoaderTest {
   @MiskTestModule
-  val module = MiskServiceModule()
+  val module = MiskTestingServiceModule()
 
   val clientComboPemPath = "classpath:/ssl/client_cert_key_combo.pem"
   val clientTrustPemPath = "classpath:/ssl/client_cert.pem"

--- a/misk/src/test/kotlin/misk/tasks/RepeatedTaskQueueTest.kt
+++ b/misk/src/test/kotlin/misk/tasks/RepeatedTaskQueueTest.kt
@@ -3,7 +3,7 @@ package misk.tasks
 import com.google.common.util.concurrent.Service
 import com.google.inject.Provides
 import com.google.inject.util.Modules
-import misk.MiskServiceModule
+import misk.MiskTestingServiceModule
 import misk.backoff.ExponentialBackoff
 import misk.backoff.FlatBackoff
 import misk.backoff.retry
@@ -454,7 +454,7 @@ internal class RepeatedTaskQueueTest {
 
   class TestModule : KAbstractModule() {
     override fun configure() {
-      install(Modules.override(MiskServiceModule()).with(FakeClockModule()))
+      install(Modules.override(MiskTestingServiceModule()).with(FakeClockModule()))
       multibind<Service>().to<RepeatedTaskQueue>()
     }
 

--- a/misk/src/test/kotlin/misk/tokens/RealTokenGeneratorTest.kt
+++ b/misk/src/test/kotlin/misk/tokens/RealTokenGeneratorTest.kt
@@ -1,6 +1,6 @@
 package misk.tokens
 
-import misk.MiskServiceModule
+import misk.MiskTestingServiceModule
 import misk.testing.MiskTest
 import misk.testing.MiskTestModule
 import org.assertj.core.api.Assertions.assertThat
@@ -11,7 +11,7 @@ import kotlin.test.assertFailsWith
 @MiskTest
 class RealTokenGeneratorTest {
   @MiskTestModule
-  val module = MiskServiceModule()
+  val module = MiskTestingServiceModule()
 
   @Inject lateinit var tokenGenerator: TokenGenerator
 

--- a/misk/src/test/kotlin/misk/tracing/ClientServerTraceTest.kt
+++ b/misk/src/test/kotlin/misk/tracing/ClientServerTraceTest.kt
@@ -8,7 +8,7 @@ import helpers.protos.Dinosaur
 import io.opentracing.Tracer
 import io.opentracing.mock.MockSpan
 import io.opentracing.mock.MockTracer
-import misk.MiskServiceModule
+import misk.MiskTestingServiceModule
 import misk.client.HttpClientEndpointConfig
 import misk.client.HttpClientsConfig
 import misk.client.TypedHttpClientModule
@@ -57,7 +57,7 @@ internal class ClientServerTraceTest {
   @BeforeEach
   fun createClient() {
     clientInjector = Guice.createInjector(
-        MockTracingBackendModule(), MiskServiceModule(), ClientModule(jetty))
+        MockTracingBackendModule(), MiskTestingServiceModule(), ClientModule(jetty))
   }
 
   @Test
@@ -84,7 +84,7 @@ internal class ClientServerTraceTest {
 
   @Test
   fun noTracerNoTracesOrFailures() {
-    val clientInjector = Guice.createInjector(MiskServiceModule(), ClientModule(jetty))
+    val clientInjector = Guice.createInjector(MiskTestingServiceModule(), ClientModule(jetty))
     val client = clientInjector.getInstance<ReturnADinosaur>(Names.named("dinosaur"))
 
     client.getDinosaur(dinosaurRequest).execute()

--- a/misk/src/test/kotlin/misk/web/actions/DefaultActionsWithWithAccessControlModuleTest.kt
+++ b/misk/src/test/kotlin/misk/web/actions/DefaultActionsWithWithAccessControlModuleTest.kt
@@ -1,7 +1,7 @@
 package misk.web.actions
 
 import misk.MiskCaller
-import misk.MiskServiceModule
+import misk.MiskTestingServiceModule
 import misk.inject.KAbstractModule
 import misk.security.authz.MiskCallerAuthenticator
 import misk.testing.MiskTest
@@ -13,7 +13,7 @@ internal class DefaultActionsWorkWithAccessControlModuleTest {
   @MiskTestModule
   val module = object : KAbstractModule() {
     override fun configure() {
-      install(MiskServiceModule())
+      install(MiskTestingServiceModule())
       multibind<MiskCallerAuthenticator>().to<ExampleAuthenticator>()
     }
   }

--- a/misk/src/test/kotlin/misk/web/actions/LivenessCheckActionTest.kt
+++ b/misk/src/test/kotlin/misk/web/actions/LivenessCheckActionTest.kt
@@ -2,7 +2,7 @@ package misk.web.actions
 
 import com.google.common.util.concurrent.ServiceManager
 import com.google.inject.util.Modules
-import misk.MiskServiceModule
+import misk.MiskTestingServiceModule
 import misk.services.FakeServiceModule
 import misk.testing.MiskTest
 import misk.testing.MiskTestModule
@@ -14,7 +14,7 @@ import javax.inject.Inject
 class LivenessCheckActionTest {
   @MiskTestModule
   val module = Modules.combine(
-      MiskServiceModule(),
+      MiskTestingServiceModule(),
       FakeServiceModule()
   )
 

--- a/misk/src/test/kotlin/misk/web/actions/ReadinessCheckActionTest.kt
+++ b/misk/src/test/kotlin/misk/web/actions/ReadinessCheckActionTest.kt
@@ -2,7 +2,7 @@ package misk.web.actions
 
 import com.google.common.util.concurrent.ServiceManager
 import com.google.inject.util.Modules
-import misk.MiskServiceModule
+import misk.MiskTestingServiceModule
 import misk.healthchecks.FakeHealthCheck
 import misk.healthchecks.FakeHealthCheckModule
 import misk.services.FakeServiceModule
@@ -16,7 +16,7 @@ import javax.inject.Inject
 class ReadinessCheckActionTest {
   @MiskTestModule
   val module = Modules.combine(
-      MiskServiceModule(),
+      MiskTestingServiceModule(),
       FakeServiceModule(),
       FakeHealthCheckModule()
   )

--- a/misk/src/test/kotlin/misk/web/actions/StatusActionTest.kt
+++ b/misk/src/test/kotlin/misk/web/actions/StatusActionTest.kt
@@ -3,7 +3,7 @@ package misk.web.actions
 import com.google.common.util.concurrent.Service
 import com.google.common.util.concurrent.ServiceManager
 import com.google.inject.util.Modules
-import misk.MiskServiceModule
+import misk.MiskTestingServiceModule
 import misk.healthchecks.FakeHealthCheck
 import misk.healthchecks.FakeHealthCheckModule
 import misk.healthchecks.HealthStatus
@@ -18,7 +18,7 @@ import javax.inject.Inject
 class StatusActionTest {
   @MiskTestModule
   val module = Modules.combine(
-      MiskServiceModule(),
+      MiskTestingServiceModule(),
       FakeServiceModule(),
       FakeHealthCheckModule()
   )

--- a/misk/src/test/kotlin/misk/web/ssl/Http2ConnectivityTest.kt
+++ b/misk/src/test/kotlin/misk/web/ssl/Http2ConnectivityTest.kt
@@ -2,7 +2,7 @@ package misk.web.ssl
 
 import com.google.inject.Guice
 import com.google.inject.Provides
-import misk.MiskServiceModule
+import misk.MiskTestingServiceModule
 import misk.client.HttpClientEndpointConfig
 import misk.client.HttpClientModule
 import misk.client.HttpClientSSLConfig
@@ -25,10 +25,7 @@ import okhttp3.Protocol
 import okhttp3.Request
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.condition.DisabledOnJre
-import org.junit.jupiter.api.condition.JRE
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -105,7 +102,7 @@ class Http2ConnectivityTest {
   // _after_ we start the services
   class ClientModule(val jetty: JettyService) : KAbstractModule() {
     override fun configure() {
-      install(MiskServiceModule())
+      install(MiskTestingServiceModule())
       install(HttpClientModule("default"))
     }
 

--- a/misk/src/test/kotlin/misk/web/ssl/JceksSslClientServerTest.kt
+++ b/misk/src/test/kotlin/misk/web/ssl/JceksSslClientServerTest.kt
@@ -4,7 +4,7 @@ import com.google.inject.Guice
 import com.google.inject.Provides
 import com.google.inject.name.Names
 import helpers.protos.Dinosaur
-import misk.MiskServiceModule
+import misk.MiskTestingServiceModule
 import misk.client.HttpClientEndpointConfig
 import misk.client.HttpClientModule
 import misk.client.HttpClientSSLConfig
@@ -116,7 +116,7 @@ internal class JceksSslClientServerTest {
   // need to create the client module _after_ we start the services
   class ClientModule(val jetty: JettyService) : KAbstractModule() {
     override fun configure() {
-      install(MiskServiceModule())
+      install(MiskTestingServiceModule())
       install(HttpClientModule("cert-and-trust", Names.named("cert-and-trust")))
       install(HttpClientModule("no-cert", Names.named("no-cert")))
       install(HttpClientModule("no-trust", Names.named("no-trust")))

--- a/misk/src/test/kotlin/misk/web/ssl/PemSslClientServerTest.kt
+++ b/misk/src/test/kotlin/misk/web/ssl/PemSslClientServerTest.kt
@@ -4,7 +4,7 @@ import com.google.inject.Guice
 import com.google.inject.Provides
 import com.google.inject.name.Names
 import helpers.protos.Dinosaur
-import misk.MiskServiceModule
+import misk.MiskTestingServiceModule
 import misk.client.HttpClientEndpointConfig
 import misk.client.HttpClientModule
 import misk.client.HttpClientSSLConfig
@@ -118,7 +118,7 @@ internal class PemSslClientServerTest {
   // need to create the client module _after_ we start the services
   class ClientModule(val jetty: JettyService) : KAbstractModule() {
     override fun configure() {
-      install(MiskServiceModule())
+      install(MiskTestingServiceModule())
       install(HttpClientModule("cert-and-trust", Names.named("cert-and-trust")))
       install(HttpClientModule("no-cert", Names.named("no-cert")))
       install(HttpClientModule("no-trust", Names.named("no-trust")))

--- a/samples/exemplar/src/main/java/com/squareup/exemplar/ExemplarJavaApp.java
+++ b/samples/exemplar/src/main/java/com/squareup/exemplar/ExemplarJavaApp.java
@@ -2,7 +2,8 @@ package com.squareup.exemplar;
 
 import com.google.common.collect.ImmutableList;
 import misk.MiskApplication;
-import misk.MiskServiceModule;
+import misk.MiskRealServiceModule;
+import misk.MiskTestingServiceModule;
 import misk.config.ConfigModule;
 import misk.config.MiskConfig;
 import misk.environment.Environment;
@@ -16,7 +17,7 @@ public class ExemplarJavaApp {
         environment, ImmutableList.of());
 
     new MiskApplication(
-        new MiskServiceModule(),
+        new MiskRealServiceModule(),
         new MiskWebModule(),
         new ExemplarJavaModule(),
         new ConfigModule<>(ExemplarJavaConfig.class, "exemplar", config),

--- a/samples/exemplar/src/main/kotlin/com/squareup/exemplar/ExemplarService.kt
+++ b/samples/exemplar/src/main/kotlin/com/squareup/exemplar/ExemplarService.kt
@@ -1,7 +1,8 @@
 package com.squareup.exemplar
 
 import misk.MiskApplication
-import misk.MiskServiceModule
+import misk.MiskRealServiceModule
+import misk.MiskTestingServiceModule
 import misk.config.ConfigModule
 import misk.config.MiskConfig
 import misk.environment.Environment
@@ -14,7 +15,7 @@ fun main(args: Array<String>) {
   val config = MiskConfig.load<ExemplarConfig>("exemplar", environment)
 
   MiskApplication(
-      MiskServiceModule(),
+      MiskRealServiceModule(),
       MiskWebModule(),
       ExemplarModule(),
       ConfigModule.create("exemplar", config),

--- a/samples/exemplarchat/src/main/kotlin/com/squareup/chat/ChatService.kt
+++ b/samples/exemplarchat/src/main/kotlin/com/squareup/chat/ChatService.kt
@@ -1,7 +1,8 @@
 package com.squareup.chat
 
 import misk.MiskApplication
-import misk.MiskServiceModule
+import misk.MiskRealServiceModule
+import misk.MiskTestingServiceModule
 import misk.config.ConfigModule
 import misk.config.MiskConfig
 import misk.environment.Environment
@@ -15,7 +16,7 @@ fun main(args: Array<String>) {
   val config = MiskConfig.load<ChatConfig>("chat", environment)
 
   MiskApplication(
-      MiskServiceModule(),
+      MiskRealServiceModule(),
       MiskWebModule(),
       RealEventRouterModule(environment),
       ChatModule(),

--- a/samples/exemplarchat/src/test/kotlin/com/squareup/chat/ChatWebSocketActionTest.kt
+++ b/samples/exemplarchat/src/test/kotlin/com/squareup/chat/ChatWebSocketActionTest.kt
@@ -2,7 +2,7 @@ package com.squareup.chat
 
 import com.google.inject.util.Modules
 import com.squareup.chat.actions.ChatWebSocketAction
-import misk.MiskServiceModule
+import misk.MiskTestingServiceModule
 import misk.eventrouter.EventRouterTester
 import misk.eventrouter.EventRouterTestingModule
 import misk.testing.MiskTest
@@ -15,7 +15,7 @@ import javax.inject.Inject
 @MiskTest(startService = true)
 class ChatWebSocketActionTest {
   @MiskTestModule
-  val module = Modules.combine(MiskServiceModule(), EventRouterTestingModule())
+  val module = Modules.combine(MiskTestingServiceModule(), EventRouterTestingModule())
 
   @Inject lateinit var chatWebSocketAction: ChatWebSocketAction
   @Inject lateinit var eventRouterTester: EventRouterTester


### PR DESCRIPTION
This allows unit testing envs to use MiskTestingServiceModule, which
does not rely on environment vars or the underlying filesystem.