### PR TITLE
Remove eager misk/web pull

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,6 @@ language: java
 jdk:
   - openjdk11
 
-install:
-  - docker pull squareup/misk-web
-
 script:
   - ./gradlew test --parallel --scan
 


### PR DESCRIPTION
@adrw: It looks like with a recent bump of misk-web, the version that should be docker-pulled is 0.1.3. Thus, this install command was causing us to perform two docker pulls of misk-web. One for latest and one for 0.1.3. I'm not really seeing why we want this in the install step anyways instead of happening as part of the gradle build, so I'm removing it for now to reduce the extra build time.

Example build log where the pull happens twice, latest master: https://travis-ci.org/square/misk/builds/491356844