### PR TITLE
Enable gradle build caching for CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ install:
   - docker pull squareup/misk-web
 
 script:
-  - ./gradlew test --parallel --scan
+  - ./gradlew test --parallel --scan --build-cache
 
 # Gradle caching - as per https://docs.travis-ci.com/user/languages/java/#Projects-Using-Gradle
 before_cache:


### PR DESCRIPTION
Turns out we weren't actually using build caches! The travis-CI config we had was the travis-side of storing/loading the cache results, but the cache was never being populated in the first place.