### PR TITLE
Expose QueueName.deadletterQueue

### DIFF
--- a/misk-aws/src/main/kotlin/misk/jobqueue/sqs/QueueUrlMapping.kt
+++ b/misk-aws/src/main/kotlin/misk/jobqueue/sqs/QueueUrlMapping.kt
@@ -17,6 +17,6 @@ internal class QueueUrlMapping @Inject internal constructor(private val sqs: Ama
   }
 }
 
-internal val QueueName.isDeadLetterQueue get() = value.endsWith("_dlq")
-internal val QueueName.deadLetterQueue
+val QueueName.isDeadLetterQueue get() = value.endsWith("_dlq")
+val QueueName.deadLetterQueue
   get() = if (isDeadLetterQueue) this else QueueName(this.value + "_dlq")


### PR DESCRIPTION
Since this is an enforced convention, we should expose it. Otherwise we'll see this everywhere:

```kotlin
      var queueName = "jobqueue-exemplar_queue"
      if (deadletter) {
        queueName += "_dlq"
      }
```