### PR TITLE
Set RBR mode via mycnf instead of global var

### DIFF
--- a/misk-hibernate/src/main/kotlin/misk/vitess/StartVitessService.kt
+++ b/misk-hibernate/src/main/kotlin/misk/vitess/StartVitessService.kt
@@ -167,6 +167,7 @@ class DockerVitessCluster(
         "-mysql_bind_host=0.0.0.0",
         "-data_dir=/vt/vtdataroot",
         "-schema_dir=schema",
+        "-extra_my_cnf=/vt/src/vitess.io/vitess/config/mycnf/rbr.cnf",
         "-keyspaces=$keyspacesArg",
         "-num_shards=$shardCounts"
     )
@@ -197,7 +198,6 @@ class DockerVitessCluster(
     grantExternalAccessToDbaUser()
 
     turnOnGeneralLog()
-    setRowBasedBinaryLogging()
   }
 
   private fun waitUntilHealthy() {
@@ -254,17 +254,6 @@ class DockerVitessCluster(
       connection.createStatement().use { statement ->
         statement.execute("SET GLOBAL log_output = 'TABLE'")
         statement.execute("SET GLOBAL general_log = 1")
-      }
-    }
-  }
-
-  /**
-   * Set binary logging to row based.
-   */
-  private fun setRowBasedBinaryLogging() {
-    cluster.openMysqlConnection().use { connection ->
-      connection.createStatement().use { statement ->
-        statement.execute("SET GLOBAL binlog_format = 'ROW'")
       }
     }
   }


### PR DESCRIPTION
Setting the global var at runtime only affects sessions created afterwards. Any sessions cached from before setting this var still use STATEMENT logging, and can result in some transactions non-deterministically logging as statements instead of rows.

I also had to change the `VitessScaleSafetyChecks` because with RBR mode turned on, it looks like Vitess no appends writes the `_stream` tag in a comment at the end of the query, breaking the transaction decorator that's extracting the keyspace ID for DML statements.

STATEMENT mode:
```sql
| 2019-01-29 18:09:10.851772 | vt_dba[vt_dba] @ localhost []  |        95 | 866341052 | Query        | /* insert misk.hibernate.DbMovie */ insert into movies(created_at, name, release_date, updated_at, id) values ('2017-12-31 16:00:00.0', 'Jurassic Park', '1993-06-09', '2017-12-31 16:00:00.0', 1) /* _stream movies (id ) (1 ); */ /* vtgate:: keyspace_id:166b40b44aba4bd6 */         |
```
ROW mode:
```sql
| 2019-01-29 18:13:33.579635 | vt_dba[vt_dba] @ localhost []  |        95 | 749452573 | Query        | /* insert misk.hibernate.DbMovie */ insert into movies(created_at, name, release_date, updated_at, id) values ('2017-12-31 16:00:00.0', 'Jurassic Park', '1993-06-09', '2017-12-31 16:00:00.0', 1) /* vtgate:: keyspace_id:166b40b44aba4bd6 */ |
```

I made the general log query a little more generic, but I'm not sure if it will catch all DML properly. The original query looks a bit fragile to start with, so I think the new query should still be acceptable.