### PR TITLE
Web Actions Tab: Add null handling to Application/Network Interceptors

### DIFF
--- a/misk/src/main/kotlin/misk/web/BoundAction.kt
+++ b/misk/src/main/kotlin/misk/web/BoundAction.kt
@@ -33,8 +33,7 @@ internal class BoundAction<A : WebAction>(
   parameterExtractorFactories: List<ParameterExtractor.Factory>,
   val pathPattern: PathPattern,
   val action: Action,
-  val dispatchMechanism: DispatchMechanism,
-  val webActionMetadataFactory: WebActionMetadataAction.Factory
+  val dispatchMechanism: DispatchMechanism
 ) {
   private val parameterExtractors = action.function.parameters
       .drop(1) // the first parameter is always _this_
@@ -153,7 +152,7 @@ internal class BoundAction<A : WebAction>(
   }
 
   internal val metadata: WebActionMetadata by lazy {
-    webActionMetadataFactory.create(
+    WebActionMetadataAction.WebActionMetadata(
         name = action.name,
         function = action.function,
         functionAnnotations = action.function.annotations,

--- a/misk/src/main/kotlin/misk/web/MiskWebModule.kt
+++ b/misk/src/main/kotlin/misk/web/MiskWebModule.kt
@@ -17,6 +17,7 @@ import misk.web.actions.LivenessCheckAction
 import misk.web.actions.NotFoundAction
 import misk.web.actions.ReadinessCheckAction
 import misk.web.actions.StatusAction
+import misk.web.actions.WebActionMetadataAction
 import misk.web.exceptions.ActionExceptionLogLevelConfig
 import misk.web.exceptions.ActionExceptionMapper
 import misk.web.exceptions.ExceptionHandlingInterceptor
@@ -28,6 +29,7 @@ import misk.web.extractors.PathPatternParameterExtractorFactory
 import misk.web.extractors.QueryStringParameterExtractorFactory
 import misk.web.extractors.RequestBodyParameterExtractor
 import misk.web.extractors.WebSocketParameterExtractorFactory
+import misk.web.formatter.ClassNameFormatter
 import misk.web.interceptors.InternalErrorInterceptorFactory
 import misk.web.interceptors.MarshallerInterceptor
 import misk.web.interceptors.MetricsInterceptor
@@ -139,6 +141,10 @@ class MiskWebModule(private val config: WebConfig) : KAbstractModule() {
     install(WebActionModule.create<ReadinessCheckAction>())
     install(WebActionModule.create<LivenessCheckAction>())
     install(WebActionModule.create<NotFoundAction>())
+
+    // WebActionMetadataAction.Factory
+    bind<ClassNameFormatter>().toInstance(ClassNameFormatter())
+    bind<WebActionMetadataAction.Factory>().toInstance(WebActionMetadataAction.Factory())
   }
 
   @Provides @Singleton

--- a/misk/src/main/kotlin/misk/web/MiskWebModule.kt
+++ b/misk/src/main/kotlin/misk/web/MiskWebModule.kt
@@ -141,10 +141,6 @@ class MiskWebModule(private val config: WebConfig) : KAbstractModule() {
     install(WebActionModule.create<ReadinessCheckAction>())
     install(WebActionModule.create<LivenessCheckAction>())
     install(WebActionModule.create<NotFoundAction>())
-
-    // WebActionMetadataAction.Factory
-    bind<ClassNameFormatter>().toInstance(ClassNameFormatter())
-    bind<WebActionMetadataAction.Factory>().toInstance(WebActionMetadataAction.Factory())
   }
 
   @Provides @Singleton

--- a/misk/src/main/kotlin/misk/web/actions/WebActionFactory.kt
+++ b/misk/src/main/kotlin/misk/web/actions/WebActionFactory.kt
@@ -29,8 +29,7 @@ internal class WebActionFactory @Inject constructor(
   private val userProvidedNetworkInterceptorFactories: List<NetworkInterceptor.Factory>,
   @MiskDefault private val miskNetworkInterceptorFactories: List<NetworkInterceptor.Factory>,
   @MiskDefault private val miskApplicationInterceptorFactories: List<ApplicationInterceptor.Factory>,
-  private val parameterExtractorFactories: List<ParameterExtractor.Factory>,
-  private val webActionMetadataFactory: WebActionMetadataAction.Factory
+  private val parameterExtractorFactories: List<ParameterExtractor.Factory>
 ) {
 
   /** Returns the bound actions for `webActionClass`. */
@@ -129,6 +128,6 @@ internal class WebActionFactory @Inject constructor(
     }
 
     return BoundAction(provider, networkInterceptors, applicationInterceptors,
-        parameterExtractorFactories, PathPattern.parse(pathPattern), action, dispatchMechanism, webActionMetadataFactory)
+        parameterExtractorFactories, PathPattern.parse(pathPattern), action, dispatchMechanism)
   }
 }

--- a/misk/src/main/kotlin/misk/web/actions/WebActionFactory.kt
+++ b/misk/src/main/kotlin/misk/web/actions/WebActionFactory.kt
@@ -29,7 +29,8 @@ internal class WebActionFactory @Inject constructor(
   private val userProvidedNetworkInterceptorFactories: List<NetworkInterceptor.Factory>,
   @MiskDefault private val miskNetworkInterceptorFactories: List<NetworkInterceptor.Factory>,
   @MiskDefault private val miskApplicationInterceptorFactories: List<ApplicationInterceptor.Factory>,
-  private val parameterExtractorFactories: List<ParameterExtractor.Factory>
+  private val parameterExtractorFactories: List<ParameterExtractor.Factory>,
+  private val webActionMetadataFactory: WebActionMetadataAction.Factory
 ) {
 
   /** Returns the bound actions for `webActionClass`. */
@@ -128,6 +129,6 @@ internal class WebActionFactory @Inject constructor(
     }
 
     return BoundAction(provider, networkInterceptors, applicationInterceptors,
-        parameterExtractorFactories, PathPattern.parse(pathPattern), action, dispatchMechanism)
+        parameterExtractorFactories, PathPattern.parse(pathPattern), action, dispatchMechanism, webActionMetadataFactory)
   }
 }

--- a/misk/src/main/kotlin/misk/web/actions/WebActionMetadataAction.kt
+++ b/misk/src/main/kotlin/misk/web/actions/WebActionMetadataAction.kt
@@ -7,6 +7,7 @@ import misk.web.NetworkInterceptor
 import misk.web.PathPattern
 import misk.web.RequestContentType
 import misk.web.ResponseContentType
+import misk.web.formatter.ClassNameFormatter
 import misk.web.jetty.WebActionsServlet
 import misk.web.mediatype.MediaRange
 import misk.web.mediatype.MediaTypes
@@ -30,6 +31,44 @@ class WebActionMetadataAction @Inject constructor() : WebAction {
   }
 
   data class Response(val webActionMetadata: List<WebActionMetadata>)
+
+  class Factory {
+    @Inject lateinit var classNameFormatter: ClassNameFormatter
+
+    fun create(
+      name: String,
+      function: Function<*>,
+      functionAnnotations: List<Annotation>,
+      acceptedMediaRanges: List<MediaRange>,
+      responseContentType: MediaType?,
+      parameterTypes: List<KType>,
+      returnType: KType,
+      pathPattern: PathPattern,
+      applicationInterceptors: List<ApplicationInterceptor>,
+      networkInterceptors: List<NetworkInterceptor>,
+      dispatchMechanism: DispatchMechanism,
+      allowedServices: Set<String>,
+      allowedRoles: Set<String>
+    ): WebActionMetadata {
+      return WebActionMetadata(
+          name = name,
+          function = function.toString(),
+          functionAnnotations = functionAnnotations.map { it.toString() },
+          requestMediaTypes = acceptedMediaRanges.map { it.toString() },
+          responseMediaType = responseContentType.toString(),
+          parameterTypes = parameterTypes.map { it.toString() },
+          returnType = returnType.toString(),
+          pathPattern = pathPattern.toString(),
+          applicationInterceptors = applicationInterceptors.map {
+            classNameFormatter.format(it::class)
+          },
+          networkInterceptors = networkInterceptors.map { classNameFormatter.format(it::class) },
+          dispatchMechanism = dispatchMechanism,
+          allowedServices = allowedServices,
+          allowedRoles = allowedRoles
+      )
+    }
+  }
 }
 
 data class WebActionMetadata(
@@ -47,35 +86,3 @@ data class WebActionMetadata(
   val allowedServices: Set<String>,
   val allowedRoles: Set<String>
 )
-
-internal fun WebActionMetadata(
-    name: String,
-    function: Function<*>,
-    functionAnnotations: List<Annotation>,
-    acceptedMediaRanges: List<MediaRange>,
-    responseContentType: MediaType?,
-    parameterTypes: List<KType>,
-    returnType: KType,
-    pathPattern: PathPattern,
-    applicationInterceptors: List<ApplicationInterceptor>,
-    networkInterceptors: List<NetworkInterceptor>,
-    dispatchMechanism: DispatchMechanism,
-    allowedServices: Set<String>,
-    allowedRoles: Set<String>
-): WebActionMetadata {
-  return WebActionMetadata(
-      name = name,
-      function = function.toString(),
-      functionAnnotations = functionAnnotations.map { it.toString() },
-      requestMediaTypes = acceptedMediaRanges.map { it.toString() },
-      responseMediaType = responseContentType.toString(),
-      parameterTypes = parameterTypes.map { it.toString() },
-      returnType = returnType.toString(),
-      pathPattern = pathPattern.toString(),
-      applicationInterceptors = applicationInterceptors.map { it::class.qualifiedName.toString() },
-      networkInterceptors = networkInterceptors.map { it::class.qualifiedName.toString() },
-      dispatchMechanism = dispatchMechanism,
-      allowedServices = allowedServices,
-      allowedRoles = allowedRoles
-  )
-}

--- a/misk/src/main/kotlin/misk/web/actions/WebActionMetadataAction.kt
+++ b/misk/src/main/kotlin/misk/web/actions/WebActionMetadataAction.kt
@@ -19,7 +19,9 @@ import javax.inject.Singleton
 import kotlin.reflect.KType
 
 @Singleton
-class WebActionMetadataAction @Inject constructor() : WebAction {
+class WebActionMetadataAction @Inject constructor(
+  val classNameFormatter: ClassNameFormatter
+) : WebAction {
   @Inject internal lateinit var servletProvider: Provider<WebActionsServlet>
 
   @Get("/api/webactionmetadata")
@@ -32,42 +34,38 @@ class WebActionMetadataAction @Inject constructor() : WebAction {
 
   data class Response(val webActionMetadata: List<WebActionMetadata>)
 
-  class Factory {
-    @Inject lateinit var classNameFormatter: ClassNameFormatter
-
-    fun create(
-      name: String,
-      function: Function<*>,
-      functionAnnotations: List<Annotation>,
-      acceptedMediaRanges: List<MediaRange>,
-      responseContentType: MediaType?,
-      parameterTypes: List<KType>,
-      returnType: KType,
-      pathPattern: PathPattern,
-      applicationInterceptors: List<ApplicationInterceptor>,
-      networkInterceptors: List<NetworkInterceptor>,
-      dispatchMechanism: DispatchMechanism,
-      allowedServices: Set<String>,
-      allowedRoles: Set<String>
-    ): WebActionMetadata {
-      return WebActionMetadata(
-          name = name,
-          function = function.toString(),
-          functionAnnotations = functionAnnotations.map { it.toString() },
-          requestMediaTypes = acceptedMediaRanges.map { it.toString() },
-          responseMediaType = responseContentType.toString(),
-          parameterTypes = parameterTypes.map { it.toString() },
-          returnType = returnType.toString(),
-          pathPattern = pathPattern.toString(),
-          applicationInterceptors = applicationInterceptors.map {
-            classNameFormatter.format(it::class)
-          },
-          networkInterceptors = networkInterceptors.map { classNameFormatter.format(it::class) },
-          dispatchMechanism = dispatchMechanism,
-          allowedServices = allowedServices,
-          allowedRoles = allowedRoles
-      )
-    }
+  fun WebActionMetadata(
+    name: String,
+    function: Function<*>,
+    functionAnnotations: List<Annotation>,
+    acceptedMediaRanges: List<MediaRange>,
+    responseContentType: MediaType?,
+    parameterTypes: List<KType>,
+    returnType: KType,
+    pathPattern: PathPattern,
+    applicationInterceptors: List<ApplicationInterceptor>,
+    networkInterceptors: List<NetworkInterceptor>,
+    dispatchMechanism: DispatchMechanism,
+    allowedServices: Set<String>,
+    allowedRoles: Set<String>
+  ): WebActionMetadata {
+    return WebActionMetadata(
+        name = name,
+        function = function.toString(),
+        functionAnnotations = functionAnnotations.map { it.toString() },
+        requestMediaTypes = acceptedMediaRanges.map { it.toString() },
+        responseMediaType = responseContentType.toString(),
+        parameterTypes = parameterTypes.map { it.toString() },
+        returnType = returnType.toString(),
+        pathPattern = pathPattern.toString(),
+        applicationInterceptors = applicationInterceptors.map {
+          classNameFormatter.format(it::class)
+        },
+        networkInterceptors = networkInterceptors.map { classNameFormatter.format(it::class) },
+        dispatchMechanism = dispatchMechanism,
+        allowedServices = allowedServices,
+        allowedRoles = allowedRoles
+    )
   }
 }
 

--- a/misk/src/main/kotlin/misk/web/formatter/ClassNameFormatter.kt
+++ b/misk/src/main/kotlin/misk/web/formatter/ClassNameFormatter.kt
@@ -1,0 +1,12 @@
+package misk.web.formatter
+
+import kotlin.reflect.KClass
+
+class ClassNameFormatter {
+  fun <T : Any> format(kclass: KClass<T>): String {
+    return when (kclass.qualifiedName) {
+      null -> kclass.toString().split("class ").last()
+      else -> kclass.qualifiedName.toString()
+    }
+  }
+}

--- a/misk/src/main/kotlin/misk/web/formatter/ClassNameFormatter.kt
+++ b/misk/src/main/kotlin/misk/web/formatter/ClassNameFormatter.kt
@@ -1,8 +1,9 @@
 package misk.web.formatter
 
+import javax.inject.Inject
 import kotlin.reflect.KClass
 
-class ClassNameFormatter {
+class ClassNameFormatter @Inject constructor() {
   fun <T : Any> format(kclass: KClass<T>): String {
     return when (kclass.qualifiedName) {
       null -> kclass.toString().split("class ").last()

--- a/misk/src/main/kotlin/misk/web/metadata/AdminDashboardModule.kt
+++ b/misk/src/main/kotlin/misk/web/metadata/AdminDashboardModule.kt
@@ -115,7 +115,7 @@ class AdminDashboardModule(val environment: Environment) : KAbstractModule() {
 }
 
 // Module that allows testing/development environments to bind up the admin dashboard
-class AdminDashboardTestingModule(val environment: Environment): KAbstractModule() {
+class AdminDashboardTestingModule(val environment: Environment) : KAbstractModule() {
   override fun configure() {
     install(AdminDashboardModule(environment))
     multibind<AccessAnnotationEntry>()

--- a/misk/src/test/kotlin/misk/web/formatter/ClassNameFormatterTest.kt
+++ b/misk/src/test/kotlin/misk/web/formatter/ClassNameFormatterTest.kt
@@ -1,0 +1,53 @@
+package misk.web.formatter
+
+import com.google.common.base.CharMatcher
+import misk.testing.MiskTest
+import misk.web.NetworkChain
+import misk.web.NetworkInterceptor
+import misk.web.Response
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+@MiskTest(startService = false)
+class ClassNameFormatterTest {
+  fun isValid(className: String) {
+    assertTrue(className.isNotBlank())
+    assertNotNull(className)
+    assertTrue(
+        CharMatcher.inRange('A', 'Z').or(CharMatcher.inRange('a', 'z')).matchesAnyOf(className))
+  }
+
+  @Test fun validQualifiedName() {
+    val formatted = ClassNameFormatter().format(ValidQualifiedNameClass::class)
+    isValid(formatted)
+    assertEquals(formatted, ValidQualifiedNameClass::class.qualifiedName.toString())
+  }
+
+  @Test fun missingQualifiedName() {
+    val noQualifiedNameClass = NoQualifiedNameFactory().create()
+    assertNull(noQualifiedNameClass::class.qualifiedName)
+
+    val formatted = ClassNameFormatter().format(noQualifiedNameClass::class)
+    isValid(formatted)
+    assertEquals(formatted, noQualifiedNameClass::class.toString().split("class ").last())
+  }
+}
+
+class ValidQualifiedNameClass {}
+
+class NoQualifiedNameFactory {
+  fun create(): NetworkInterceptor {
+    return NoQualifiedNameClass
+  }
+
+  private companion object {
+    val NoQualifiedNameClass = object : NetworkInterceptor {
+      override fun intercept(chain: NetworkChain): Response<*> {
+        return Response("False")
+      }
+    }
+  }
+}

--- a/misk/web/tabs/web-actions/src/ducks/webActions.ts
+++ b/misk/web/tabs/web-actions/src/ducks/webActions.ts
@@ -266,7 +266,7 @@ export const WebActionsReducer = (
   state = initialState,
   action: IAction<WEBACTIONS, {}>
 ) => {
-  switch (action.type) {
+  switch (action.type)  {
     case WEBACTIONS.DINOSAUR:
     case WEBACTIONS.FAILURE:
     case WEBACTIONS.METADATA:


### PR DESCRIPTION
* Application or Network Interceptors are appearing null when they lack a qualified class name
* New `ClassNameFormatter` that handles formatting a valid class name