### PR TITLE
Make misk-hibernate-testing depend on misk-hibernate

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -66,12 +66,12 @@ subprojects {
       jvmTarget = "1.8"
       allWarningsAsErrors = true
     }
-  } 
+  }
   sourceSets {
     main.java.srcDirs += 'src/main/kotlin/'
     test.java.srcDirs += 'src/test/kotlin/'
   }
-  
+
   dependencies {
     testImplementation dep.junitApi
     testRuntimeOnly dep.junitEngine

--- a/misk-hibernate-testing/build.gradle
+++ b/misk-hibernate-testing/build.gradle
@@ -4,3 +4,9 @@ dependencies {
   compile project(':misk-testing')
   compile project(':misk-hibernate')
 }
+
+test {
+  // To help that with parallel execution by reusing test setup,
+  // misk-hibernate-testing is made dependent on misk-hibernate
+  dependsOn ':misk-hibernate:test'
+}


### PR DESCRIPTION
This is to ensure that when run in parallel,
the expensive DB setup is only performed once