### PR TITLE
Implement optional RequestLoggingInterceptor

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -15,6 +15,7 @@ ext.dep = [
   "grpcProtobuf": "io.grpc:grpc-protobuf:1.14.0",
   "grpcStub": "io.grpc:grpc-stub:1.14.0",
   "guava": "com.google.guava:guava:23.6-jre",
+  "guavaTestLib": "com.google.guava:guava-testlib:23.6-jre",
   "guice": "com.google.inject:guice:4.2.2",
   "guiceMultibindings": "com.google.inject.extensions:guice-multibindings:4.2.2",
   "guiceServlet": "com.google.inject.extensions:guice-servlet:4.2.2",

--- a/misk-testing/build.gradle
+++ b/misk-testing/build.gradle
@@ -9,5 +9,6 @@ dependencies {
   compile dep.okio
   compile dep.openTracingMock
   compile dep.mockitoCore
+  compile dep.guavaTestLib
   compile project(':misk')
 }

--- a/misk-testing/src/main/kotlin/misk/MiskTestingServiceModule.kt
+++ b/misk-testing/src/main/kotlin/misk/MiskTestingServiceModule.kt
@@ -1,10 +1,11 @@
 package misk
 
-import misk.MiskCommonServiceModule
 import misk.environment.FakeEnvVarModule
 import misk.inject.KAbstractModule
+import misk.random.FakeRandomModule
 import misk.resources.TestingResourceLoaderModule
 import misk.time.FakeClockModule
+import misk.time.FakeTickerModule
 
 /**
  * [MiskTestingServiceModule] should be installed in unit testing environments.
@@ -18,6 +19,8 @@ class MiskTestingServiceModule : KAbstractModule() {
     install(TestingResourceLoaderModule())
     install(FakeEnvVarModule())
     install(FakeClockModule())
+    install(FakeTickerModule())
+    install(FakeRandomModule())
     install(MiskCommonServiceModule())
   }
 }

--- a/misk-testing/src/main/kotlin/misk/random/FakeRandom.kt
+++ b/misk-testing/src/main/kotlin/misk/random/FakeRandom.kt
@@ -1,0 +1,26 @@
+package misk.random
+
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class FakeRandom : Random() {
+  var nextBoolean : Boolean? = null
+  var nextInt : Int? = null
+  var nextLong : Long? = null
+  var nextFloat : Float? = null
+  var nextDouble : Double? = null
+
+  override fun nextBoolean(): Boolean = nextBoolean ?: super.nextBoolean()
+  override fun nextInt(): Int = nextInt ?: super.nextInt()
+  override fun nextLong(): Long = nextLong ?: super.nextLong()
+  override fun nextFloat(): Float = nextFloat ?: super.nextFloat()
+  override fun nextDouble(): Double = nextDouble ?: super.nextDouble()
+}
+
+@Singleton
+class FakeThreadLocalRandom : ThreadLocalRandom() {
+  @Inject lateinit var fakeRandom: FakeRandom
+
+  override fun current() = fakeRandom
+}

--- a/misk-testing/src/main/kotlin/misk/random/FakeRandomModule.kt
+++ b/misk-testing/src/main/kotlin/misk/random/FakeRandomModule.kt
@@ -1,0 +1,11 @@
+package misk.random
+
+import misk.inject.KAbstractModule
+
+class FakeRandomModule : KAbstractModule() {
+  override fun configure() {
+    bind<FakeRandom>()
+    bind<Random>().to<FakeRandom>()
+    bind<ThreadLocalRandom>().to<FakeThreadLocalRandom>()
+  }
+}

--- a/misk-testing/src/main/kotlin/misk/time/FakeTickerModule.kt
+++ b/misk-testing/src/main/kotlin/misk/time/FakeTickerModule.kt
@@ -1,0 +1,12 @@
+package misk.time
+
+import com.google.common.base.Ticker
+import com.google.common.testing.FakeTicker
+import misk.inject.KAbstractModule
+
+class FakeTickerModule : KAbstractModule() {
+  override fun configure() {
+    bind<Ticker>().to<FakeTicker>()
+    bind<FakeTicker>().asEagerSingleton()
+  }
+}

--- a/misk/src/main/kotlin/misk/MiskServiceModule.kt
+++ b/misk/src/main/kotlin/misk/MiskServiceModule.kt
@@ -25,8 +25,10 @@ import misk.inject.KAbstractModule
 import misk.metrics.MetricsModule
 import misk.moshi.MoshiModule
 import misk.prometheus.PrometheusHistogramRegistryModule
+import misk.random.RandomModule
 import misk.resources.ResourceLoaderModule
 import misk.time.ClockModule
+import misk.time.TickerModule
 import misk.tokens.TokenGeneratorModule
 import javax.inject.Singleton
 
@@ -43,6 +45,8 @@ class MiskRealServiceModule : KAbstractModule() {
     install(RealEnvVarModule())
     install(ClockModule())
     install(SleeperModule())
+    install(TickerModule())
+    install(RandomModule())
     install(MiskCommonServiceModule())
   }
 }

--- a/misk/src/main/kotlin/misk/random/Random.kt
+++ b/misk/src/main/kotlin/misk/random/Random.kt
@@ -1,0 +1,17 @@
+package misk.random
+
+import javax.inject.Singleton
+
+/**
+ * Abstraction for Java's Random that allows for testing.
+ */
+@Singleton
+open class Random : java.util.Random()
+
+/**
+ * Abstraction for Java's ThreadLocalRandom that allows for testing.
+ */
+@Singleton
+open class ThreadLocalRandom {
+  open fun current() : java.util.Random = java.util.concurrent.ThreadLocalRandom.current()
+}

--- a/misk/src/main/kotlin/misk/random/RandomModule.kt
+++ b/misk/src/main/kotlin/misk/random/RandomModule.kt
@@ -1,0 +1,11 @@
+package misk.random
+
+import misk.inject.KAbstractModule
+
+
+internal class RandomModule : KAbstractModule() {
+  override fun configure() {
+    bind<Random>()
+    bind<ThreadLocalRandom>()
+  }
+}

--- a/misk/src/main/kotlin/misk/time/TickerModule.kt
+++ b/misk/src/main/kotlin/misk/time/TickerModule.kt
@@ -1,0 +1,10 @@
+package misk.time
+
+import com.google.common.base.Ticker
+import misk.inject.KAbstractModule
+
+internal class TickerModule : KAbstractModule() {
+  override fun configure() {
+    bind<Ticker>().toInstance(Ticker.systemTicker())
+  }
+}

--- a/misk/src/main/kotlin/misk/web/MiskWebModule.kt
+++ b/misk/src/main/kotlin/misk/web/MiskWebModule.kt
@@ -96,10 +96,6 @@ class MiskWebModule : KAbstractModule() {
     multibind<NetworkInterceptor.Factory>(MiskDefault::class)
         .to<RequestLogContextInterceptor.Factory>()
 
-    // Optionally log request and response details
-    multibind<NetworkInterceptor.Factory>(MiskDefault::class)
-        .to<RequestLoggingInterceptor.Factory>()
-
     // Collect metrics on the status of results and response times of requests
     multibind<NetworkInterceptor.Factory>(MiskDefault::class)
         .to<MetricsInterceptor.Factory>()
@@ -116,6 +112,10 @@ class MiskWebModule : KAbstractModule() {
     // the client's requested content-type
     multibind<NetworkInterceptor.Factory>(MiskDefault::class)
         .to<MarshallerInterceptor.Factory>()
+
+    // Optionally log request and response details
+    multibind<ApplicationInterceptor.Factory>(MiskDefault::class)
+      .to<RequestLoggingInterceptor.Factory>()
 
     install(ExceptionMapperModule.create<ActionException, ActionExceptionMapper>())
 

--- a/misk/src/main/kotlin/misk/web/actions/WebActionFactory.kt
+++ b/misk/src/main/kotlin/misk/web/actions/WebActionFactory.kt
@@ -31,7 +31,8 @@ internal class WebActionFactory {
 
   @Inject lateinit var userProvidedNetworkInterceptorFactories: List<NetworkInterceptor.Factory>
 
-  @Inject @MiskDefault lateinit var miskInterceptorFactories: List<NetworkInterceptor.Factory>
+  @Inject @MiskDefault lateinit var miskNetworkInterceptorFactories: List<NetworkInterceptor.Factory>
+  @Inject @MiskDefault lateinit var miskApplicationInterceptorFactories: List<ApplicationInterceptor.Factory>
 
   @Inject lateinit var parameterExtractorFactories: List<ParameterExtractor.Factory>
 
@@ -121,10 +122,11 @@ internal class WebActionFactory {
 
     val networkInterceptors = ArrayList<NetworkInterceptor>()
     // Ensure that default interceptors are called before any user provided interceptors
-    miskInterceptorFactories.mapNotNullTo(networkInterceptors) { it.create(action) }
+    miskNetworkInterceptorFactories.mapNotNullTo(networkInterceptors) { it.create(action) }
     userProvidedNetworkInterceptorFactories.mapNotNullTo(networkInterceptors) { it.create(action) }
 
     val applicationInterceptors = ArrayList<ApplicationInterceptor>()
+    miskApplicationInterceptorFactories.mapNotNullTo(applicationInterceptors) { it.create(action) }
     userProvidedApplicationInterceptorFactories.mapNotNullTo(applicationInterceptors) {
       it.create(action)
     }

--- a/misk/src/main/kotlin/misk/web/interceptors/RequestLoggingInterceptor.kt
+++ b/misk/src/main/kotlin/misk/web/interceptors/RequestLoggingInterceptor.kt
@@ -1,32 +1,91 @@
 package misk.web.interceptors
 
 import com.google.common.base.Stopwatch
+import com.google.common.base.Ticker
 import misk.Action
-import misk.web.NetworkChain
-import misk.web.NetworkInterceptor
+import misk.ApplicationInterceptor
+import misk.Chain
+import misk.MiskCaller
 import misk.logging.getLogger
-import misk.web.Response
+import misk.random.ThreadLocalRandom
+import misk.scope.ActionScoped
+import javax.inject.Inject
 import javax.inject.Singleton
+import kotlin.reflect.full.findAnnotation
 
 private val logger = getLogger<RequestLoggingInterceptor>()
 
 /**
- * Prints timing for calling into an action. Doesn't count time writing the response to the remote
- * client.
+ * Logs request and response information for an action.
+ * Timing information doesn't count time writing the response to the remote client.
  */
-internal class RequestLoggingInterceptor : NetworkInterceptor {
+internal class RequestLoggingInterceptor internal constructor(
+  private val action: Action,
+  private val sampling: Double,
+  private val includeBody: Boolean,
+  private val caller: ActionScoped<MiskCaller?>,
+  private val ticker: Ticker,
+  private val random: ThreadLocalRandom
+) : ApplicationInterceptor {
+
   @Singleton
-  class Factory : NetworkInterceptor.Factory {
-    override fun create(action: Action): NetworkInterceptor? {
-      // TODO: return null if we don't want to log the request
-      return RequestLoggingInterceptor()
+  class Factory @Inject internal constructor(
+    private val caller: @JvmSuppressWildcards ActionScoped<MiskCaller?>,
+    private val ticker: Ticker,
+    private val random: ThreadLocalRandom
+  ): ApplicationInterceptor.Factory {
+    override fun create(action: Action): ApplicationInterceptor? {
+      val logRequestResponse = action.function.findAnnotation<LogRequestResponse>() ?: return null
+      require(0.0 < logRequestResponse.sampling && logRequestResponse.sampling <= 1.0) {
+        "${action.name} @LogRequestResponse sampling must be in the range (0.0, 1.0]"
+      }
+
+      return RequestLoggingInterceptor(
+        action,
+        logRequestResponse.sampling,
+        logRequestResponse.includeBody,
+        caller,
+        ticker,
+        random
+      )
     }
   }
 
-  override fun intercept(chain: NetworkChain): Response<*> {
-    val stopwatch = Stopwatch.createStarted()
-    val result = chain.proceed(chain.request)
-    logger.debug { "action ${chain.action} took $stopwatch" }
-    return result
+  override fun intercept(chain: Chain): Any {
+    val randomDouble = random.current().nextDouble()
+    if (randomDouble >= sampling) {
+      return chain.proceed(chain.args)
+    }
+
+    val principal = caller.get()?.principal ?: "unknown"
+    val requestString = if (includeBody) chain.args.toString() else ""
+
+    logger.info { "${action.name} principal=$principal request=$requestString" }
+
+    val stopwatch = Stopwatch.createStarted(ticker)
+    try {
+      val result = chain.proceed(chain.args)
+      val resultString = if (includeBody) result.toString() else ""
+      logger.info { "${action.name} principal=$principal time=$stopwatch response=$resultString" }
+      return result
+    } catch (t: Throwable) {
+      logger.info { "${action.name} principal=$principal time=$stopwatch failed" }
+      throw t
+    }
   }
 }
+
+/**
+ * Annotation indicating that request and response information should be logged.
+ *
+ * sampling is used to sample the number of requests logged with 0.0 for none and 1.0 for all.
+ * Valid values are in the range (0.0, 1.0].
+ *
+ * If includeBody is true both the action arguments and the response will be logged.
+ *
+ * If arguments and responses may include sensitive information, it is expected that the toString()
+ * methods of these objects will redact it.
+ */
+@Retention(AnnotationRetention.RUNTIME)
+@Target(AnnotationTarget.FUNCTION)
+annotation class LogRequestResponse(val sampling: Double, val includeBody: Boolean)

--- a/misk/src/test/kotlin/misk/web/interceptors/RequestLoggingInterceptorTest.kt
+++ b/misk/src/test/kotlin/misk/web/interceptors/RequestLoggingInterceptorTest.kt
@@ -1,0 +1,160 @@
+package misk.web.interceptors
+
+import com.google.common.testing.FakeTicker
+import misk.inject.KAbstractModule
+import misk.logging.LogCollector
+import misk.logging.LogCollectorModule
+import misk.random.FakeRandom
+import misk.security.authz.AccessControlModule
+import misk.security.authz.FakeCallerAuthenticator
+import misk.security.authz.MiskCallerAuthenticator
+import misk.security.authz.Unauthenticated
+import misk.testing.MiskTest
+import misk.testing.MiskTestModule
+import misk.web.Get
+import misk.web.PathParam
+import misk.web.ResponseContentType
+import misk.web.WebTestingModule
+import misk.web.actions.WebAction
+import misk.web.actions.WebActionEntry
+import misk.web.jetty.JettyService
+import misk.web.mediatype.MediaTypes
+import okhttp3.OkHttpClient
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.util.concurrent.TimeUnit
+import javax.inject.Inject
+
+@MiskTest(startService = true)
+internal class RequestLoggingInterceptorTest {
+
+  @MiskTestModule
+  val module = TestModule()
+  val httpClient = OkHttpClient()
+
+  @Inject private lateinit var jettyService: JettyService
+  @Inject private lateinit var logCollector: LogCollector
+  @Inject private lateinit var fakeTicker: FakeTicker
+  @Inject private lateinit var fakeRandom: FakeRandom
+
+  @BeforeEach
+  fun setUp() {
+    fakeTicker.setAutoIncrementStep(100L, TimeUnit.MILLISECONDS)
+  }
+
+  @Test
+  fun includesBody() {
+    assertThat(invoke("/call/includeBodyRequestLogging/hello", "caller").isSuccessful).isTrue()
+    val messages = logCollector.takeMessages(RequestLoggingInterceptor::class)
+    assertThat(messages).containsExactly(
+      "IncludeBodyRequestLoggingAction principal=caller request=[hello]",
+      "IncludeBodyRequestLoggingAction principal=caller time=100.0 ms response=echo: hello"
+    )
+  }
+
+  @Test
+  fun excludesBody() {
+    assertThat(invoke("/call/excludeBodyRequestLogging/hello", "caller").isSuccessful).isTrue()
+    val messages = logCollector.takeMessages(RequestLoggingInterceptor::class)
+    assertThat(messages).containsExactly(
+      "ExcludeBodyRequestLoggingAction principal=caller request=",
+      "ExcludeBodyRequestLoggingAction principal=caller time=100.0 ms response="
+    )
+  }
+
+  @Test
+  fun exceptionThrown() {
+    assertThat(invoke("/call/exceptionThrowingRequestLogging/fail", "caller").code()).isEqualTo(500)
+    val messages = logCollector.takeMessages(RequestLoggingInterceptor::class)
+    assertThat(messages).containsExactly(
+      "ExceptionThrowingRequestLoggingAction principal=caller request=[fail]",
+      "ExceptionThrowingRequestLoggingAction principal=caller time=100.0 ms failed"
+    )
+  }
+
+  @Test
+  fun notSampled() {
+    fakeRandom.nextDouble = 0.7;
+    assertThat(invoke("/call/sampledRequestLogging/hello", "caller").isSuccessful).isTrue()
+    assertThat(logCollector.takeMessages(RequestLoggingInterceptor::class)).isEmpty()
+  }
+
+  @Test
+  fun sampled() {
+    fakeRandom.nextDouble = 0.2;
+    assertThat(invoke("/call/sampledRequestLogging/hello", "caller").isSuccessful).isTrue()
+    assertThat(logCollector.takeMessages(RequestLoggingInterceptor::class)).isNotEmpty()
+  }
+
+  @Test
+  fun noRequestLoggingIfMissingAnnotation() {
+    assertThat(invoke("/call/noRequestLogging/hello", "caller").isSuccessful).isTrue()
+    assertThat(logCollector.takeMessages(RequestLoggingInterceptor::class)).isEmpty()
+  }
+
+  fun invoke(path: String, asService: String? = null): okhttp3.Response {
+    val url = jettyService.httpServerUrl.newBuilder()
+      .encodedPath(path)
+      .build()
+
+    val request = okhttp3.Request.Builder()
+      .url(url)
+      .get()
+    asService?.let { request.addHeader(FakeCallerAuthenticator.SERVICE_HEADER, it) }
+    return httpClient.newCall(request.build()).execute()
+  }
+
+  internal class IncludeBodyRequestLoggingAction : WebAction {
+    @Get("/call/includeBodyRequestLogging/{message}")
+    @Unauthenticated
+    @ResponseContentType(MediaTypes.APPLICATION_JSON)
+    @LogRequestResponse(sampling = 1.0, includeBody = true)
+    fun call(@PathParam message: String) = "echo: $message"
+  }
+
+  internal class ExcludeBodyRequestLoggingAction : WebAction {
+    @Get("/call/excludeBodyRequestLogging/{message}")
+    @Unauthenticated
+    @ResponseContentType(MediaTypes.APPLICATION_JSON)
+    @LogRequestResponse(sampling = 1.0, includeBody = false)
+    fun call(@PathParam message: String) = "echo: $message"
+  }
+
+  internal class ExceptionThrowingRequestLoggingAction : WebAction {
+    @Get("/call/exceptionThrowingRequestLogging/{message}")
+    @Unauthenticated
+    @ResponseContentType(MediaTypes.APPLICATION_JSON)
+    @LogRequestResponse(sampling = 1.0, includeBody = true)
+    fun call(@PathParam message: String) : String = throw IllegalStateException(message)
+  }
+
+  internal class SampledRequestLoggingAction : WebAction {
+    @Get("/call/sampledRequestLogging/{message}")
+    @Unauthenticated
+    @ResponseContentType(MediaTypes.APPLICATION_JSON)
+    @LogRequestResponse(sampling = 0.4, includeBody = true)
+    fun call(@PathParam message: String) = "echo: $message"
+  }
+
+  internal class NoRequestLoggingAction : WebAction {
+    @Get("/call/noRequestLogging/{message}")
+    @Unauthenticated
+    @ResponseContentType(MediaTypes.APPLICATION_JSON)
+    fun call(@PathParam message: String) = "echo: $message"
+  }
+
+  class TestModule : KAbstractModule() {
+    override fun configure() {
+      install(AccessControlModule())
+      install(WebTestingModule())
+      install(LogCollectorModule())
+      multibind<MiskCallerAuthenticator>().to<FakeCallerAuthenticator>()
+      multibind<WebActionEntry>().toInstance(WebActionEntry<RequestLoggingInterceptorTest.IncludeBodyRequestLoggingAction>())
+      multibind<WebActionEntry>().toInstance(WebActionEntry<RequestLoggingInterceptorTest.ExcludeBodyRequestLoggingAction>())
+      multibind<WebActionEntry>().toInstance(WebActionEntry<RequestLoggingInterceptorTest.ExceptionThrowingRequestLoggingAction>())
+      multibind<WebActionEntry>().toInstance(WebActionEntry<RequestLoggingInterceptorTest.NoRequestLoggingAction>())
+      multibind<WebActionEntry>().toInstance(WebActionEntry<RequestLoggingInterceptorTest.SampledRequestLoggingAction>())
+    }
+  }
+}


### PR DESCRIPTION
Fleshes out the (primarily stub) RequestLoggingInterceptor.

Configuration is set statically until we've implemented a component for dynamic configuration.
Rate limiting is also not yet implemented.

It is related to #80 but more focused on logging higher-level action requests/responses than httpd-style access logs.