### PR TITLE
Modify RedisConfig and use JedisPool

### DIFF
--- a/misk-redis/src/main/kotlin/misk/redis/FakeRedis.kt
+++ b/misk-redis/src/main/kotlin/misk/redis/FakeRedis.kt
@@ -6,6 +6,7 @@ import java.time.Instant
 import java.util.concurrent.ConcurrentHashMap
 import javax.inject.Inject
 
+/** Mimics a Redis instance for testing. */
 class FakeRedis : Redis {
   @Inject lateinit var clock: FakeClock
 

--- a/misk-redis/src/main/kotlin/misk/redis/RedisConfig.kt
+++ b/misk-redis/src/main/kotlin/misk/redis/RedisConfig.kt
@@ -2,8 +2,18 @@ package misk.redis
 
 import misk.config.Config
 
-data class RedisConfig(
-  val host_name: String,
-  val port: Int,
-  val auth_password: String
-) : Config
+class RedisConfig: java.util.LinkedHashMap<String, RedisReplicationGroupConfig>, Config {
+  constructor(): super()
+  constructor(m: Map<String, RedisReplicationGroupConfig>): super(m)
+}
+
+data class RedisReplicationGroupConfig(
+  val writer_endpoint: RedisNodeConfig,
+  val reader_endpoint: RedisNodeConfig,
+  val redis_auth_password: String
+)
+
+data class RedisNodeConfig(
+  val hostname: String,
+  val port: Int
+)

--- a/misk-redis/src/main/kotlin/misk/redis/RedisModule.kt
+++ b/misk-redis/src/main/kotlin/misk/redis/RedisModule.kt
@@ -4,18 +4,37 @@ import com.google.common.util.concurrent.Service
 import com.google.inject.Provides
 import com.google.inject.Singleton
 import misk.inject.KAbstractModule
-import redis.clients.jedis.Jedis
+import redis.clients.jedis.JedisPool
+import redis.clients.jedis.JedisPoolConfig
 
-class RedisModule : KAbstractModule() {
+/**
+ * Configures a JedisPool to connect to a Redis instance. The use of a JedisPool ensures thread safety.
+ * See: https://github.com/xetorthio/jedis/wiki/Getting-started#using-jedis-in-a-multithreaded-environment
+ */
+class RedisModule(private val jedisPoolConfig: JedisPoolConfig) : KAbstractModule() {
   override fun configure() {
     multibind<Service>().to<RedisService>()
   }
 
   @Provides @Singleton
   internal fun provideRedisClient(config: RedisConfig): Redis {
-    // Connect to the redis instance
-    val jedis = Jedis(config.host_name, config.port, true)
-    jedis.auth(config.auth_password)
-    return RealRedis(jedis)
+    // Get the first replication group, we only support 1 replication group per service
+    val replicationGroup = config[config.keys.first()]
+      ?: throw RuntimeException("At least 1 replication group must be specified")
+
+    // Create our jedis pool
+    val jedisPool = JedisPool(
+      jedisPoolConfig,
+      replicationGroup.writer_endpoint.hostname,
+      replicationGroup.writer_endpoint.port,
+      true
+    )
+
+    // Authenticate with the redis server
+    jedisPool.resource.use {
+      it.auth(replicationGroup.redis_auth_password)
+    }
+
+    return RealRedis(jedisPool)
   }
 }

--- a/misk-redis/src/main/kotlin/misk/redis/RedisService.kt
+++ b/misk-redis/src/main/kotlin/misk/redis/RedisService.kt
@@ -5,9 +5,7 @@ import javax.inject.Inject
 import javax.inject.Provider
 import javax.inject.Singleton
 
-/**
- * Controls the connection lifecycle for Redis.
- */
+/** Controls the connection lifecycle for Redis. */
 @Singleton
 internal class RedisService @Inject internal constructor(
   private val redisProvider: Provider<Redis>

--- a/misk-redis/src/main/kotlin/misk/redis/RedisTestModule.kt
+++ b/misk-redis/src/main/kotlin/misk/redis/RedisTestModule.kt
@@ -2,7 +2,7 @@ package misk.redis
 
 import misk.inject.KAbstractModule
 
-internal class RedisTestModule : KAbstractModule() {
+class RedisTestModule : KAbstractModule() {
   override fun configure() {
     bind<Redis>().toInstance(FakeRedis())
   }


### PR DESCRIPTION
RedisConfig updated to include a writer and reader endpoint. We also use JedisPool
instead of single Jedis instances to ensure thread safety.