### PR TITLE
Remove data source properties already set by jdbcUrl

### DIFF
--- a/misk-hibernate/src/main/kotlin/misk/jdbc/DataSourceService.kt
+++ b/misk-hibernate/src/main/kotlin/misk/jdbc/DataSourceService.kt
@@ -70,20 +70,6 @@ internal class DataSourceService(
       config.dataSourceProperties["maintainTimeStats"] = "false"
     }
 
-    // https://dev.mysql.com/doc/connector-j/8.0/en/connector-j-reference-using-ssl.html
-    if (!this.config.trust_certificate_key_store_url.isNullOrBlank()) {
-      require(!this.config.trust_certificate_key_store_password.isNullOrBlank()) {
-        "must provide a trust_certificate_key_store_password"
-      }
-      config.dataSourceProperties["trustCertificateKeyStoreUrl"] =
-          this.config.trust_certificate_key_store_url
-      config.dataSourceProperties["trustCertificateKeyStorePassword"] =
-          this.config.trust_certificate_key_store_password
-      config.dataSourceProperties["verifyServerCertificate"] = "true"
-      config.dataSourceProperties["useSSL"] = "true"
-      config.dataSourceProperties["requireSSL"] = "true"
-    }
-
     hikariDataSource = HikariDataSource(config)
     dataSource = decorate(hikariDataSource!!)
 


### PR DESCRIPTION
The `java.sql.Driver#connect` method on the Driver interface recommends to set properties in the url or the property hash, but not both:

```
     * <P>The {@code Properties} argument can be used to pass
     * arbitrary string tag/value pairs as connection arguments.
     * Normally at least "user" and "password" properties should be
     * included in the {@code Properties} object.
     * <p>
     * <B>Note:</B> If a property is specified as part of the {@code url} and
     * is also specified in the {@code Properties} object, it is
     * implementation-defined as to which value will take precedence. For
     * maximum portability, an application should only specify a property once.
```

Removing the certs being set in the dataSourceProperties to reduce confusion and because they're already set on the jdbcUrl which is built earlier.