### PR TITLE
Web Actions Tab: Fix All/None Roles/Services bug

### DIFF
--- a/misk/web/tabs/web-actions/src/ducks/webActions.ts
+++ b/misk/web/tabs/web-actions/src/ducks/webActions.ts
@@ -159,7 +159,7 @@ function* handleMetadata() {
             )
         )
         const emptyAllowedArrayValue =
-          authFunctionAnnotations.length > 1 &&
+          authFunctionAnnotations.length > 0 &&
           authFunctionAnnotations[0].includes("Unauthenticated")
             ? "All"
             : "None"


### PR DESCRIPTION
* `Unauthenticated` annotation wasn't correctly determining "All" or "None" for the Services and Roles metadata