### PR TITLE
Updates MoshiJsonAdapter to be available externally

### DIFF
--- a/misk/src/main/kotlin/misk/moshi/MoshiJsonAdapter.kt
+++ b/misk/src/main/kotlin/misk/moshi/MoshiJsonAdapter.kt
@@ -5,4 +5,4 @@ import javax.inject.Qualifier
 @Qualifier
 @Retention(AnnotationRetention.RUNTIME)
 @Target(AnnotationTarget.FIELD, AnnotationTarget.FUNCTION, AnnotationTarget.VALUE_PARAMETER)
-internal annotation class MoshiJsonAdapter
+annotation class MoshiJsonAdapter


### PR DESCRIPTION
I think we need to make the `MoshiJsonAdapter` annotation public, so that I can inject my custom Factory.