### PR TITLE
Add native misk web tab build task into CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,22 +1,28 @@
-language: java
-
-jdk:
-  - openjdk11
-
-script:
-  - ./gradlew test --parallel --scan --build-cache
-
-# Gradle caching - as per https://docs.travis-ci.com/user/languages/java/#Projects-Using-Gradle
-before_cache:
-  - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
-  - rm -fr $HOME/.gradle/caches/*/plugin-resolution/
-
-cache:
-  bundler: true
-  directories:
-    - $HOME/.gradle/caches/
-    - $HOME/.gradle/wrapper/
-
-services:
-  - mysql
-  - docker
+matrix:
+  include:
+    - language: java
+      jdk:
+        - openjdk11
+      script:
+        - ./gradlew test --parallel --scan --build-cache
+      # Gradle caching - as per https://docs.travis-ci.com/user/languages/java/#Projects-Using-Gradle
+      before_cache:
+        - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
+        - rm -fr $HOME/.gradle/caches/*/plugin-resolution/
+      cache:
+        bundler: true
+        directories:
+          - $HOME/.gradle/caches/
+          - $HOME/.gradle/wrapper/
+      services:
+        - mysql
+        - docker
+    - language: node_js
+      node_js:
+        - 10.15
+      script:
+        - |
+          for dir in */web/tabs/*
+          do
+            (cd $dir && npm install -g @misk/cli && npm install && miskweb build)
+          done


### PR DESCRIPTION
This will fail if the tab has a regression and cannot be built. It's split up as a separate build so does not get in the way of the misk kotlin build.