### PR TITLE
FakeLease triggers afterAcquire() on register like ZKLease

### DIFF
--- a/misk/src/main/kotlin/misk/clustering/fake/lease/FakeLeaseManager.kt
+++ b/misk/src/main/kotlin/misk/clustering/fake/lease/FakeLeaseManager.kt
@@ -43,6 +43,9 @@ class FakeLeaseManager : LeaseManager {
 
     override fun addListener(listener: Lease.StateChangeListener) {
       listeners.add(listener)
+      if (checkHeld()) {
+        listener.afterAcquire(this)
+      }
     }
 
     fun notifyAfterAcquire() {


### PR DESCRIPTION
This matches ZKLease. I left it out by accident when I added listeners.