### PR TITLE
Allow disabling Vitess cowrite check

### DIFF
--- a/misk-hibernate-testing/src/main/kotlin/misk/jdbc/VitessScaleSafetyChecks.kt
+++ b/misk-hibernate-testing/src/main/kotlin/misk/jdbc/VitessScaleSafetyChecks.kt
@@ -223,7 +223,7 @@ class VitessScaleSafetyChecks(
     }
 
     override fun afterQuery(query: String) {
-      if (!isDml(query)) return
+      if (!enabled.get() || !isDml(query)) return
 
       val queryInDatabase = extractLastDmlQuery() ?: return
 


### PR DESCRIPTION
Quick change to allow disabling the cowrite check in `VitessScaleSafetyChecks.CowriteDetector`. This will let us migrate a `DbChild` entity between two `DbRoot` entities on the same shard in a single transaction, avoiding potential data loss.