### PR TITLE
Map high range to lowest vnode

### DIFF
--- a/misk/src/main/kotlin/misk/clustering/ClusterHashRing.kt
+++ b/misk/src/main/kotlin/misk/clustering/ClusterHashRing.kt
@@ -40,7 +40,7 @@ class ClusterHashRing(
     }
 
     val resourceHash = hashFn.hashBytes(resourceId.toByteArray()).asInt()
-    val vnode = vnodes.first { it >= resourceHash }
+    val vnode = vnodes.firstOrNull { it >= resourceHash } ?: vnodes[0]
     return vnodesToMembers[vnode] ?: throw IllegalStateException(
         "no member corresponding to vnode hash $vnode")
   }


### PR DESCRIPTION
If we have 3 vnodes and they hash to a, b, and c, we want to map the hashed resource ID to
vnodes using the following ranges.

```
  [0, a] => a
  (a, b] => b
  (b, c] => c
  (c, INT_MAX] => a
```

Previously, if a resource hashed to the last range `(c, INT_MAX]`, the hash ring would throw an exception