### PR TITLE
StartVitessService can reuse running Vitess server

### DIFF
--- a/misk-hibernate/src/main/kotlin/misk/vitess/StartVitessService.kt
+++ b/misk-hibernate/src/main/kotlin/misk/vitess/StartVitessService.kt
@@ -301,6 +301,17 @@ class LogContainerResultCallback : ResultCallbackTemplate<LogContainerResultCall
   }
 }
 
+/**
+ * All Vitess clusters used by the app/test are tracked in a global cache as a [DockerVitessCluster].
+ *
+ * On startup, the service will look for a cluster in the cache, and if not found, look for it in
+ * Docker by container name, or as a last resort start the container itself.
+ *
+ * On shutdown, the cache is invalidated by a JVM shutdown hook. On invalidation, the cache will
+ * call the each entry's `stop()` method. If the cluster container was created in this JVM, it
+ * will be stopped and removed. Otherwise (if the container was started by a different process), it
+ * will be left running.
+ */
 class StartVitessService(
   private val qualifier: KClass<out Annotation>,
   private val environment: Environment,


### PR DESCRIPTION
Gives a stable name for the Vitess docker container that `StartVitessService` starts, and allows the service to reuse an already running container with the same name, so that Vitess can be started in a separate process and kept running across dev server restart and test invocations. This is intended to help with rapid iteration of code changes without having to pay the cost of starting a Vitess server each time.

`startVitessDaemon` provides a simple hook for a `main` function to start a Vitess server in a separate process.