### PR TITLE
Add listener support to Leases

### DIFF
--- a/misk/src/main/kotlin/misk/clustering/fake/lease/FakeLeaseManager.kt
+++ b/misk/src/main/kotlin/misk/clustering/fake/lease/FakeLeaseManager.kt
@@ -3,6 +3,7 @@ package misk.clustering.fake.lease
 import com.google.common.collect.Sets.newConcurrentHashSet
 import misk.clustering.lease.Lease
 import misk.clustering.lease.LeaseManager
+import java.util.concurrent.ConcurrentHashMap
 import javax.inject.Singleton
 
 /**
@@ -12,16 +13,23 @@ import javax.inject.Singleton
 @Singleton
 class FakeLeaseManager : LeaseManager {
   private val leasesHeldElsewhere = newConcurrentHashSet<String>()
+  private val leases = ConcurrentHashMap<String, FakeLease>()
 
-  override fun requestLease(name: String): Lease = FakeLease(name, this)
+  override fun requestLease(name: String): Lease {
+    return leases.computeIfAbsent(name) {
+      FakeLease(name, this)
+    }
+  }
 
   fun isLeaseHeld(name: String) = !leasesHeldElsewhere.contains(name)
 
   fun markLeaseHeld(name: String) {
     leasesHeldElsewhere.remove(name)
+    (requestLease(name) as FakeLease).notifyAfterAcquire()
   }
 
   fun markLeaseHeldElsewhere(name: String) {
+    (requestLease(name) as FakeLease).notifyBeforeRelease()
     leasesHeldElsewhere.add(name)
   }
 
@@ -29,6 +37,24 @@ class FakeLeaseManager : LeaseManager {
     override val name: String,
     private val manager: FakeLeaseManager
   ) : Lease {
+    private val listeners = mutableListOf<Lease.StateChangeListener>()
+
     override fun checkHeld() = manager.isLeaseHeld(name)
+
+    override fun addListener(listener: Lease.StateChangeListener) {
+      listeners.add(listener)
+    }
+
+    fun notifyAfterAcquire() {
+      listeners.forEach {
+        it.afterAcquire(this)
+      }
+    }
+
+    fun notifyBeforeRelease() {
+      listeners.forEach {
+        it.beforeRelease(this)
+      }
+    }
   }
 }

--- a/misk/src/main/kotlin/misk/clustering/lease/Lease.kt
+++ b/misk/src/main/kotlin/misk/clustering/lease/Lease.kt
@@ -18,4 +18,24 @@ interface Lease {
    * so it is marked as a function rather than a property to make the potential expense clearer
    */
   fun checkHeld(): Boolean
+
+  /**
+   * Registers a listener that is called on lease state changes.
+   */
+  fun addListener(listener: StateChangeListener)
+
+  interface StateChangeListener {
+    /**
+     * Called immediately after the lease is acquired. Also called immediately if the lease is
+     * already owned by this process instance when the listener is registered.
+     * @param lease the lease that is acquired
+     */
+    fun afterAcquire(lease: Lease)
+
+    /**
+     * Called immediately before the lease is released.
+     * @param lease the lease that is released
+     */
+    fun beforeRelease(lease: Lease)
+  }
 }


### PR DESCRIPTION
Allow clients to register listeners for lease state changes. If the client chooses to use listeners, it should not have ever to call `checkHeld()`, since the `LeaseManager` should automatically update leases in the background.

This interface is meant for apps that need to lease long-running background processes. An app that uses listeners would instead do something like

```kotlin
leaseManager.requestLease("my-lease").addListener(object : Lease.StateChangeListener {
  override fun afterAcquire(lease: Lease) {
    startBackgroundProcess()
  }

  override fun beforeRelease(lease: Lease) {
    stopBackgroundProcess()
  }
}
```