### PR TITLE
Load test files from in memory map instead of classpath

### DIFF
--- a/misk/src/main/kotlin/misk/resources/FakeFilesystemLoaderBackend.kt
+++ b/misk/src/main/kotlin/misk/resources/FakeFilesystemLoaderBackend.kt
@@ -1,0 +1,31 @@
+package misk.resources
+
+import okio.Buffer
+import okio.BufferedSource
+import okio.ByteString.Companion.encodeUtf8
+import javax.inject.Inject
+import javax.inject.Qualifier
+import javax.inject.Singleton
+
+/**
+ * A fake [FilesystemLoaderBackend] that loads file contents from an in-memory map. The map
+ * can be populated by adding to the [ForFakeFiles] map.
+ *
+ * ```
+ * newMapBinder<String, String>(ForFakeFiles::class).addBinding("/etc/foo.txt").toInstance("hello!")
+ * ```
+ */
+@Singleton
+internal class FakeFilesystemLoaderBackend @Inject constructor(
+  @ForFakeFiles private val files: Map<String, String>
+) : ResourceLoader.Backend() {
+  override fun open(path: String): BufferedSource? {
+    val file = files[path] ?: return null
+    return Buffer().write(file.encodeUtf8())
+  }
+
+  override fun exists(path: String) = files.containsKey(path)
+}
+
+@Qualifier
+annotation class ForFakeFiles

--- a/misk/src/main/kotlin/misk/resources/ResourceLoaderModule.kt
+++ b/misk/src/main/kotlin/misk/resources/ResourceLoaderModule.kt
@@ -2,6 +2,7 @@ package misk.resources
 
 import com.google.inject.multibindings.MapBinder
 import misk.inject.KAbstractModule
+import misk.inject.asSingleton
 
 class ResourceLoaderModule : KAbstractModule() {
   override fun configure() {
@@ -14,19 +15,16 @@ class ResourceLoaderModule : KAbstractModule() {
 }
 
 /**
- * Can be used instead of [ResourceLoaderModule] in tests to load filesystem: resources from the
- * classpath instead.
- *
- * The files should be located at the same path within the classpath. For example, if loading
- * filesystem:/etc/secrets/password.txt, the file must exist at
- * src/test/resources/etc/secrets/password.txt
+ * Can be used instead of [ResourceLoaderModule] in tests to load filesystem: resources using
+ * [FakeFilesystemLoaderBackend]
  */
 class TestingResourceLoaderModule : KAbstractModule() {
   override fun configure() {
     val mapBinder = MapBinder.newMapBinder(
         binder(), String::class.java, ResourceLoader.Backend::class.java)
     mapBinder.addBinding("classpath:").toInstance(ClasspathResourceLoaderBackend)
-    mapBinder.addBinding("filesystem:").toInstance(ClasspathResourceLoaderBackend)
+    mapBinder.addBinding("filesystem:").to<FakeFilesystemLoaderBackend>()
     mapBinder.addBinding("memory:").to<MemoryResourceLoaderBackend>()
+    newMapBinder<String, String>(ForFakeFiles::class)
   }
 }

--- a/misk/src/test/kotlin/misk/resources/FakeFileLoaderTest.kt
+++ b/misk/src/test/kotlin/misk/resources/FakeFileLoaderTest.kt
@@ -1,0 +1,37 @@
+package misk.resources
+
+import com.google.inject.util.Modules
+import misk.inject.KAbstractModule
+import misk.testing.MiskTest
+import misk.testing.MiskTestModule
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import javax.inject.Inject
+
+@MiskTest(startService = false)
+class FakeFileLoaderTest {
+
+  @MiskTestModule
+  private val module = Modules.combine(TestingResourceLoaderModule(), FakeFilesModule())
+
+  @Inject private lateinit var loader : ResourceLoader
+
+
+  @Test fun loadFileFromMemory() {
+    assertThat(loader.utf8("filesystem:/some/test/file")).contains("test data!")
+  }
+
+  @Test fun fileDoesNotExist() {
+    assertThat(loader.exists("filesystem:/does/not/exist"))
+        .isFalse()
+    assertThat(loader.utf8("filesystem:/does/not/exist")).isNull()
+  }
+
+  private class FakeFilesModule : KAbstractModule() {
+    override fun configure() {
+      newMapBinder<String, String>(ForFakeFiles::class)
+          .addBinding("/some/test/file")
+          .toInstance("test data!")
+    }
+  }
+}


### PR DESCRIPTION
Now apps don't have to copy files around to their local src/test
directory. Instead they just install a map binding and it allows
sharing common files, like certs.