### PR TITLE
Poll ZK for lease changes

### DIFF
--- a/misk-zookeeper/src/main/kotlin/misk/clustering/zookeeper/ForZkLease.kt
+++ b/misk-zookeeper/src/main/kotlin/misk/clustering/zookeeper/ForZkLease.kt
@@ -1,0 +1,7 @@
+package misk.clustering.zookeeper
+
+import javax.inject.Qualifier
+
+@Qualifier
+@Target(AnnotationTarget.FIELD, AnnotationTarget.FUNCTION, AnnotationTarget.VALUE_PARAMETER)
+annotation class ForZkLease

--- a/misk-zookeeper/src/main/kotlin/misk/clustering/zookeeper/ZookeeperModule.kt
+++ b/misk-zookeeper/src/main/kotlin/misk/clustering/zookeeper/ZookeeperModule.kt
@@ -1,17 +1,25 @@
 package misk.clustering.zookeeper
 
 import com.google.common.util.concurrent.Service
+import com.google.common.util.concurrent.ThreadFactoryBuilder
 import com.google.inject.Key
+import com.google.inject.Provides
 import misk.clustering.lease.LeaseManager
 import misk.inject.KAbstractModule
 import misk.inject.asSingleton
+import misk.inject.toKey
+import misk.tasks.RepeatedTaskQueue
 import misk.zookeeper.CuratorFrameworkProvider
 import org.apache.curator.framework.CuratorFramework
+import java.time.Clock
+import java.util.concurrent.Executors
+import javax.inject.Singleton
 
 class ZookeeperModule : KAbstractModule() {
   override fun configure() {
     multibind<Service>().to<ZkService>()
     multibind<Service>().to<ZkLeaseManager>()
+    multibind<Service>().to(RepeatedTaskQueue::class.toKey(ForZkLease::class)).asSingleton()
     bind<LeaseManager>().to<ZkLeaseManager>()
     bind<CuratorFramework>().toProvider(CuratorFrameworkProvider::class.java).asSingleton()
   }
@@ -22,5 +30,15 @@ class ZookeeperModule : KAbstractModule() {
 
     /** @property Key<*> the Key of the lease manager service */
     val leaseManagerKey: Key<*> = Key.get(ZkLeaseManager::class.java)
+  }
+
+  @Provides @ForZkLease @Singleton
+  fun provideTaskQueue(clock: Clock): RepeatedTaskQueue {
+    return RepeatedTaskQueue(
+        "zk-lease-poller",
+        clock,
+        Executors.newFixedThreadPool(1, ThreadFactoryBuilder()
+            .setNameFormat("zk-lease-poller")
+            .build()))
   }
 }

--- a/misk-zookeeper/src/test/kotlin/misk/clustering/zookeeper/ZkLeaseTest.kt
+++ b/misk-zookeeper/src/test/kotlin/misk/clustering/zookeeper/ZkLeaseTest.kt
@@ -91,7 +91,7 @@ internal class ZkLeaseTest {
 
     // Fake a cluster change which moves the lease to another process
     cluster.resourceMapper.removeMapping(leasePath)
-    leaseManager.handleClusterChange()
+    leaseManager.checkAllLeases()
 
     // Should no longer own the lease and should have deleted the lease node
     assertThat(lease.checkHeld()).isFalse()
@@ -236,8 +236,8 @@ internal class ZkLeaseTest {
     reset(listenerMock)
 
     // Further calls to checkHeld() should not trigger events because the lease does not change
-    lease.checkHeld()
-    lease.checkHeld()
+    assertThat(lease.checkHeld()).isTrue()
+    assertThat(lease.checkHeld()).isTrue()
     verifyZeroInteractions(listenerMock)
     reset(listenerMock)
 

--- a/misk/src/main/kotlin/misk/clustering/ClusterHashRing.kt
+++ b/misk/src/main/kotlin/misk/clustering/ClusterHashRing.kt
@@ -35,7 +35,9 @@ class ClusterHashRing(
 
   /** @return The [Cluster.Member] that should own the given resource id */
   override fun get(resourceId: String): Cluster.Member {
-    check(vnodesToMembers.isNotEmpty()) { "no members available for $resourceId" }
+    if (vnodesToMembers.isEmpty()) {
+      throw NoMembersAvailableException(resourceId)
+    }
 
     val resourceHash = hashFn.hashBytes(resourceId.toByteArray()).asInt()
     val vnode = vnodes.first { it >= resourceHash }

--- a/misk/src/main/kotlin/misk/clustering/ClusterResourceMapper.kt
+++ b/misk/src/main/kotlin/misk/clustering/ClusterResourceMapper.kt
@@ -7,6 +7,9 @@ package misk.clustering
  * own mappings if there is a mechanism specific to that cluster (or to supply a fake)
  */
 interface ClusterResourceMapper {
-  /** @return The [Cluster.Member] that should own the given resource id */
+  /**
+   * @throws NoMembersAvailableException if there are no members in the cluster
+   * @return The [Cluster.Member] that should own the given resource id
+   */
   operator fun get(resourceId: String): Cluster.Member
 }

--- a/misk/src/main/kotlin/misk/clustering/NoMembersAvailableException.kt
+++ b/misk/src/main/kotlin/misk/clustering/NoMembersAvailableException.kt
@@ -1,0 +1,7 @@
+package misk.clustering
+
+/**
+ * Thrown if the cluster does not have any members available.
+ */
+class NoMembersAvailableException(val resourceId: String) :
+    Exception("no members available for $resourceId")

--- a/misk/src/main/kotlin/misk/clustering/fake/ExplicitClusterResourceMapper.kt
+++ b/misk/src/main/kotlin/misk/clustering/fake/ExplicitClusterResourceMapper.kt
@@ -2,6 +2,7 @@ package misk.clustering.fake
 
 import misk.clustering.Cluster
 import misk.clustering.ClusterResourceMapper
+import misk.clustering.NoMembersAvailableException
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicReference
 
@@ -30,6 +31,9 @@ class ExplicitClusterResourceMapper : ClusterResourceMapper {
   }
 
   override fun get(resourceId: String): Cluster.Member {
+    if (mappings.isEmpty()) {
+      defaultMapping.get() ?: throw NoMembersAvailableException(resourceId)
+    }
     return mappings[resourceId] ?: defaultMapping.get() ?: throw IllegalStateException(
         "no mapping for $resourceId")
   }

--- a/misk/src/test/kotlin/misk/clustering/ClusterHashRingTest.kt
+++ b/misk/src/test/kotlin/misk/clustering/ClusterHashRingTest.kt
@@ -3,6 +3,7 @@ package misk.clustering
 import com.google.common.hash.Hashing
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 
 internal class ClusterHashRingTest {
   @Test fun singleNode() {
@@ -39,5 +40,13 @@ internal class ClusterHashRingTest {
         hashFn = Hashing.murmur3_32(0))
     assertThat(listOf("foo", "bar", "zed", "abadidea").map { hashRing3[it] })
         .containsExactly(zork, quark, zork, zork)
+  }
+
+  @Test fun zeroNodes() {
+    val hashRing =
+        ClusterHashRing(members = setOf(), hashFn = Hashing.murmur3_32(0))
+    assertThrows<NoMembersAvailableException> {
+      hashRing["foo"]
+    }
   }
 }


### PR DESCRIPTION
With addition of listener support in #753, the ZK lease manager actually
now needs to poll for changes to leases in addition to receiving cluster
watch events. The node can receive cluster membership changes about
another member exiting the cluster, but before that member releases its
leases.

This change also changes the Lease check to be a bit nicer when there
are no members in the cluster. It will assume it doesn't own the lease
and log a warning, rather than logging an error and ignoring a potential
state transition. This should only have an effect on logs on service
startup/shutdown when there 0 services running.