### PR TITLE
ConfigAdminAction reads the full loaded Config

### DIFF
--- a/misk/src/main/kotlin/misk/config/ConfigModule.kt
+++ b/misk/src/main/kotlin/misk/config/ConfigModule.kt
@@ -11,6 +11,7 @@ class ConfigModule<T : Config>(
   override fun configure() {
     bind<String>().annotatedWith<AppName>().toInstance(appName)
     bind(configClass).toInstance(config)
+    bind<Config>().toInstance(config)
   }
 
   companion object {

--- a/misk/src/main/kotlin/misk/config/MiskConfig.kt
+++ b/misk/src/main/kotlin/misk/config/MiskConfig.kt
@@ -70,6 +70,14 @@ object MiskConfig {
     }
   }
 
+  fun <T : Config> toYaml(config: T): String {
+    val mapper = ObjectMapper(YAMLFactory()).registerModules(
+        KotlinModule(),
+        JavaTimeModule(),
+        SecretJacksonModule())
+    return mapper.writeValueAsString(config)
+  }
+
   @JvmStatic
   fun filesInDir(
     dir: String,

--- a/misk/src/test/kotlin/misk/web/actions/TestAdminDashboardActionModule.kt
+++ b/misk/src/test/kotlin/misk/web/actions/TestAdminDashboardActionModule.kt
@@ -1,6 +1,7 @@
 package misk.web.actions
 
 import misk.config.AppName
+import misk.config.Config
 import misk.environment.Environment
 import misk.inject.KAbstractModule
 import misk.security.authz.AccessAnnotationEntry
@@ -14,7 +15,10 @@ class TestAdminDashboardActionModule : KAbstractModule() {
     install(AdminDashboardModule(Environment.TESTING))
     multibind<AccessAnnotationEntry>()
         .toInstance(AccessAnnotationEntry<AdminDashboardAccess>(roles = listOf("engineers")))
+    bind<Config>().toInstance(TestAdminDashboardConfig())
     // TODO(wesley): Remove requirement for AppName to bind AdminDashboard APIs
     bind<String>().annotatedWith<AppName>().toInstance("testApp")
   }
 }
+
+class TestAdminDashboardConfig : Config


### PR DESCRIPTION
Bind the app config as a `Config`, inject into ConfigAdminAction, and serialize it to YAML.