### PR TITLE
Set key to file url instead of file name to allow config override files with the same names

### DIFF
--- a/misk/src/main/kotlin/misk/config/MiskConfig.kt
+++ b/misk/src/main/kotlin/misk/config/MiskConfig.kt
@@ -125,7 +125,7 @@ object MiskConfig {
     // Load from override files second, in the order specified, only if they exist
     val overrideFileUrls = overrideFiles
         .filter { it.exists() }
-        .map { it.name to it.toURI().toURL() }
+        .map { it.toURI().toURL().toString() to it.toURI().toURL() }
 
     // Produce a combined map of all of the results
     return (embeddedConfigUrls + overrideFileUrls).map { it.first to it.second?.readUtf8() }.toMap()

--- a/misk/src/test/kotlin/misk/config/MiskConfigTest.kt
+++ b/misk/src/test/kotlin/misk/config/MiskConfigTest.kt
@@ -112,4 +112,23 @@ class MiskConfigTest {
     assertThat(filesInDir[0]).endsWith("/overrides/override-test-app1.yaml")
     assertThat(filesInDir[1]).endsWith("/overrides/override-test-app2.yaml")
   }
+
+  @Test
+  fun handlesDuplicateNamedExternalFiles() {
+    val overrides = listOf(
+      MiskConfigTest::class.java.getResource("/overrides/override-test-app1.yaml"),
+      MiskConfigTest::class.java.getResource("/additional_overrides/override-test-app1.yaml"))
+      .map { File(it.file) }
+
+    val config = MiskConfig.load<TestConfig>("test_app", defaultEnv, overrides)
+    assertThat(config.consumer_a).isEqualTo(ConsumerConfig(14, 1))
+    assertThat(config.consumer_b).isEqualTo(ConsumerConfig(34, 79))
+  }
+
+  @Test
+  fun handlesNonExistentExternalFile() {
+    // A common config does not exist, but the testing config does, loading the config should not fail
+    val config = MiskConfig.load<DurationConfig>("no_common_config_app", defaultEnv, listOf())
+    assertThat(config.interval).isEqualTo(Duration.ofSeconds(23))
+  }
 }

--- a/misk/src/test/resources/additional_overrides/override-test-app1.yaml
+++ b/misk/src/test/resources/additional_overrides/override-test-app1.yaml
@@ -1,0 +1,2 @@
+consumer_a:
+  min_items: 14

--- a/misk/src/test/resources/no_common_config_app-testing.yaml
+++ b/misk/src/test/resources/no_common_config_app-testing.yaml
@@ -1,0 +1,1 @@
+interval: "PT23S"


### PR DESCRIPTION
For e.g., if we had the following override files when loading our test_app's misk config

/resources/db_config/test_app-config.yaml
/resources/cache_config/test_app-config.yaml

We would like to override our config with the content from both files. Currently, we only
use the filename as a key when creating a mapping of our config. This PR changes the key
to contain the entire URL.