### PR TITLE
Add FakeSleeper and FakeScheduledExecutorService

### DIFF
--- a/misk-testing/src/main/kotlin/misk/concurrent/FakeScheduledExecutorService.kt
+++ b/misk-testing/src/main/kotlin/misk/concurrent/FakeScheduledExecutorService.kt
@@ -1,0 +1,77 @@
+package misk.concurrent
+
+import com.google.common.collect.MultimapBuilder
+import com.google.common.util.concurrent.MoreExecutors
+import java.time.Clock
+import java.util.concurrent.Callable
+import java.util.concurrent.Delayed
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.FutureTask
+import java.util.concurrent.RunnableFuture
+import java.util.concurrent.ScheduledExecutorService
+import java.util.concurrent.ScheduledFuture
+import java.util.concurrent.TimeUnit
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * ScheduledExecutorService for testing that runs in the current thread and is triggered using the
+ * `tick()` method. An injected [Clock] is used to decide whether to execute a scheduled task.
+ */
+@Singleton
+class FakeScheduledExecutorService @Inject constructor(private val clock: Clock) :
+    ScheduledExecutorService, ExecutorService by MoreExecutors.newDirectExecutorService() {
+
+  private val futures =
+      MultimapBuilder.treeKeys().arrayListValues().build<Long, RunnableFuture<*>>()
+
+  /** Check the current time on the clock and run any scheduled tasks that are due. */
+  fun tick() {
+    futures.entries().stream()
+        .filter { entry -> entry.key <= clock.millis() }
+        .forEach { entry -> entry.value.run() }
+  }
+
+  override fun schedule(
+    command: Runnable,
+    delay: Long, unit: TimeUnit
+  ) = scheduleTask(delay, unit) { command.run() }
+
+  override fun <V> schedule(
+    callable: Callable<V>,
+    delay: Long, unit: TimeUnit
+  ) = scheduleTask(delay, unit) { callable.call() }
+
+  private fun <V> scheduleTask(delay: Long, unit: TimeUnit, task: () -> V): ScheduledFuture<V> {
+    val executeAt = clock.millis() + unit.toMillis(delay)
+    val future =
+        ScheduledFutureTask(executeAt, clock, task)
+    futures.put(executeAt, future)
+    return future
+  }
+
+  override fun scheduleAtFixedRate(
+    command: Runnable?,
+    initialDelay: Long, period: Long, unit: TimeUnit?
+  ): ScheduledFuture<*> {
+    TODO("not implemented")
+  }
+
+  override fun scheduleWithFixedDelay(
+    command: Runnable?,
+    initialDelay: Long, delay: Long, unit: TimeUnit?
+  ): ScheduledFuture<*> {
+    TODO("not implemented")
+  }
+
+  class ScheduledFutureTask<V>(
+    val executeAt: Long, val clock: Clock,
+    task: () -> V
+  ) : FutureTask<V>(task), ScheduledFuture<V> {
+    override fun compareTo(other: Delayed): Int =
+        getDelay(TimeUnit.MILLISECONDS).compareTo(other.getDelay(TimeUnit.MILLISECONDS))
+
+    override fun getDelay(unit: TimeUnit) =
+        unit.convert(clock.millis() - executeAt, TimeUnit.MILLISECONDS)
+  }
+}

--- a/misk-testing/src/main/kotlin/misk/concurrent/FakeSleeper.kt
+++ b/misk-testing/src/main/kotlin/misk/concurrent/FakeSleeper.kt
@@ -1,0 +1,77 @@
+package misk.concurrent
+
+import java.time.Clock
+import java.time.Duration
+import java.util.concurrent.locks.ReentrantLock
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlin.concurrent.withLock
+
+/**
+ * [Sleeper] for testing that blocks threads calling [sleep], and checks whether the threads should
+ * wake using the [tick()] method. An injected [Clock] is used to decide whether to wake a thread.
+ */
+@Singleton
+class FakeSleeper @Inject constructor(private val clock: Clock) : Sleeper {
+  private var count: Int = 0
+  private var lastDuration: Duration? = null
+  private val lock = ReentrantLock()
+  private val wakeCondition = lock.newCondition()
+  private val waitForThreads = lock.newCondition()
+  private var numSleepingThreads = 0
+
+  /**
+   * Check the current time and triggers any sleeping threads that are due to be awoken.
+   */
+  fun tick() {
+    lock.withLock {
+      wakeCondition.signalAll()
+    }
+  }
+
+  /**
+   * Blocks until the given number of threads are asleep (as a result of calling [sleep] on this
+   * [FakeSleeper]).
+   */
+  fun waitForSleep(numThreads: Int) {
+    lock.withLock {
+      while (numSleepingThreads < numThreads) {
+        waitForThreads.await()
+      }
+    }
+  }
+
+  override fun sleep(duration: Duration) {
+    val sleepUntil = clock.millis() + duration.toMillis()
+    lock.withLock {
+      count++
+      lastDuration = duration
+      numSleepingThreads++
+      while (clock.millis() < sleepUntil) {
+        waitForThreads.signalAll()
+        wakeCondition.await()
+      }
+      numSleepingThreads--
+    }
+  }
+
+  /**
+   * Returns the total number of times the [FakeSleeper] has been called. This is thread-safe, but
+   * the value may not be meaningful if the sleeper is being used concurrently.
+   */
+  fun sleepCount(): Int {
+    lock.withLock {
+      return count
+    }
+  }
+
+  /**
+   * Returns the last duration [FakeSleeper] was called with. This is thread-safe, but the value may
+   * not be meaningful if the sleeper is being used concurrently.
+   */
+  fun lastSleepDuration(): Duration? {
+    lock.withLock {
+      return lastDuration
+    }
+  }
+}

--- a/misk-testing/src/main/kotlin/misk/concurrent/FakeSleeperModule.kt
+++ b/misk-testing/src/main/kotlin/misk/concurrent/FakeSleeperModule.kt
@@ -1,0 +1,10 @@
+package misk.concurrent
+
+import misk.inject.KAbstractModule
+
+class FakeSleeperModule : KAbstractModule() {
+  override fun configure() {
+    bind<Sleeper>().to<FakeSleeper>()
+    bind<FakeSleeper>()
+  }
+}

--- a/misk-testing/src/test/kotlin/misk/concurrent/FakeScheduledExecutorServiceTest.kt
+++ b/misk-testing/src/test/kotlin/misk/concurrent/FakeScheduledExecutorServiceTest.kt
@@ -1,0 +1,29 @@
+package misk.concurrent
+
+import misk.time.FakeClock
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.time.Duration
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+
+class FakeScheduledExecutorServiceTest {
+  @Test
+  fun testScheduleTask() {
+    val clock = FakeClock()
+    val executor = FakeScheduledExecutorService(clock)
+    val done = CountDownLatch(1)
+    val result = 5
+
+    val task = executor.schedule<Int>({
+      done.countDown()
+      result
+    }, 10, TimeUnit.SECONDS)
+
+    clock.add(Duration.ofSeconds(10))
+    executor.tick()
+
+    assertThat(done.await(1L, TimeUnit.SECONDS)).isTrue()
+    assertThat(task.get()).isEqualTo(result)
+  }
+}

--- a/misk-testing/src/test/kotlin/misk/concurrent/FakeSleeperTest.kt
+++ b/misk-testing/src/test/kotlin/misk/concurrent/FakeSleeperTest.kt
@@ -1,0 +1,81 @@
+package misk.concurrent
+
+import misk.time.FakeClock
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.time.Duration
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+
+class FakeSleeperTest {
+  @Test
+  fun testSleep() {
+    val clock = FakeClock()
+    val sleeper = FakeSleeper(clock)
+    val awake = CountDownLatch(1)
+    Thread {
+      sleeper.sleep(Duration.ofMillis(1000))
+      awake.countDown()
+    }.start()
+
+    sleeper.waitForSleep(1)
+
+    clock.add(Duration.ofMillis(1000))
+    sleeper.tick()
+    assertThat(awake.await(1L, TimeUnit.SECONDS)).isTrue()
+    assertThat(sleeper.sleepCount()).isEqualTo(1)
+    assertThat(sleeper.lastSleepDuration()).isEqualTo(Duration.ofMillis(1000))
+  }
+
+  @Test
+  fun testConcurrentSleep() {
+    val clock = FakeClock()
+    val sleeper = FakeSleeper(clock)
+    val awake = CountDownLatch(2)
+    Thread {
+      sleeper.sleep(Duration.ofMillis(1000))
+      awake.countDown()
+    }.start()
+    Thread {
+      sleeper.sleep(Duration.ofMillis(1000))
+      awake.countDown()
+    }.start()
+
+    sleeper.waitForSleep(2)
+
+    clock.add(Duration.ofMillis(1000))
+    sleeper.tick()
+    assertThat(awake.await(1L, TimeUnit.SECONDS)).isTrue()
+    assertThat(sleeper.sleepCount()).isEqualTo(2)
+    assertThat(sleeper.lastSleepDuration()).isEqualTo(Duration.ofMillis(1000))
+  }
+
+  @Test
+  fun testSequentialWake() {
+    val clock = FakeClock()
+    val sleeper = FakeSleeper(clock)
+    val awake1 = CountDownLatch(1)
+    val awake2 = CountDownLatch(1)
+    Thread {
+      sleeper.sleep(Duration.ofMillis(1000))
+      awake1.countDown()
+    }.start()
+    Thread {
+      sleeper.sleep(Duration.ofMillis(2000))
+      awake2.countDown()
+    }.start()
+
+    sleeper.waitForSleep(2)
+    clock.add(Duration.ofMillis(1000))
+    sleeper.tick()
+
+    assertThat(awake1.await(1L, TimeUnit.SECONDS)).isTrue()
+
+    sleeper.waitForSleep(1)
+    clock.add(Duration.ofMillis(1000))
+    sleeper.tick()
+
+    assertThat(awake2.await(1L, TimeUnit.SECONDS)).isTrue()
+    assertThat(sleeper.sleepCount()).isEqualTo(2)
+  }
+}

--- a/misk/src/main/kotlin/misk/MiskServiceModule.kt
+++ b/misk/src/main/kotlin/misk/MiskServiceModule.kt
@@ -18,6 +18,7 @@ import com.google.inject.spi.InstanceBinding
 import com.google.inject.spi.LinkedKeyBinding
 import com.google.inject.spi.ProviderInstanceBinding
 import com.google.inject.util.Types
+import misk.concurrent.SleeperModule
 import misk.environment.RealEnvVarModule
 import misk.healthchecks.HealthCheck
 import misk.inject.KAbstractModule
@@ -41,6 +42,7 @@ class MiskRealServiceModule : KAbstractModule() {
     install(ResourceLoaderModule())
     install(RealEnvVarModule())
     install(ClockModule())
+    install(SleeperModule())
     install(MiskCommonServiceModule())
   }
 }

--- a/misk/src/main/kotlin/misk/concurrent/Sleeper.kt
+++ b/misk/src/main/kotlin/misk/concurrent/Sleeper.kt
@@ -1,0 +1,19 @@
+package misk.concurrent
+
+import java.time.Duration
+
+/**
+ * Abstraction for Thread.sleep() that allows for testing.
+ */
+interface Sleeper {
+  fun sleep(duration: Duration)
+
+  companion object {
+    val DEFAULT: Sleeper = object : Sleeper {
+      override fun sleep(duration: Duration) {
+        Thread.sleep(duration.toMillis())
+      }
+    }
+  }
+
+}

--- a/misk/src/main/kotlin/misk/concurrent/SleeperModule.kt
+++ b/misk/src/main/kotlin/misk/concurrent/SleeperModule.kt
@@ -1,0 +1,9 @@
+package misk.concurrent
+
+import misk.inject.KAbstractModule
+
+internal class SleeperModule : KAbstractModule() {
+  override fun configure() {
+    bind<Sleeper>().toInstance(Sleeper.DEFAULT)
+  }
+}


### PR DESCRIPTION
`FakeScheduledExecutorService` can be used to test delayed task execution, and is copied from an internal implementation by @davidgarth 

`FakeSleeper` can be used to test `Thread.sleep()` calls.
