### PR TITLE
Add support for providing trust_certificate_key_store_path and client_certificate_key_store_path

### DIFF
--- a/misk-hibernate/src/test/kotlin/misk/jdbc/DataSourceConfigTest.kt
+++ b/misk-hibernate/src/test/kotlin/misk/jdbc/DataSourceConfigTest.kt
@@ -43,4 +43,57 @@ class DataSourceConfigTest {
         "keyStorePassword=changeit&useSSL=true",
         config.buildJdbcUrl(Environment.TESTING))
   }
+
+  @Test
+  fun buildVitessJDBCUrlWithPath() {
+    val config = DataSourceConfig(DataSourceType.VITESS,
+        trust_certificate_key_store_path = "path/to/truststore",
+        trust_certificate_key_store_password = "changeit",
+        client_certificate_key_store_path = "path/to/keystore",
+        client_certificate_key_store_password = "changeit")
+    assertEquals("jdbc:vitess://127.0.0.1:27001/?trustStore=path/to/truststore&" +
+        "trustStorePassword=changeit&keyStore=path/to/keystore&" +
+        "keyStorePassword=changeit&useSSL=true", config.buildJdbcUrl(Environment.TESTING))
+  }
+
+  @Test
+  fun buildVitessJDBCUrlWithActualUrl() {
+    val config = DataSourceConfig(DataSourceType.VITESS,
+        trust_certificate_key_store_url = "file://path/to/truststore",
+        trust_certificate_key_store_password = "changeit",
+        client_certificate_key_store_url = "file://path/to/keystore",
+        client_certificate_key_store_password = "changeit")
+    assertEquals("jdbc:vitess://127.0.0.1:27001/?trustStore=path/to/truststore&" +
+        "trustStorePassword=changeit&keyStore=path/to/keystore&" +
+        "keyStorePassword=changeit&useSSL=true", config.buildJdbcUrl(Environment.TESTING))
+  }
+
+  @Test
+  fun buildMysqlJDBCUrlWithTruststoreViaUrl() {
+    val config = DataSourceConfig(DataSourceType.MYSQL,
+        trust_certificate_key_store_url = "file://path/to/truststore",
+        trust_certificate_key_store_password = "changeit")
+    assertEquals("jdbc:tracing:mysql://127.0.0.1:3306/?useLegacyDatetimeCode=false&" +
+        "createDatabaseIfNotExist=true&trustCertificateKeyStoreUrl=" +
+        "file://path/to/truststore&trustCertificateKeyStorePassword=changeit&verifyServerCertificate=true" +
+        "&useSSL=true&requireSSL=true", config.buildJdbcUrl(Environment.TESTING))
+  }
+
+  @Test
+  fun buildMysqlJDBCUrlWithTruststoreViaPath() {
+    val config = DataSourceConfig(DataSourceType.MYSQL,
+        trust_certificate_key_store_path = "path/to/truststore",
+        trust_certificate_key_store_password = "changeit")
+    assertEquals("jdbc:tracing:mysql://127.0.0.1:3306/?useLegacyDatetimeCode=false&" +
+        "createDatabaseIfNotExist=true&trustCertificateKeyStoreUrl=" +
+        "file://path/to/truststore&trustCertificateKeyStorePassword=changeit&verifyServerCertificate=true" +
+        "&useSSL=true&requireSSL=true", config.buildJdbcUrl(Environment.TESTING))
+  }
+
+  @Test
+  fun buildMysqlJDBCUrlWithNoTls() {
+    val config = DataSourceConfig(DataSourceType.MYSQL)
+    assertEquals("jdbc:tracing:mysql://127.0.0.1:3306/?useLegacyDatetimeCode=false&" +
+        "createDatabaseIfNotExist=true", config.buildJdbcUrl(Environment.TESTING))
+  }
 }


### PR DESCRIPTION
Some database drivers (e.g. Vitess) don't accept urls for certs in the
JDBC url they generate. So, for the sake of clarity, allow folks to
specify paths instead of urls. Fields ending in url imply that the string
begins with a scheme, so to ensure that clients do the right thing,
provide the path fields as an alternative.