### PR TITLE
Install the FakeClockModule in MiskTestingServiceModule, move MiskTestingServiceModule into misk-testing

### DIFF
--- a/misk-testing/src/main/kotlin/misk/MiskTestingServiceModule.kt
+++ b/misk-testing/src/main/kotlin/misk/MiskTestingServiceModule.kt
@@ -1,0 +1,23 @@
+package misk
+
+import misk.MiskCommonServiceModule
+import misk.environment.FakeEnvVarModule
+import misk.inject.KAbstractModule
+import misk.resources.TestingResourceLoaderModule
+import misk.time.FakeClockModule
+
+/**
+ * [MiskTestingServiceModule] should be installed in unit testing environments.
+ *
+ * This should not contain application level fakes for testing. It includes a small, selective
+ * set of fake bindings to replace real bindings that cannot exist in a unit testing environment
+ * (e.g system env vars and filesystem dependencies).
+ */
+class MiskTestingServiceModule : KAbstractModule() {
+  override fun configure() {
+    install(TestingResourceLoaderModule())
+    install(FakeEnvVarModule())
+    install(FakeClockModule())
+    install(MiskCommonServiceModule())
+  }
+}

--- a/misk/src/main/kotlin/misk/MiskServiceModule.kt
+++ b/misk/src/main/kotlin/misk/MiskServiceModule.kt
@@ -18,7 +18,6 @@ import com.google.inject.spi.InstanceBinding
 import com.google.inject.spi.LinkedKeyBinding
 import com.google.inject.spi.ProviderInstanceBinding
 import com.google.inject.util.Types
-import misk.environment.FakeEnvVarModule
 import misk.environment.RealEnvVarModule
 import misk.healthchecks.HealthCheck
 import misk.inject.KAbstractModule
@@ -26,7 +25,6 @@ import misk.metrics.MetricsModule
 import misk.moshi.MoshiModule
 import misk.prometheus.PrometheusHistogramRegistryModule
 import misk.resources.ResourceLoaderModule
-import misk.resources.TestingResourceLoaderModule
 import misk.time.ClockModule
 import misk.tokens.TokenGeneratorModule
 import javax.inject.Singleton
@@ -42,34 +40,19 @@ class MiskRealServiceModule : KAbstractModule() {
   override fun configure() {
     install(ResourceLoaderModule())
     install(RealEnvVarModule())
+    install(ClockModule())
     install(MiskCommonServiceModule())
   }
 }
 
 /**
- * [MiskTestingServiceModule] should be installed in unit testing environments.
- *
- * This should not contain application level fakes for testing. It includes a small, selective
- * set of fake bindings to replace real bindings that cannot exist in a unit testing environment
- * (e.g system env vars and filesystem dependencies).
- */
-class MiskTestingServiceModule : KAbstractModule() {
-  override fun configure() {
-    install(TestingResourceLoaderModule())
-    install(FakeEnvVarModule())
-    install(MiskCommonServiceModule())
-  }  
-}
-
-/**
  * [MiskCommonServiceModule] has common bindings for all environments (both real and testing)
  */
-private class MiskCommonServiceModule : KAbstractModule() {
+class MiskCommonServiceModule : KAbstractModule() {
   override fun configure() {
     binder().disableCircularProxies()
     binder().requireExactBindingAnnotations()
     install(MetricsModule())
-    install(ClockModule())
     install(MoshiModule())
     install(TokenGeneratorModule())
     install(PrometheusHistogramRegistryModule())

--- a/samples/exemplar/src/main/java/com/squareup/exemplar/ExemplarJavaApp.java
+++ b/samples/exemplar/src/main/java/com/squareup/exemplar/ExemplarJavaApp.java
@@ -3,7 +3,6 @@ package com.squareup.exemplar;
 import com.google.common.collect.ImmutableList;
 import misk.MiskApplication;
 import misk.MiskRealServiceModule;
-import misk.MiskTestingServiceModule;
 import misk.config.ConfigModule;
 import misk.config.MiskConfig;
 import misk.environment.Environment;


### PR DESCRIPTION
The `MiskTestingServiceModule` currently binds a real system clock to `Clock`, which means that in order for tests to use a `FakeClock`, you have to override `MiskTestingServiceModule` with a `FakeClockModule`.

The main change this PR makes is that `MiskTestingServiceModule` now installs a `FakeClockModule`, and `MiskRealServiceModule` installs a `ClockModule`.

However, this would cause a circular dependency between the `:misk` and `:misk-testing` projects. In order to access `FakeClockModule`, the `:misk` project needs to depend on the `:misk-testing` project, which it can't do because `:misk-testing` depends on `:misk`.

The solution I opted for in this PR is to move `MiskTestingServiceModule` into `:misk-testing`. This removes the need for `:misk` to depend on `:misk-testing`. Existing misk apps should already have a dependency on `:misk-testing` for their testing classes, and thus no changes should be required.

Perhaps a better solution could be to make a `:misk-app`-type project and have `MiskTestingServiceModule` and similar files moved into there. Then the `:misk-app` project could depend on both `:misk` and `:misk-testing`. This also resolves the circular dependency. Existing misk apps will have to have their imports updated and add a dependency to `:misk-app`.