### PR TITLE
Use UTC for JDBC timezone

### DIFF
--- a/misk-hibernate/src/main/kotlin/misk/hibernate/SessionFactoryService.kt
+++ b/misk-hibernate/src/main/kotlin/misk/hibernate/SessionFactoryService.kt
@@ -94,6 +94,7 @@ internal class SessionFactoryService(
       applySetting(AvailableSettings.USE_SQL_COMMENTS, "true")
       applySetting(AvailableSettings.USE_GET_GENERATED_KEYS, "true")
       applySetting(AvailableSettings.USE_NEW_ID_GENERATOR_MAPPINGS, "false")
+      applySetting(AvailableSettings.JDBC_TIME_ZONE, "UTC")
     }
 
     val registry = registryBuilder.build()


### PR DESCRIPTION
When the JDBC driver converts a java Instant to a SQL Timestamp it uses
the default system timezone if not specified. for many developers, this
is their local timezone.