### PR TITLE
Grant the app binlog privileges (for test).

### DIFF
--- a/misk-hibernate/src/main/kotlin/misk/vitess/StartVitessService.kt
+++ b/misk-hibernate/src/main/kotlin/misk/vitess/StartVitessService.kt
@@ -256,7 +256,7 @@ class DockerVitessCluster(
             "-S", "/vt/vtdataroot/vt_0000000001/mysql.sock",
             "-u", "root",
             "mysql",
-            "-e", "grant all on *.* to 'vt_dba'@'%'")
+            "-e", "grant all on *.* to 'vt_dba'@'%'; grant REPLICATION CLIENT, REPLICATION SLAVE on *.* to 'vt_app'@'%'")
         .exec()
 
     docker.execStartCmd(exec.id)


### PR DESCRIPTION
Grant the app user `REPLICATION CLIENT` and `REPLICATION SLAVE` privileges
so that it can check status and read binary logs.