### PR TITLE
Run test suite with --parallel to parallelize gradle tasks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ install:
   - docker pull squareup/misk-web
 
 script:
-  - ./gradlew test
+  - ./gradlew test --parallel
 
 # Gradle caching - as per https://docs.travis-ci.com/user/languages/java/#Projects-Using-Gradle
 before_cache:


### PR DESCRIPTION
This runs the various _gradle tasks_ in parallel (as much as it can). Takes a couple minutes off the build time.

r @adrw @hamdanjaveed @ryanhall07 