### PR TITLE
Expose datasource defaults

### DIFF
--- a/misk-hibernate/src/main/kotlin/misk/hibernate/HibernateModule.kt
+++ b/misk-hibernate/src/main/kotlin/misk/hibernate/HibernateModule.kt
@@ -38,8 +38,10 @@ private const val ROW_COUNT_WARNING_LIMIT = 2000
 
 class HibernateModule(
   private val qualifier: KClass<out Annotation>,
-  private val config: DataSourceConfig
+  config: DataSourceConfig
 ) : KAbstractModule() {
+  val config = config.withDefaults()
+
   override fun configure() {
     val configKey = DataSourceConfig::class.toKey(qualifier)
 

--- a/misk-hibernate/src/main/kotlin/misk/jdbc/DataSourceConfig.kt
+++ b/misk-hibernate/src/main/kotlin/misk/jdbc/DataSourceConfig.kt
@@ -7,58 +7,21 @@ import java.time.Duration
 /** Defines a type of datasource */
 enum class DataSourceType(
   val driverClassName: String,
-  val hibernateDialect: String,
-  val buildJdbcUrl: (DataSourceConfig, Environment) -> String
+  val hibernateDialect: String
 ) {
   MYSQL(
       driverClassName = "io.opentracing.contrib.jdbc.TracingDriver",
-      hibernateDialect = "org.hibernate.dialect.MySQL57Dialect",
-      buildJdbcUrl = { config, env ->
-        val port = config.port ?: 3306
-        val host = config.host ?: "127.0.0.1"
-        val database = config.database ?: ""
-        val testing = env == Environment.TESTING || env == Environment.DEVELOPMENT
-        var queryParams = if (testing) "?createDatabaseIfNotExist=true" else ""
-        // TODO(rhall): share this with DataSource config in SessionFactoryService.
-        // https://github.com/square/misk/issues/397
-        // Explicitly not updating VITESS below since this is a temporary hack until the above
-        // issue is resolved.
-        if (!config.trust_certificate_key_store_url.isNullOrBlank()) {
-          require(!config.trust_certificate_key_store_password.isNullOrBlank()) {
-            "must provide a trust_certificate_key_store_password"
-          }
-          if (!testing) {
-            queryParams += "?"
-          } else {
-            queryParams += "&"
-          }
-          queryParams += "trustCertificateKeyStoreUrl=${config.trust_certificate_key_store_url}"
-          queryParams += "&trustCertificateKeyStorePassword=${config.trust_certificate_key_store_password}"
-          queryParams += "&verifyServerCertificate=true"
-          queryParams += "&useSSL=true"
-          queryParams += "&requireSSL=true"
-        }
-        "jdbc:tracing:mysql://$host:$port/$database$queryParams"
-      }
+      hibernateDialect = "org.hibernate.dialect.MySQL57Dialect"
   ),
   HSQLDB(
       driverClassName = "org.hsqldb.jdbcDriver",
-      hibernateDialect = "org.hibernate.dialect.H2Dialect",
-      buildJdbcUrl = { config, _ ->
-        "jdbc:hsqldb:mem:${config.database!!};sql.syntax_mys=true"
-      }
+      hibernateDialect = "org.hibernate.dialect.H2Dialect"
   ),
   VITESS(
       // TODO: Switch back to mysql protocol when this issue is fixed: https://github.com/vitessio/vitess/issues/4100
       // Find the correct buildJdbcUrl and port in the git history
       driverClassName = "io.vitess.jdbc.VitessDriver",
-      hibernateDialect = "misk.hibernate.VitessDialect",
-      buildJdbcUrl = { config, _ ->
-        val port = config.port ?: 27001
-        val host = config.host ?: "127.0.0.1"
-        val database = config.database ?: ""
-        "jdbc:vitess://$host:$port/$database"
-      }
+      hibernateDialect = "misk.hibernate.VitessDialect"
   ),
 }
 
@@ -78,14 +41,72 @@ data class DataSourceConfig(
   val migrations_resources: List<String>? = null,
   val vitess_schema_dir: String? = null,
   val vitess_schema_resource_root: String? = null,
-  /*
-     See https://dev.mysql.com/doc/connector-j/8.0/en/connector-j-reference-using-ssl.html for
-     trust_certificate_key_store_* details.
-   */
+    /*
+       See https://dev.mysql.com/doc/connector-j/8.0/en/connector-j-reference-using-ssl.html for
+       trust_certificate_key_store_* details.
+     */
   val trust_certificate_key_store_url: String? = null,
   val trust_certificate_key_store_password: String? = null,
   val show_sql: String? = "false"
-)
+) {
+  fun withDefaults(): DataSourceConfig {
+    return when (type) {
+      DataSourceType.MYSQL -> {
+        copy(
+            port = port ?: 3306,
+            host = host ?: "127.0.0.1",
+            database = database ?: ""
+        )
+      }
+      DataSourceType.HSQLDB -> {
+        this
+      }
+      DataSourceType.VITESS -> {
+        copy(
+            port = port ?: 27001,
+            host = host ?: "127.0.0.1",
+            database = database ?: ""
+        )
+      }
+    }
+  }
+
+  fun buildJdbcUrl(env: Environment): String {
+    val config = withDefaults()
+    return when (type) {
+      DataSourceType.MYSQL -> {
+        val testing = env == Environment.TESTING || env == Environment.DEVELOPMENT
+        var queryParams = if (testing) "?createDatabaseIfNotExist=true" else ""
+        // TODO(rhall): share this with DataSource config in SessionFactoryService.
+        // https://github.com/square/misk/issues/397
+        // Explicitly not updating VITESS below since this is a temporary hack until the above
+        // issue is resolved.
+        if (!trust_certificate_key_store_url.isNullOrBlank()) {
+          require(!trust_certificate_key_store_password.isNullOrBlank()) {
+            "must provide a trust_certificate_key_store_password"
+          }
+          if (!testing) {
+            queryParams += "?"
+          } else {
+            queryParams += "&"
+          }
+          queryParams += "trustCertificateKeyStoreUrl=${trust_certificate_key_store_url}"
+          queryParams += "&trustCertificateKeyStorePassword=${trust_certificate_key_store_password}"
+          queryParams += "&verifyServerCertificate=true"
+          queryParams += "&useSSL=true"
+          queryParams += "&requireSSL=true"
+        }
+        "jdbc:tracing:mysql://${config.host}:${config.port}/${config.database}$queryParams"
+      }
+      DataSourceType.HSQLDB -> {
+        "jdbc:hsqldb:mem:${database!!};sql.syntax_mys=true"
+      }
+      DataSourceType.VITESS -> {
+        "jdbc:vitess://${config.host}:${config.port}/${config.database}"
+      }
+    }
+  }
+}
 
 /** Configuration element for a cluster of DataSources */
 data class DataSourceClusterConfig(

--- a/misk-hibernate/src/main/kotlin/misk/jdbc/DataSourceService.kt
+++ b/misk-hibernate/src/main/kotlin/misk/jdbc/DataSourceService.kt
@@ -40,7 +40,7 @@ internal class DataSourceService(
 
     val config = HikariConfig()
     config.driverClassName = this.config.type.driverClassName
-    config.jdbcUrl = this.config.type.buildJdbcUrl(this.config, environment)
+    config.jdbcUrl = this.config.buildJdbcUrl(environment)
     if (this.config.username != null) {
       config.username = this.config.username
     }

--- a/misk-hibernate/src/main/kotlin/misk/jdbc/PingDatabaseService.kt
+++ b/misk-hibernate/src/main/kotlin/misk/jdbc/PingDatabaseService.kt
@@ -29,7 +29,7 @@ class PingDatabaseService @Inject constructor(
   override val producedKeys: Set<Key<*>> = setOf(PingDatabaseService::class.toKey(qualifier))
 
   override fun startUp() {
-    val jdbcUrl = config.type.buildJdbcUrl(config, environment)
+    val jdbcUrl = this.config.buildJdbcUrl(environment)
     val dataSource = DriverDataSource(
         jdbcUrl, config.type.driverClassName, Properties(), config.username, config.password)
     retry(10, ExponentialBackoff(Duration.ofMillis(20), Duration.ofMillis(1000))) {

--- a/misk-hibernate/src/main/kotlin/misk/vitess/StartVitessService.kt
+++ b/misk-hibernate/src/main/kotlin/misk/vitess/StartVitessService.kt
@@ -105,7 +105,7 @@ class VitessCluster(
   fun openMysqlConnection() = mysqlDataSource().connection
 
   private fun dataSource(): DriverDataSource {
-    val jdbcUrl = config.type.buildJdbcUrl(config, TESTING)
+    val jdbcUrl = config.buildJdbcUrl(TESTING)
     return DriverDataSource(
         jdbcUrl, config.type.driverClassName, Properties(), config.username, config.password)
   }
@@ -120,7 +120,7 @@ class VitessCluster(
 
   private fun mysqlDataSource(): DriverDataSource {
     val config = mysqlConfig()
-    val jdbcUrl = config.type.buildJdbcUrl(config, TESTING)
+    val jdbcUrl = config.buildJdbcUrl(TESTING)
     return DriverDataSource(
         jdbcUrl, config.type.driverClassName, Properties(), config.username, config.password)
   }


### PR DESCRIPTION
In local testing, we have a convention of providing partial configs expecting misk to fill in the defaults. This should probably change in the future...

For now though, I need access to the defaults per data source type and would like to not duplicate them, so I exposed a `withDefaults()` method. I also moved `buildJdbcUrl()` out of the enum and into the `DataSourceConfig` to make this work, and I think it's probably actually cleaner this way.