### PR TITLE
Remove Producer.Transaction interface

### DIFF
--- a/misk-events/src/main/kotlin/misk/events/Producer.kt
+++ b/misk-events/src/main/kotlin/misk/events/Producer.kt
@@ -5,30 +5,10 @@ package misk.events
  */
 interface Producer {
   /**
-   * A producer [Transaction] is a unit of publishing. Producer transactions adhere to the
-   * transactional concepts of isolation (events publishing within a transaction are only
-   * visible to consumers once the transaction is committed) and atomicity (once committed, all
-   * events within the transactions are made available to consumers - no events will be lost).
+   * Publishes an event to an event stream.
    *
-   * Note that a Producer transaction is _not_ connected to a database transaction; it is solely
-   * a transaction within the event streaming system. To coordinate event publishing with
-   * local database transactions, use a [SpooledProducer] which stores the events in a local table
-   * as part of the local database transaction.
-   *
-   * Transactions remaining outstanding until the application calls commit, or rollback, or until
-   * a producer specific timeout occurs.
-   *
-   * Transactions may only be used from the thread that began them; accessing a transaction
-   * in multiple threads or handing it off between threads has undefined behavior.
-   *
-   * Having multiple outstanding transactions on the same thread also has undefined behavior.
+   * If multiple events need to be produced published atomically, or if end-to-end ordering is required, use a
+   * [SpooledProducer].
    */
-  interface Transaction {
-    fun publish(topic: Topic, vararg events: Event)
-    fun commit()
-    fun rollback()
-  }
-
-  /** Begins a new transaction on the current thread */
-  fun beginTransaction(): Transaction
+  fun publish(topic: Topic, vararg events: Event)
 }


### PR DESCRIPTION
Removing the `Producer.Transaction` interface and publishing events directly. We will offer `SpooledPublisher` for publishing events atomically, and must be backed by a data store. `Producer.Transaction` is limited in that while the events are published as one atomic block, they are not a part of a database transaction, and thus only provide partial atomicity when used as a step business logic that modifies database state. We prefer only one way of supporting atomic transactional event publishes.