### PR TITLE
Add tag support to TracerExt

### DIFF
--- a/misk/src/main/kotlin/misk/tracing/TracerExt.kt
+++ b/misk/src/main/kotlin/misk/tracing/TracerExt.kt
@@ -4,12 +4,19 @@ import io.opentracing.Span
 import io.opentracing.Tracer
 import io.opentracing.tag.Tags
 
-/** [trace] traces the given function with the specific span name */
-fun <T : Any?> Tracer.trace(spanName: String, f: () -> T): T = traceWithSpan(spanName) { _ -> f() }
+/** [trace] traces the given function with the specific span name and optional tags */
+fun <T : Any?> Tracer.trace(spanName: String, tags: Map<String, String> = mapOf(), f: () -> T): T =
+    traceWithSpan(spanName, tags) { f() }
 
 /** [trace] traces the given function, passing the span into the function */
-fun <T : Any?> Tracer.traceWithSpan(spanName: String, f: (Span) -> T): T {
+fun <T : Any?> Tracer.traceWithSpan(
+  spanName: String,
+  tags: Map<String, String> = mapOf(),
+  f: (Span) -> T
+): T {
   val spanBuilder = buildSpan(spanName)
+  tags.forEach { k, v -> spanBuilder.withTag(k, v) }
+
   activeSpan()?.let { spanBuilder.asChildOf(it) }
 
   val scope = spanBuilder.startActive(true)

--- a/misk/src/test/kotlin/misk/tracing/TracerExtTest.kt
+++ b/misk/src/test/kotlin/misk/tracing/TracerExtTest.kt
@@ -29,6 +29,21 @@ class TracerExtTest {
     val spanUsed = tracer.traceWithSpan("traceMe") { span -> span }
     assertThat(mockTracer.finishedSpans().size).isEqualTo(1)
     assertThat(spanUsed).isEqualTo(mockTracer.finishedSpans().first())
+    assertThat(mockTracer.finishedSpans().first().tags()).isEmpty()
+  }
+
+  @Test
+  fun traceTracedMethodWithTags() {
+    val mockTracer = tracer as MockTracer
+
+    val tags = mapOf("a" to "b", "x" to "y")
+
+    assertThat(mockTracer.finishedSpans().size).isEqualTo(0)
+    val spanUsed = tracer.traceWithSpan("traceMe", tags) { span -> span }
+    assertThat(mockTracer.finishedSpans().size).isEqualTo(1)
+    assertThat(spanUsed).isEqualTo(mockTracer.finishedSpans().first())
+
+    assertThat(mockTracer.finishedSpans().first().tags()).isEqualTo(tags)
   }
 
   @Test


### PR DESCRIPTION
Adds support for passing optional tags when creating spans.