### PR TITLE
Rename WebActionMetadataAction path

### DIFF
--- a/misk/src/main/kotlin/misk/web/actions/WebActionMetadataAction.kt
+++ b/misk/src/main/kotlin/misk/web/actions/WebActionMetadataAction.kt
@@ -21,7 +21,7 @@ import kotlin.reflect.KType
 class WebActionMetadataAction @Inject constructor() : WebAction {
   @Inject internal lateinit var servletProvider: Provider<WebActionsServlet>
 
-  @Get("/api/webactionmetadata")
+  @Get("/api/webaction/metadata")
   @RequestContentType(MediaTypes.APPLICATION_JSON)
   @ResponseContentType(MediaTypes.APPLICATION_JSON)
   @AdminDashboardAccess

--- a/misk/web/tabs/web-actions/src/ducks/webActions.ts
+++ b/misk/web/tabs/web-actions/src/ducks/webActions.ts
@@ -175,7 +175,7 @@ const groupByWebActionHash = (
 
 function* handleMetadata() {
   try {
-    const { data } = yield call(axios.get, "/api/webactionmetadata")
+    const { data } = yield call(axios.get, "/api/webaction/metadata")
     const { webActionMetadata } = data
     const metadata = chain(webActionMetadata)
       .map((action: IWebActionAPI) => {


### PR DESCRIPTION
* Match idiom of introspective dashboard web actions being named as {name}MetadataAction with the path /api/{name}/metadata