### PR TITLE
Upgrade gradle to 5.1 and remove unused CI var

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 plugins {
   id "org.jetbrains.kotlin.jvm" version "1.3.11" apply false
   id "com.vanniktech.maven.publish" version "0.4.0" apply false
-  id 'com.gradle.build-scan' version '1.16'
+  id 'com.gradle.build-scan' version '2.1'
 }
 
 buildScan {
@@ -11,7 +11,6 @@ buildScan {
 
 ext {
   isCi = "true".equals(System.getenv('CI'))
-  isSqCi = "true".equals(System.getenv('SQCI'))
   rep = null
 }
 apply from: file("./dependencies.gradle")
@@ -39,7 +38,7 @@ subprojects {
     }
 
     dependencies {
-      classpath 'com.github.jengelman.gradle.plugins:shadow:2.0.2'
+      classpath 'com.github.jengelman.gradle.plugins:shadow:4.0.4'
     }
   }
   repositories {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.9-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.1-bin.zip


### PR DESCRIPTION
Looking to upgrade all repos to gradle 5+, starting with Misk. Will require the following steps, but proving it out via Misk first.

```
Upgrade to gradle 5.1:
- Add following plugins to be part of master-dependencies
  - com.github.jengelman.gradle.plugins:shadow
  - com.gradle.build-scan
- Add polyrepo command to run script + open PRs/merge on green (slight variation from what auto dep upgrade does today)
- Run upgrade command that:
  - Converts their plugin usage to leverage dependencies.gradle
  - Upgrades their gradle version to 5.1
```