### PR TITLE
StartVitessService produces itself as a service dependency

### DIFF
--- a/misk-hibernate/src/main/kotlin/misk/vitess/StartVitessService.kt
+++ b/misk-hibernate/src/main/kotlin/misk/vitess/StartVitessService.kt
@@ -12,8 +12,10 @@ import com.github.dockerjava.netty.NettyDockerCmdExecFactory
 import com.google.common.cache.CacheBuilder
 import com.google.common.cache.CacheLoader
 import com.google.common.util.concurrent.AbstractIdleService
+import com.google.inject.Key
 import com.squareup.moshi.Moshi
 import com.zaxxer.hikari.util.DriverDataSource
+import misk.DependentService
 import misk.backoff.ExponentialBackoff
 import misk.backoff.retry
 import misk.environment.Environment
@@ -276,7 +278,10 @@ class StartVitessService(
   private val qualifier: KClass<out Annotation>,
   private val environment: Environment,
   private val config: DataSourceConfig
-) : AbstractIdleService() {
+) : AbstractIdleService(), DependentService {
+
+  override val consumedKeys: Set<Key<*>> = setOf()
+  override val producedKeys: Set<Key<*>> = setOf(Key.get(StartVitessService::class.java))
 
   var cluster: DockerVitessCluster? = null
 

--- a/misk-testing/src/main/kotlin/misk/service/ServiceTestingModule.kt
+++ b/misk-testing/src/main/kotlin/misk/service/ServiceTestingModule.kt
@@ -27,9 +27,6 @@ class ServiceTestingModule<T : Service> internal constructor(
         getProvider(wrappedServiceType.java),
         extraDependencies
     )).asSingleton()
-
-    // Bind the wrapped service directly so that application code can inject it
-    bind(wrappedServiceType.java)
   }
 
   companion object {


### PR DESCRIPTION
Allows other services to depend on Vitess being available, e.g. for testing.