### PR TITLE
Introduce CachedTestService to speedup tests

### DIFF
--- a/misk-aws/src/test/kotlin/misk/jobqueue/sqs/DockerSqs.kt
+++ b/misk-aws/src/test/kotlin/misk/jobqueue/sqs/DockerSqs.kt
@@ -4,11 +4,11 @@ import com.amazonaws.services.sqs.AmazonSQS
 import com.amazonaws.services.sqs.model.QueueDoesNotExistException
 import com.github.dockerjava.api.model.ExposedPort
 import com.github.dockerjava.api.model.Ports
-import com.google.common.util.concurrent.AbstractIdleService
 import misk.containers.Composer
 import misk.containers.Container
 import misk.jobqueue.sqs.DockerSqs.Companion.CLIENT_PORT
 import misk.logging.getLogger
+import misk.service.CachedTestService
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -37,12 +37,10 @@ internal class DockerSqs {
   }
 
 
-  @Singleton
-  internal class Service @Inject constructor(
-    private val server: DockerSqs,
+  @Singleton internal class Service @Inject constructor(
     private val client: AmazonSQS
-  ) : AbstractIdleService() {
-    override fun startUp() {
+  ) : CachedTestService() {
+    override fun actualStartup() {
       server.start()
       while (true) {
         try {
@@ -57,8 +55,12 @@ internal class DockerSqs {
       }
     }
 
-    override fun shutDown() {
+    override fun actualShutdown() {
       server.stop()
+    }
+
+    companion object {
+      val server = DockerSqs()
     }
   }
 

--- a/misk-aws/src/test/kotlin/misk/jobqueue/sqs/SqsJobQueueTest.kt
+++ b/misk-aws/src/test/kotlin/misk/jobqueue/sqs/SqsJobQueueTest.kt
@@ -40,7 +40,13 @@ internal class SqsJobQueueTest {
   @Inject private lateinit var consumer: JobConsumer
   @Inject private lateinit var sqsMetrics: SqsMetrics
 
+  private lateinit var queueName: QueueName
+  private lateinit var deadLetterQueueName: QueueName
+
   @BeforeEach fun createQueues() {
+    // Ensure that each test case runs on a unique queue
+    queueName = QueueName("sqs_job_queue_test" + queueSuffix.incrementAndGet())
+    deadLetterQueueName = queueName.deadLetterQueue
     sqs.createQueue(deadLetterQueueName.value)
     sqs.createQueue(CreateQueueRequest()
         .withQueueName(queueName.value)
@@ -257,7 +263,6 @@ internal class SqsJobQueueTest {
   }
 
   companion object {
-    private val queueName = QueueName("my_queue")
-    private val deadLetterQueueName = queueName.deadLetterQueue
+    private val queueSuffix = AtomicInteger(0)
   }
 }

--- a/misk-testing/src/main/kotlin/misk/service/CachedTestService.kt
+++ b/misk-testing/src/main/kotlin/misk/service/CachedTestService.kt
@@ -1,0 +1,73 @@
+package misk.service
+
+import com.google.common.util.concurrent.AbstractIdleService
+import misk.logging.getLogger
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicBoolean
+
+/**
+ * Test services can derive from CachedTestService
+ * if they'd like to reuse the same service for the span
+ * of a given runtime. This is helpful when you want to avoid
+ * incurring the cost of service startup and shutdown with
+ * each test run.
+ *
+ * NOTE: The caching is only useful if the implementing service
+ * references a shared instance of their underlying resources.
+ * A common way to do this is to leverage a companion object.
+ *
+ * Example:
+ *
+ * @Singleton class TestService : CachedTestService() {
+ *   override fun actualStartup() {
+ *     service.start()
+ *   }
+ *
+ *   override fun actualShutdown() {
+ *     service.stop()
+ *   }
+ *
+ *   companion object {
+ *     private val service = Service()
+ *   }
+ * }
+ *
+ * Sharing the same underlying resources also means that
+ * your tests need to be more conscious about accessing
+ * resources scoped uniquely to that test run, or else
+ * making sure that they cleanup resources before they're run.
+ * This is similar to how we work with DBs, where either
+ * you run something like truncate tables before your tests,
+ * or you ensure that all your test statements are made
+ * relative to the scope of your test.
+ */
+abstract class CachedTestService : AbstractIdleService() {
+  final override fun startUp() {
+    val serviceBool = hasStartedByService.getOrPut(javaClass.name) { AtomicBoolean() }
+    if (serviceBool.compareAndSet(false, true)) {
+      log.info { "starting $javaClass.name" }
+      actualStartup()
+      Runtime.getRuntime().addShutdownHook(Thread {
+        log.info { "stopping $javaClass.name" }
+        actualShutdown()
+      })
+    } else {
+      log.info { "$javaClass.name already running, not starting anything" }
+    }
+  }
+
+  final override fun shutDown() {
+    log.info { "$javaClass.name is cached, will shutdown on runtime shutdown" }
+  }
+
+  companion object {
+    private val hasStartedByService = ConcurrentHashMap<String, AtomicBoolean>()
+    private val log = getLogger<CachedTestService>()
+  }
+
+  /** Actually starts the service up. This will be invoked once per runtime. */
+  abstract fun actualStartup()
+
+  /** Actually shuts the service down. This will be invoked once per runtime. */
+  abstract fun actualShutdown()
+}

--- a/misk-testing/src/test/kotlin/misk/service/CachedTestServiceTest.kt
+++ b/misk-testing/src/test/kotlin/misk/service/CachedTestServiceTest.kt
@@ -1,0 +1,52 @@
+package misk.service
+
+import org.junit.jupiter.api.Test
+import java.util.concurrent.atomic.AtomicBoolean
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+internal class CachedTestServiceTest {
+  class ServiceA : CachedTestService() {
+    override fun actualStartup() {
+      started.set(true)
+    }
+
+    override fun actualShutdown() {
+      started.set(false)
+    }
+
+    companion object {
+      var started = AtomicBoolean(false)
+    }
+  }
+
+  class ServiceB : CachedTestService() {
+    override fun actualStartup() {
+      started.set(true)
+    }
+
+    override fun actualShutdown() {
+      started.set(false)
+    }
+
+    companion object {
+      var started = AtomicBoolean(false)
+    }
+  }
+
+  @Test fun cachedTestServiceWithMultipleServices() {
+    val serviceA = ServiceA()
+    val serviceB = ServiceB()
+
+    assertFalse { ServiceA.started.get() }
+    assertFalse { ServiceB.started.get() }
+
+    serviceA.startAsync().awaitRunning()
+    assertTrue { ServiceA.started.get() }
+    assertFalse { ServiceB.started.get() }
+
+    serviceB.startAsync().awaitRunning()
+    assertTrue { ServiceA.started.get() }
+    assertTrue { ServiceB.started.get() }
+  }
+}


### PR DESCRIPTION
To reuse services across test runs in a given
runtime. We use this for the docker sqs service
and the zk test service.