### PR TITLE
Hibernate.field can find inherited properties

### DIFF
--- a/misk-hibernate/src/main/kotlin/misk/hibernate/Hibernate.kt
+++ b/misk-hibernate/src/main/kotlin/misk/hibernate/Hibernate.kt
@@ -52,6 +52,10 @@ internal fun field(entityClass: Class<*>, property: Property): Field {
   try {
     return entityClass.getDeclaredField(property.name)
   } catch (e: NoSuchFieldException) {
+    val superclass = entityClass.superclass
+    if (superclass != null) {
+      return field(superclass, property)
+    }
     throw IllegalStateException("expected a field for ${property.name} in ${entityClass.name}", e)
   }
 }

--- a/misk-hibernate/src/test/kotlin/misk/hibernate/HibernateTest.kt
+++ b/misk-hibernate/src/test/kotlin/misk/hibernate/HibernateTest.kt
@@ -1,0 +1,32 @@
+package misk.hibernate
+
+import org.hibernate.mapping.Property
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+internal class HibernateTest {
+  @Test
+  fun inheritedFieldTest() {
+    val parentProperty = Property()
+    parentProperty.name = "parentVal"
+    val childProperty = Property()
+    childProperty.name = "childVal"
+
+    assertEquals("parentVal", field(Parent::class.java, parentProperty).name)
+    assertEquals("parentVal", field(Child::class.java, parentProperty).name)
+    assertEquals("childVal", field(Child::class.java, childProperty).name)
+
+    assertThrows<IllegalStateException> {
+      field(Parent::class.java, childProperty)
+    }
+  }
+
+  open class Parent {
+    lateinit var parentVal: String
+  }
+
+  class Child: Parent() {
+    lateinit var childVal: String
+  }
+}


### PR DESCRIPTION
This was throwing errors on startup for inherited properties due to a usage in https://github.com/square/misk/blob/3fb0b899e5ae6402ceccb345fee606b8bdf3b6a7/misk-hibernate/src/main/kotlin/misk/hibernate/SessionFactoryService.kt#L150 which iterates through all properties in all Entities. It only looked for fields declared by entity class, not any inherited fields.