### PR TITLE
Add functions to get/set values as ByteArrays in misk-redis.

### DIFF
--- a/misk-redis/src/main/kotlin/misk/redis/FakeRedis.kt
+++ b/misk-redis/src/main/kotlin/misk/redis/FakeRedis.kt
@@ -1,6 +1,7 @@
 package misk.redis
 
 import misk.time.FakeClock
+import okio.ByteString
 import java.time.Duration
 import java.time.Instant
 import java.util.concurrent.ConcurrentHashMap
@@ -10,17 +11,19 @@ import javax.inject.Inject
 class FakeRedis : Redis {
   @Inject lateinit var clock: FakeClock
 
-  // The value type stored in our key-value store
+  // The value type stored in our key-value store.
   private data class Value (
-    val value: String,
+    val data: ByteString,
     val expiryInstant: Instant
   )
 
-  // Acts as the Redis key-value store
+  // Acts as the Redis key-value store.
   private val keyValueStore = ConcurrentHashMap<String, Value>()
 
   override fun del(key: String): Boolean {
-    if (!keyValueStore.containsKey(key)) return false
+    if (!keyValueStore.containsKey(key)) {
+      return false
+    }
 
     return keyValueStore.remove(key) != null
   }
@@ -30,7 +33,7 @@ class FakeRedis : Redis {
     return keys.count { del(it) }
   }
 
-  override fun get(key: String): String? {
+  override fun get(key: String): ByteString? {
     val value = keyValueStore[key] ?: return null
 
     // Check if the key has expired
@@ -39,18 +42,21 @@ class FakeRedis : Redis {
       return null
     }
 
-    return value.value
+    return value.data
   }
 
-  // Sets the value for a key, the key does not expire
-  override fun set(key: String, value: String): String {
+  override fun set(key: String, value: ByteString) {
     // Set the key to expire at the latest possible instant
-    keyValueStore[key] = Value(value = value, expiryInstant = Instant.MAX)
-    return value
+    keyValueStore[key] = Value(
+      data = value,
+      expiryInstant = Instant.MAX
+    )
   }
 
-  override fun set(key: String, expiryDuration: Duration, value: String): String {
-    keyValueStore[key] = Value(value = value, expiryInstant = clock.instant().plusSeconds(expiryDuration.seconds))
-    return value
+  override fun set(key: String, expiryDuration: Duration, value: ByteString) {
+    keyValueStore[key] = Value(
+      data = value,
+      expiryInstant = clock.instant().plusSeconds(expiryDuration.seconds)
+    )
   }
 }

--- a/misk-redis/src/main/kotlin/misk/redis/RealRedis.kt
+++ b/misk-redis/src/main/kotlin/misk/redis/RealRedis.kt
@@ -1,42 +1,54 @@
 package misk.redis
 
+import okio.ByteString
+import okio.ByteString.Companion.toByteString
 import redis.clients.jedis.JedisPool
 import java.time.Duration
 
 /** For each command, a Jedis instance is retrieved from the pool and returned once the command has been issued. */
 class RealRedis(private val jedisPool: JedisPool) : Redis {
+  // Delete key
   override fun del(key: String): Boolean {
     jedisPool.resource.use { jedis ->
       return (jedis.del(key) == 1L)
     }
   }
 
+  // Delete multiple keys
   override fun del(vararg keys: String): Int {
     jedisPool.resource.use { jedis ->
       return jedis.del(*keys).toInt()
     }
   }
 
-  override fun get(key: String): String? {
+  // Get a ByteString value
+  override fun get(key: String): ByteString? {
     jedisPool.resource.use { jedis ->
-      return jedis.get(key)
+      return jedis.get(key.toByteArray(charset)).toByteString()
     }
   }
 
-  override fun set(key: String, value: String): String {
+  // Set a ByteArray value
+  override fun set(key: String, value: ByteString) {
     jedisPool.resource.use { jedis ->
-      return jedis.set(key, value)
+      jedis.set(key.toByteArray(charset), value.toByteArray())
     }
   }
 
-  override fun set(key: String, expiryDuration: Duration, value: String): String {
+  // Set a ByteArray value with an expiration
+  override fun set(key: String, expiryDuration: Duration, value: ByteString) {
     jedisPool.resource.use { jedis ->
-      return jedis.setex(key, expiryDuration.seconds.toInt(), value)
+      jedis.setex(key.toByteArray(charset), expiryDuration.seconds.toInt(), value.toByteArray())
     }
   }
 
   /** Closes the connection to Redis. */
   fun close() {
     return jedisPool.close()
+  }
+
+  companion object {
+    /** The charset used to convert String keys to ByteArrays for Jedis commands. */
+    private val charset = Charsets.UTF_8
   }
 }

--- a/misk-redis/src/main/kotlin/misk/redis/Redis.kt
+++ b/misk-redis/src/main/kotlin/misk/redis/Redis.kt
@@ -1,5 +1,6 @@
 package misk.redis
 
+import okio.ByteString
 import java.time.Duration
 
 /** A Redis client. */
@@ -8,7 +9,7 @@ interface Redis {
    * Deletes a single key.
    *
    * @param key the key to delete
-   * @return 0 if the key was not deleted, 1 if the key was deleted
+   * @return false if the key was not deleted, true if the key was deleted
    */
   fun del(key: String): Boolean
 
@@ -22,29 +23,27 @@ interface Redis {
   fun del(vararg keys: String): Int
 
   /**
-   * Retrieves a key.
+   * Retrieves the value for the given key as a [ByteString].
    *
    * @param key the key to retrieve
-   * @return a string value if the key was found, null if the key was not found
+   * @return a [ByteString] if the key was found, null if the key was not found
    */
-  operator fun get(key: String): String?
+  operator fun get(key: String): ByteString?
 
   /**
-   * Sets a value for a key.
+   * Sets the [ByteString] value for the given key.
    *
    * @param key the key to set
    * @param value the value to set
-   * @return the value that was set
    */
-  operator fun set(key: String, value: String): String
+  operator fun set(key: String, value: ByteString)
 
   /**
-   * Sets a key with an expiration date.
+   * Sets the [ByteString] value for a key with an expiration date.
    *
    * @param key the key to set
    * @param expiryDuration the amount of time before the key expires
    * @param value the value to set
-   * @return the value that was set
    */
-  fun set(key: String, expiryDuration: Duration, value: String): String
+  operator fun set(key: String, expiryDuration: Duration, value: ByteString)
 }

--- a/misk-redis/src/test/kotlin/misk/redis/FakeRedisTest.kt
+++ b/misk-redis/src/test/kotlin/misk/redis/FakeRedisTest.kt
@@ -6,28 +6,35 @@ import misk.testing.MiskTest
 import misk.testing.MiskTestModule
 import misk.time.FakeClock
 import misk.time.FakeClockModule
+import okio.ByteString.Companion.encodeUtf8
 import org.junit.jupiter.api.Test
 import java.time.Duration
 import javax.inject.Inject
-import kotlin.test.*
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
 @MiskTest
 class FakeRedisTest {
+  @Suppress("unused")
   @MiskTestModule
   val module: Module = Modules.combine(FakeClockModule(), RedisTestModule())
 
   @Inject lateinit var clock: FakeClock
   @Inject lateinit var redis: Redis
 
-  @Test fun simpleSetGet() {
+  @Test
+  fun simpleStringSetGet() {
     val key = "test key"
+    val value = "test value".encodeUtf8()
+    val valueOverride = "test value override".encodeUtf8()
     val unknownKey = "this key doesn't exist"
-    val value = "test value"
-    val valueOverride = "test value override"
 
     // Set the value and read it
     redis[key] = value
-    assertEquals(value, redis[key], "Got unexpected value")
+    assertEquals(value, redis[key])
 
     // Overwrite the value and read it
     redis[key] = valueOverride
@@ -39,16 +46,16 @@ class FakeRedisTest {
 
   @Test fun setWithExpiry() {
     val key = "key"
-    val value = "value"
+    val value = "value".encodeUtf8()
     val expirySec = 5L
 
-    // Set a key that expires
-    redis.set(key, Duration.ofSeconds(expirySec), value)
-    assertEquals(value, redis[key], "Got unexpected value")
+    // Set keys that expire
+    redis[key, Duration.ofSeconds(expirySec)] = value
+    assertEquals(value, redis[key])
 
     // Key should still be there
     clock.add(Duration.ofSeconds(4))
-    assertEquals(value, redis[key], "Got unexpected value")
+    assertEquals(value, redis[key])
 
     // Key should now be expired
     clock.add(Duration.ofSeconds(1))
@@ -61,15 +68,15 @@ class FakeRedisTest {
 
   @Test fun overridingResetsExpiry() {
     val key = "key"
-    val value = "value"
+    val value = "value".encodeUtf8()
     val expirySec = 5L
 
     // Set a key that expires
-    redis.set(key, Duration.ofSeconds(expirySec), value)
+    redis[key, Duration.ofSeconds(expirySec)] = value
 
     // Right before the key expires, override it with a new expiry time
     clock.add(Duration.ofSeconds(4))
-    redis.set(key, Duration.ofSeconds(expirySec), value)
+    redis[key, Duration.ofSeconds(expirySec)] = value
 
     // Key should not be expired
     clock.add(Duration.ofSeconds(4))
@@ -82,12 +89,12 @@ class FakeRedisTest {
 
   @Test fun deleteKey() {
     val key = "key"
+    val value = "value".encodeUtf8()
     val unknownKey = "this key doesn't exist"
-    val value = "value"
 
     // Set key
     redis[key] = value
-    assertEquals(value, redis[key], "Got unexpected value")
+    assertEquals(value, redis[key])
 
     // Delete key
     assertTrue(redis.del(key), "1 key should have been deleted")
@@ -100,7 +107,7 @@ class FakeRedisTest {
   @Test fun deleteMultipleKeys() {
     val keysToInsert = listOf("key1", "key2").toTypedArray()
     val key3 = "key3"
-    val value = "value"
+    val value = "value".encodeUtf8()
 
     // Set all keys except key3
     keysToInsert.forEach { redis[it] = value }


### PR DESCRIPTION
These functions can be used to store arbitrary arrays of bytes in Redis. A service may
want to do this to store protos for example.