### PR TITLE
Rename ConfigAdminAction

### DIFF
--- a/misk/src/main/kotlin/misk/config/ConfigMetadataAction.kt
+++ b/misk/src/main/kotlin/misk/config/ConfigMetadataAction.kt
@@ -11,14 +11,14 @@ import misk.web.metadata.AdminDashboardAccess
 import javax.inject.Singleton
 
 @Singleton
-class ConfigAdminAction @Inject constructor(
+class ConfigMetadataAction @Inject constructor(
   @AppName val appName: String,
   val environment: Environment,
   val config: Config
 ) : WebAction {
   val resources: Map<String, String?> = generateConfigResources(appName, environment, config)
 
-  @Get("/api/config/all")
+  @Get("/api/config/metadata")
   @RequestContentType(MediaTypes.APPLICATION_JSON)
   @ResponseContentType(MediaTypes.APPLICATION_JSON)
   @AdminDashboardAccess

--- a/misk/src/main/kotlin/misk/web/metadata/AdminDashboardModule.kt
+++ b/misk/src/main/kotlin/misk/web/metadata/AdminDashboardModule.kt
@@ -1,6 +1,6 @@
 package misk.web.metadata
 
-import misk.config.ConfigAdminAction
+import misk.config.ConfigMetadataAction
 import misk.environment.Environment
 import misk.inject.KAbstractModule
 import misk.security.authz.AccessAnnotationEntry
@@ -52,7 +52,7 @@ class AdminDashboardModule(val environment: Environment) : KAbstractModule() {
     ))
 
     // Config
-    install(WebActionModule.create<ConfigAdminAction>())
+    install(WebActionModule.create<ConfigMetadataAction>())
     multibind<DashboardTab, AdminDashboardTab>().toInstance(DashboardTab(
         name = "Config",
         slug = "config",

--- a/misk/src/test/kotlin/misk/web/actions/ConfigMetadataActionTest.kt
+++ b/misk/src/test/kotlin/misk/web/actions/ConfigMetadataActionTest.kt
@@ -1,7 +1,7 @@
 package misk.web.actions
 
 import misk.config.Config
-import misk.config.ConfigAdminAction
+import misk.config.ConfigMetadataAction
 import misk.environment.Environment
 import misk.testing.MiskTest
 import misk.testing.MiskTestModule
@@ -10,7 +10,7 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
 @MiskTest(startService = true)
-class ConfigAdminActionTest {
+class ConfigMetadataActionTest {
   @MiskTestModule
   val module = TestAdminDashboardActionModule()
 
@@ -19,17 +19,17 @@ class ConfigAdminActionTest {
       OverriddenConfig("bar"),
       RedactedConfig("pass1", "phrase2"))
 
-  lateinit var configAdminAction: ConfigAdminAction
+  lateinit var configMetadataAction: ConfigMetadataAction
 
   @BeforeEach fun beforeEach() {
-    configAdminAction = ConfigAdminAction(
+    configMetadataAction = ConfigMetadataAction(
         "admin_dashboard_app",
         Environment.TESTING,
         testConfig)
   }
 
   @Test fun passesAlongEffectiveConfig() {
-    val response = configAdminAction.getAll()
+    val response = configMetadataAction.getAll()
     assertThat(response.resources).containsKey("Effective Config")
 
     val effectiveConfig = response.resources.get("Effective Config")
@@ -38,7 +38,7 @@ class ConfigAdminActionTest {
   }
 
   @Test fun passesAlongFullUnderlyingConfigResources() {
-    val response = configAdminAction.getAll()
+    val response = configMetadataAction.getAll()
     assertThat(response.resources).containsKey("classpath:/admin_dashboard_app-common.yaml")
     assertThat(response.resources).containsKey("classpath:/admin_dashboard_app-testing.yaml")
 
@@ -51,7 +51,7 @@ class ConfigAdminActionTest {
   }
 
   @Test fun redactsConfig() {
-    val response = configAdminAction.getAll()
+    val response = configMetadataAction.getAll()
     assertThat(response.resources).containsKey("classpath:/admin_dashboard_app-common.yaml")
     assertThat(response.resources).containsKey("Effective Config")
 

--- a/misk/web/tabs/config/src/containers/TabContainer.tsx
+++ b/misk/web/tabs/config/src/containers/TabContainer.tsx
@@ -9,7 +9,7 @@ export interface IConfigResources {
   [name: string]: string
 }
 
-const apiUrl = "/api/config/all"
+const apiUrl = "/api/config/metadata"
 
 class TabContainer extends React.Component<IState & IDispatchProps, IState> {
   componentDidMount() {


### PR DESCRIPTION
* Match idiom of introspective dashboard web actions being named as `{name}MetadataAction` with the path `/api/{name}/metadata`