### PR TITLE
Add module for binding AWS job queue handlers

### DIFF
--- a/misk-aws/src/main/kotlin/misk/jobqueue/sqs/AwsSqsJobHandlerModule.kt
+++ b/misk-aws/src/main/kotlin/misk/jobqueue/sqs/AwsSqsJobHandlerModule.kt
@@ -1,0 +1,63 @@
+package misk.jobqueue.sqs
+
+import com.google.common.util.concurrent.AbstractIdleService
+import com.google.common.util.concurrent.Service
+import com.google.inject.Key
+import misk.DependentService
+import misk.inject.KAbstractModule
+import misk.jobqueue.JobHandler
+import misk.jobqueue.QueueName
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlin.reflect.KClass
+
+/**
+ * Install this module to register a handler for an SQS queue.
+ */
+class AwsSqsJobHandlerModule<T : JobHandler> private constructor(
+  private val queueName: QueueName,
+  private val handler: KClass<T>
+) : KAbstractModule() {
+  override fun configure() {
+    newMapBinder<QueueName, JobHandler>().addBinding(queueName).to(handler.java)
+    multibind<Service>().to<AwsSqsJobHandlerSubscriptionService>()
+  }
+
+  companion object {
+    inline fun <reified T : JobHandler> create(queueName: QueueName):
+        AwsSqsJobHandlerModule<T> = create(queueName, T::class)
+
+    @JvmStatic
+    fun <T : JobHandler> create(
+      queueName: QueueName,
+      handlerClass: Class<T>
+    ): AwsSqsJobHandlerModule<T> {
+      return create(queueName, handlerClass.kotlin)
+    }
+
+    /**
+     * Returns a module that registers a handler for an SQS queue.
+     */
+    fun <T : JobHandler> create(
+      queueName: QueueName,
+      handlerClass: KClass<T>
+    ): AwsSqsJobHandlerModule<T> {
+      return AwsSqsJobHandlerModule(queueName, handlerClass)
+    }
+  }
+}
+
+@Singleton
+internal class AwsSqsJobHandlerSubscriptionService @Inject constructor(
+  private val consumer: SqsJobConsumer,
+  private val consumerMapping: Map<QueueName, JobHandler>
+) : AbstractIdleService(), DependentService {
+  override val consumedKeys: Set<Key<*>> = setOf(Key.get(SqsJobConsumer::class.java))
+  override val producedKeys: Set<Key<*>> = setOf()
+
+  override fun startUp() {
+    consumerMapping.forEach { consumer.subscribe(it.key, it.value) }
+  }
+
+  override fun shutDown() {}
+}

--- a/misk-aws/src/main/kotlin/misk/jobqueue/sqs/SqsJobConsumer.kt
+++ b/misk-aws/src/main/kotlin/misk/jobqueue/sqs/SqsJobConsumer.kt
@@ -3,9 +3,11 @@ package misk.jobqueue.sqs
 import com.amazonaws.services.sqs.AmazonSQS
 import com.amazonaws.services.sqs.model.ReceiveMessageRequest
 import com.google.common.util.concurrent.AbstractIdleService
+import com.google.inject.Key
 import io.opentracing.Tracer
 import io.opentracing.tag.StringTag
 import io.opentracing.tag.Tags
+import misk.DependentService
 import misk.jobqueue.JobConsumer
 import misk.jobqueue.JobHandler
 import misk.jobqueue.QueueName
@@ -27,7 +29,10 @@ internal class SqsJobConsumer @Inject internal constructor(
   @ForSqsConsumer private val dispatchThreadPool: ExecutorService,
   private val tracer: Tracer,
   private val metrics: SqsMetrics
-) : AbstractIdleService(), JobConsumer {
+) : AbstractIdleService(), JobConsumer, DependentService {
+  override val consumedKeys: Set<Key<*>> = setOf()
+  override val producedKeys: Set<Key<*>> = setOf(Key.get(SqsJobConsumer::class.java))
+
   private val subscriptions = ConcurrentHashMap<QueueName, JobConsumer.Subscription>()
 
   override fun startUp() {}


### PR DESCRIPTION
Right now, to register job queue handlers, you need to define a separate
service that will in its `startUp()` function subscribe to queues, which
are actually consumed by the `SqsJobConsumer`. This is kind of a hairy
interface.

With `AwsSqsJobQueueModule`, you just have to install the module to bind
a handler to a queue.

I spent some time trying to write tests for it, but haven't found a good
way to do so because of how difficult it is to manipulate the service
dependency graph in tests. There isn't a good way for the service that
registers the subscriptions to depend on both `DockerSqs` startup and
queue creation. Since the module is pretty simple I'm just going to
leave it without tests.