### PR TITLE
Add a ClientNetworkInterceptorsModule for common interceptors

### DIFF
--- a/misk/src/main/kotlin/misk/client/ClientNetworkInterceptorsModule.kt
+++ b/misk/src/main/kotlin/misk/client/ClientNetworkInterceptorsModule.kt
@@ -1,0 +1,12 @@
+package misk.client
+
+import misk.inject.KAbstractModule
+
+/**
+ * The common set of [ClientNetworkInterceptor]s for all misk apps.
+ */
+class ClientNetworkInterceptorsModule : KAbstractModule() {
+  override fun configure() {
+    multibind<ClientNetworkInterceptor.Factory>().to<ClientMetricsInterceptor.Factory>()
+  }
+}


### PR DESCRIPTION
This will allow apps to receive common interceptors for free in the
future.