### PR TITLE
Add ACL support to ZooKeeper

### DIFF
--- a/misk-zookeeper/src/main/kotlin/misk/clustering/zookeeper/ZkLease.kt
+++ b/misk-zookeeper/src/main/kotlin/misk/clustering/zookeeper/ZkLease.kt
@@ -141,7 +141,6 @@ internal class ZkLease(
     try {
       manager.client.value.create()
           .withMode(CreateMode.EPHEMERAL)
-          .withACL(ZooDefs.Ids.OPEN_ACL_UNSAFE)
           .forPath(leaseZkPath, leaseData)
       status = Status.HELD
       log.info { "acquired lease $name" }

--- a/misk-zookeeper/src/main/kotlin/misk/clustering/zookeeper/ZkLeaseManager.kt
+++ b/misk-zookeeper/src/main/kotlin/misk/clustering/zookeeper/ZkLeaseManager.kt
@@ -9,7 +9,7 @@ import misk.clustering.lease.LeaseManager
 import misk.config.AppName
 import misk.inject.keyOf
 import misk.logging.getLogger
-import misk.zookeeper.LEASES_NODE
+import misk.zookeeper.SERVICES_NODE
 import org.apache.curator.framework.CuratorFramework
 import org.apache.curator.framework.state.ConnectionStateListener
 import java.util.concurrent.ConcurrentHashMap
@@ -35,7 +35,7 @@ internal class ZkLeaseManager @Inject internal constructor(
   override val consumedKeys = setOf(ZookeeperModule.serviceKey, keyOf<Cluster>())
   override val producedKeys = setOf(ZookeeperModule.leaseManagerKey)
 
-  internal val leaseNamespace = "$LEASES_NODE/${appName.asZkNamespace}"
+  internal val leaseNamespace = "$SERVICES_NODE/${appName.asZkNamespace}/leases"
   internal val client = lazy { curator.usingNamespace(leaseNamespace) }
 
   private val ownerName = cluster.snapshot.self.name

--- a/misk-zookeeper/src/main/kotlin/misk/clustering/zookeeper/ZkLeaseManager.kt
+++ b/misk-zookeeper/src/main/kotlin/misk/clustering/zookeeper/ZkLeaseManager.kt
@@ -9,6 +9,7 @@ import misk.clustering.lease.LeaseManager
 import misk.config.AppName
 import misk.inject.keyOf
 import misk.logging.getLogger
+import misk.zookeeper.LEASES_NODE
 import org.apache.curator.framework.CuratorFramework
 import org.apache.curator.framework.state.ConnectionStateListener
 import java.util.concurrent.ConcurrentHashMap
@@ -34,7 +35,7 @@ internal class ZkLeaseManager @Inject internal constructor(
   override val consumedKeys = setOf(ZookeeperModule.serviceKey, keyOf<Cluster>())
   override val producedKeys = setOf(ZookeeperModule.leaseManagerKey)
 
-  internal val leaseNamespace = "leases/${appName.asZkNamespace}"
+  internal val leaseNamespace = "$LEASES_NODE/${appName.asZkNamespace}"
   internal val client = lazy { curator.usingNamespace(leaseNamespace) }
 
   private val ownerName = cluster.snapshot.self.name

--- a/misk-zookeeper/src/main/kotlin/misk/clustering/zookeeper/ZookeeperModule.kt
+++ b/misk-zookeeper/src/main/kotlin/misk/clustering/zookeeper/ZookeeperModule.kt
@@ -5,6 +5,7 @@ import com.google.inject.Key
 import misk.clustering.lease.LeaseManager
 import misk.inject.KAbstractModule
 import misk.inject.asSingleton
+import misk.zookeeper.CuratorFrameworkProvider
 import org.apache.curator.framework.CuratorFramework
 
 class ZookeeperModule : KAbstractModule() {

--- a/misk-zookeeper/src/main/kotlin/misk/zookeeper/CuratorFrameworkProvider.kt
+++ b/misk-zookeeper/src/main/kotlin/misk/zookeeper/CuratorFrameworkProvider.kt
@@ -1,10 +1,10 @@
-package misk.clustering.zookeeper
+package misk.zookeeper
 
 import com.google.common.util.concurrent.ThreadFactoryBuilder
+import misk.clustering.zookeeper.ZookeeperConfig
 import org.apache.curator.framework.CuratorFramework
 import org.apache.curator.framework.CuratorFrameworkFactory
 import org.apache.curator.retry.ExponentialBackoffRetry
-import org.apache.curator.utils.DefaultZookeeperFactory
 import org.apache.zookeeper.ZooKeeper
 import org.apache.zookeeper.client.ZKClientConfig
 import javax.inject.Inject
@@ -33,7 +33,7 @@ internal class CuratorFrameworkProvider @Inject internal constructor(
         .sessionTimeoutMs(config.session_timeout_msecs)
         .canBeReadOnly(false)
         .threadFactory(ThreadFactoryBuilder()
-            .setNameFormat("zk-clustering-${config.zk_connect}")
+            .setNameFormat("zk-${config.zk_connect}")
             .build())
         .zookeeperFactory { connectString, sessionTimeout, watcher, canBeReadOnly ->
           val clientConfig = ZKClientConfig()

--- a/misk-zookeeper/src/main/kotlin/misk/zookeeper/CuratorFrameworkProvider.kt
+++ b/misk-zookeeper/src/main/kotlin/misk/zookeeper/CuratorFrameworkProvider.kt
@@ -17,11 +17,7 @@ import java.util.Collections
 import javax.inject.Inject
 import javax.inject.Provider
 
-// Directory where ZooKeeper stores the leases that it manages on a service's behalf
-const val LEASES_NODE = "leases"
-
-// Directory where service-specific directories are created that clients can use to store
-// their service-specific data
+// Directory where service-specific directories are created
 const val SERVICES_NODE = "services"
 
 const val DEFAULT_PERMS = ZooDefs.Perms.READ or
@@ -76,10 +72,10 @@ internal class CuratorFrameworkProvider @Inject internal constructor(
           }
 
           override fun getAclForPath(path: String?): List<ACL> {
-            // Shared directories need to be created in such a way that anyone can create them if
-            // they're missing and read or write to them, but anyone should not be able to delete
-            // them.
-            if (path == LEASES_NODE.asZkPath || path == SERVICES_NODE.asZkPath) {
+            // Shared directories (i.e. /services) need to be created in such a way that apps can
+            // create them if they're missing and read or write to them, but an app should not be
+            // able to delete a shared directory as it contains more than just that app's data.
+            if (path == SERVICES_NODE.asZkPath) {
               return Collections.singletonList(ACL(SHARED_DIR_PERMS, ANYONE_ID_UNSAFE))
             }
 

--- a/misk-zookeeper/src/main/kotlin/misk/zookeeper/ZkClientFactory.kt
+++ b/misk-zookeeper/src/main/kotlin/misk/zookeeper/ZkClientFactory.kt
@@ -1,0 +1,22 @@
+package misk.zookeeper
+
+import misk.clustering.zookeeper.asZkNamespace
+import misk.config.AppName
+import org.apache.curator.framework.CuratorFramework
+import javax.inject.Inject
+
+/**
+ * Factory for generating a zookeeper client that's configured to read and
+ * write data within the app's namespace.
+ */
+class ZkClientFactory @Inject constructor(
+  @AppName appName: String,
+  curator: CuratorFramework
+) {
+  internal val client = lazy { curator.usingNamespace("$SERVICES_NODE/${appName.asZkNamespace}") }
+
+  fun client(): CuratorFramework {
+    return client.value
+  }
+}
+

--- a/misk-zookeeper/src/main/kotlin/misk/zookeeper/ZkClientFactory.kt
+++ b/misk-zookeeper/src/main/kotlin/misk/zookeeper/ZkClientFactory.kt
@@ -13,7 +13,7 @@ class ZkClientFactory @Inject constructor(
   @AppName appName: String,
   curator: CuratorFramework
 ) {
-  internal val client = lazy { curator.usingNamespace("$SERVICES_NODE/${appName.asZkNamespace}") }
+  internal val client = lazy { curator.usingNamespace("$SERVICES_NODE/${appName.asZkNamespace}/data") }
 
   fun client(): CuratorFramework {
     return client.value

--- a/misk-zookeeper/src/test/kotlin/misk/clustering/zookeeper/ZkLeaseTest.kt
+++ b/misk-zookeeper/src/test/kotlin/misk/clustering/zookeeper/ZkLeaseTest.kt
@@ -62,12 +62,12 @@ internal class ZkLeaseTest {
     // Data has correct ACL set
     val acl = curator.acl.forPath(leasePath.asZkPath)
     val dnFromCert = "CN=misk-client,OU=Client,O=Misk,L=San Francisco,ST=CA,C=US"
-    assertThat(Iterables.getOnlyElement(acl)).isEqualTo(ACL(DEFAULT_PERMS, Id("x509", dnFromCert)))
+    val defaultAcl = ACL(DEFAULT_PERMS, Id("x509", dnFromCert))
+    assertThat(Iterables.getOnlyElement(acl)).isEqualTo(defaultAcl)
 
-    // Verify shared directory ACL
-    val leasesAcl = curator.acl.forPath("/leases")
-    assertThat(Iterables.getOnlyElement(leasesAcl))
-        .isEqualTo(ACL(SHARED_DIR_PERMS, ZooDefs.Ids.ANYONE_ID_UNSAFE))
+    // Verify lease directory ACL
+    val leasesAcl = curator.acl.forPath("/services/my-app/leases")
+    assertThat(Iterables.getOnlyElement(leasesAcl)).isEqualTo(defaultAcl)
   }
 
   @Test fun doesNotAcquireLeaseIfNotMappedToSelf() {

--- a/misk-zookeeper/src/test/kotlin/misk/zookeeper/ZkClientTest.kt
+++ b/misk-zookeeper/src/test/kotlin/misk/zookeeper/ZkClientTest.kt
@@ -29,14 +29,23 @@ internal class ZkClientTest {
     val client = clientFactory.client()
     client.create().forPath("/test-node", "test-data".toByteArray())
 
-    // Data is written to /services/<app-name> by default
-    val data = curatorFramework.data.forPath("/services/my-app/test-node")
+    // Data is written to /services/<app-name>/data by default
+    val data = curatorFramework.data.forPath("/services/my-app/data/test-node")
     assertThat(String(data)).isEqualTo("test-data")
 
     // Data has correct ACL set
-    val acl = curatorFramework.acl.forPath("/services/my-app/test-node")
+    val dataAcl = curatorFramework.acl.forPath("/services/my-app/data/test-node")
     val dnFromCert = "CN=misk-client,OU=Client,O=Misk,L=San Francisco,ST=CA,C=US"
-    assertThat(Iterables.getOnlyElement(acl)).isEqualTo(ACL(DEFAULT_PERMS, Id("x509", dnFromCert)))
+    val defaultACL = ACL(DEFAULT_PERMS, Id("x509", dnFromCert))
+    assertThat(Iterables.getOnlyElement(dataAcl)).isEqualTo(defaultACL)
+
+    // Data dir has correct ACL
+    val dataDirAcl = curatorFramework.acl.forPath("/services/my-app/data")
+    assertThat(Iterables.getOnlyElement(dataDirAcl)).isEqualTo(defaultACL)
+
+    // App dir has correct ACL
+    val appDirAcl = curatorFramework.acl.forPath("/services/my-app")
+    assertThat(Iterables.getOnlyElement(appDirAcl)).isEqualTo(defaultACL)
 
     // Shared directory has correct ACL set
     val servicesAcl = curatorFramework.acl.forPath("/services")

--- a/misk-zookeeper/src/test/kotlin/misk/zookeeper/ZkClientTest.kt
+++ b/misk-zookeeper/src/test/kotlin/misk/zookeeper/ZkClientTest.kt
@@ -1,0 +1,46 @@
+package misk.zookeeper
+
+import com.google.common.collect.Iterables
+import com.google.inject.util.Modules
+import misk.MiskTestingServiceModule
+import misk.clustering.zookeeper.ZkTestModule
+import misk.testing.MiskTest
+import misk.testing.MiskTestModule
+import org.apache.curator.framework.AuthInfo
+import org.apache.curator.framework.CuratorFramework
+import org.apache.zookeeper.ZooDefs
+import org.apache.zookeeper.ZooDefs.Ids.AUTH_IDS
+import org.apache.zookeeper.data.ACL
+import org.apache.zookeeper.data.Id
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.security.AuthProvider
+import javax.inject.Inject
+import kotlin.test.assertEquals
+
+@MiskTest(startService = true)
+internal class ZkClientTest {
+  @MiskTestModule private val module = Modules.combine(MiskTestingServiceModule(), ZkTestModule())
+
+  @Inject lateinit var clientFactory: ZkClientFactory
+  @Inject lateinit var curatorFramework: CuratorFramework
+
+  @Test fun clientDefaultsAreCorrect() {
+    val client = clientFactory.client()
+    client.create().forPath("/test-node", "test-data".toByteArray())
+
+    // Data is written to /services/<app-name> by default
+    val data = curatorFramework.data.forPath("/services/my-app/test-node")
+    assertThat(String(data)).isEqualTo("test-data")
+
+    // Data has correct ACL set
+    val acl = curatorFramework.acl.forPath("/services/my-app/test-node")
+    val dnFromCert = "CN=misk-client,OU=Client,O=Misk,L=San Francisco,ST=CA,C=US"
+    assertThat(Iterables.getOnlyElement(acl)).isEqualTo(ACL(DEFAULT_PERMS, Id("x509", dnFromCert)))
+
+    // Shared directory has correct ACL set
+    val servicesAcl = curatorFramework.acl.forPath("/services")
+    assertThat(Iterables.getOnlyElement(servicesAcl))
+        .isEqualTo(ACL(SHARED_DIR_PERMS, ZooDefs.Ids.ANYONE_ID_UNSAFE))
+  }
+}

--- a/misk-zookeeper/src/test/resources/zookeeper/zoo.cfg
+++ b/misk-zookeeper/src/test/resources/zookeeper/zoo.cfg
@@ -14,4 +14,5 @@ ssl.trustStore.location=/conf/truststore.jks
 ssl.trustStore.password=changeit
 ssl.keyStore.location=/conf/keystore.jks
 ssl.keyStore.password=changeit
+ssl.authProvider=x509
 server.1=localhost:2888:3888


### PR DESCRIPTION
/services/\<app-name>/... and /leases/\<app-name>/... allow CRUD access to any client who identifies as the app itself based on the Distinguished Name in the cert provided.

/services and /leases allow CRU access to any client with a cert so that they can create the parent node if need be, but cannot remove it.

Also provide a client that helps apps put their service data in the correct location.