### PR TITLE
Require DatasourceConfig host and port

### DIFF
--- a/misk-hibernate-testing/src/test/kotlin/misk/jdbc/VitessScaleSafetyChecksTest.kt
+++ b/misk-hibernate-testing/src/test/kotlin/misk/jdbc/VitessScaleSafetyChecksTest.kt
@@ -57,14 +57,15 @@ class VitessScaleSafetyChecksTest {
 """
 
   @Test fun parseQueryPlans() {
+    val dsConfig = DataSourceConfig(type = DataSourceType.VITESS, host = "127.0.0.1", port = 27001)
     val detector = VitessScaleSafetyChecks(
         OkHttpClient(),
         Moshi.Builder().build(),
-        DataSourceConfig(type = DataSourceType.VITESS),
+        dsConfig,
         StartVitessService(
             qualifier = Movies::class,
             environment = Environment.TESTING,
-            config = DataSourceConfig(type = DataSourceType.VITESS)))
+            config = dsConfig))
 
     val plans = detector.parseQueryPlans(
         Buffer().writeUtf8(queryPlans)).toList()

--- a/misk-hibernate-testing/src/test/resources/test_truncatetables_app-common.yaml
+++ b/misk-hibernate-testing/src/test/resources/test_truncatetables_app-common.yaml
@@ -1,6 +1,8 @@
 data_source:
   type: MYSQL
   username: root
+  host: 127.0.0.1
+  port: 3306
   password: ""
   database: truncatetables
   migrations_resource: classpath:/misk/hibernate/truncatetables-migrations

--- a/misk-hibernate/src/main/kotlin/misk/jdbc/DataSourceConfig.kt
+++ b/misk-hibernate/src/main/kotlin/misk/jdbc/DataSourceConfig.kt
@@ -14,8 +14,8 @@ enum class DataSourceType(
       driverClassName = "io.opentracing.contrib.jdbc.TracingDriver",
       hibernateDialect = "org.hibernate.dialect.MySQL57Dialect",
       buildJdbcUrl = { config, env ->
-        val port = config.port ?: 3306
-        val host = config.host ?: "127.0.0.1"
+        val port = config.port
+        val host = config.host
         val database = config.database ?: ""
         val testing = env == Environment.TESTING || env == Environment.DEVELOPMENT
         var queryParams = if (testing) "?createDatabaseIfNotExist=true" else ""
@@ -54,8 +54,8 @@ enum class DataSourceType(
       driverClassName = "io.vitess.jdbc.VitessDriver",
       hibernateDialect = "misk.hibernate.VitessDialect",
       buildJdbcUrl = { config, _ ->
-        val port = config.port ?: 27001
-        val host = config.host ?: "127.0.0.1"
+        val port = config.port
+        val host = config.host
         val database = config.database ?: ""
         "jdbc:vitess://$host:$port/$database"
       }
@@ -65,8 +65,8 @@ enum class DataSourceType(
 /** Configuration element for an individual datasource */
 data class DataSourceConfig(
   val type: DataSourceType,
-  val host: String? = null,
-  val port: Int? = null,
+  val host: String,
+  val port: Int,
   val database: String? = null,
   val username: String? = null,
   val password: String? = null,

--- a/misk-hibernate/src/test/resources/boxedstring-common.yaml
+++ b/misk-hibernate/src/test/resources/boxedstring-common.yaml
@@ -1,5 +1,7 @@
 data_source:
   type: MYSQL
+  host: 127.0.0.1
+  port: 3306
   username: root
   password: ""
   database: boxedstring

--- a/misk-hibernate/src/test/resources/bytestringcolumn-common.yaml
+++ b/misk-hibernate/src/test/resources/bytestringcolumn-common.yaml
@@ -1,5 +1,7 @@
 data_source:
   type: MYSQL
+  host: 127.0.0.1
+  port: 3306
   username: root
   password: ""
   database: bytestringcolumn

--- a/misk-hibernate/src/test/resources/jsoncolumn-common.yaml
+++ b/misk-hibernate/src/test/resources/jsoncolumn-common.yaml
@@ -1,5 +1,7 @@
 data_source:
   type: MYSQL
+  host: 127.0.0.1
+  port: 3306
   username: root
   password: ""
   database: jsoncolumn

--- a/misk-hibernate/src/test/resources/moviestestmodule-common.yaml
+++ b/misk-hibernate/src/test/resources/moviestestmodule-common.yaml
@@ -1,5 +1,7 @@
 data_source:
   type: VITESS
+  host: 127.0.0.1
+  port: 27001
   username: vt_app
   password: whatever
   vitess_schema_dir: src/test/resources/misk/hibernate/moviestestmodule-schema

--- a/misk-hibernate/src/test/resources/primitivecolumns-common.yaml
+++ b/misk-hibernate/src/test/resources/primitivecolumns-common.yaml
@@ -1,5 +1,7 @@
 data_source:
   type: MYSQL
+  host: 127.0.0.1
+  port: 3306
   username: root
   password: ""
   database: primitivecolumns

--- a/misk-hibernate/src/test/resources/protocolumn-common.yaml
+++ b/misk-hibernate/src/test/resources/protocolumn-common.yaml
@@ -1,5 +1,7 @@
 data_source:
   type: MYSQL
+  host: 127.0.0.1
+  port: 3306
   username: root
   password: ""
   database: protocolumn

--- a/misk-hibernate/src/test/resources/schemavalidation-common.yaml
+++ b/misk-hibernate/src/test/resources/schemavalidation-common.yaml
@@ -1,6 +1,8 @@
 data_source:
   type: MYSQL
   username: root
+  host: 127.0.0.1
+  port: 3306
   password: ""
   database: schemavalidation
   migrations_resource: classpath:/misk/hibernate/schemavalidation-migrations

--- a/misk-hibernate/src/test/resources/test_hibernate_app_vitess-common.yaml
+++ b/misk-hibernate/src/test/resources/test_hibernate_app_vitess-common.yaml
@@ -2,5 +2,7 @@ data_source_clusters:
   exemplar:
     writer:
       type: VITESS
+      host: 127.0.0.1
+      port: 27001
       username: vt_app
       password: whatever

--- a/misk-hibernate/src/test/resources/test_schemamigrator_app-common.yaml
+++ b/misk-hibernate/src/test/resources/test_schemamigrator_app-common.yaml
@@ -1,5 +1,7 @@
 data_source:
   type: MYSQL
+  host: 127.0.0.1
+  port: 3306
   username: root
   password: ""
   database: schemamigrator


### PR DESCRIPTION
The convenience of the development default value is not worth
accidentally screwing up the production config