### PR TITLE
Support overriding dependencies in service graph

### DIFF
--- a/misk/src/main/kotlin/misk/MiskServiceModule.kt
+++ b/misk/src/main/kotlin/misk/MiskServiceModule.kt
@@ -64,11 +64,12 @@ class MiskCommonServiceModule : KAbstractModule() {
     // Initialize empty sets for our multibindings.
     newMultibinder<HealthCheck>()
     newMultibinder<Service>()
+    newMultibinder<ServiceDependencyOverride>()
   }
 
   @Provides
   @Singleton
-  fun provideServiceManager(injector: Injector, services: List<Service>): ServiceManager {
+  fun provideServiceManager(injector: Injector, services: List<Service>, depOverrides: List<ServiceDependencyOverride>): ServiceManager {
     // NB(mmihic): We get the binding for the Set<Service> because this uses a multibinder,
     // which allows us to retrieve the bindings for the elements
     val serviceListBinding = injector.getBinding(serviceSetKey)
@@ -82,7 +83,7 @@ class MiskCommonServiceModule : KAbstractModule() {
       "the following services are not marked as @Singleton: ${invalidServices.joinToString(", ")}"
     }
 
-    return CoordinatedService.coordinate(services)
+    return CoordinatedService.coordinate(services, depOverrides)
   }
 
   @Suppress("DEPRECATION")

--- a/misk/src/main/kotlin/misk/ServiceDependencyOverride.kt
+++ b/misk/src/main/kotlin/misk/ServiceDependencyOverride.kt
@@ -1,0 +1,10 @@
+package misk
+
+import com.google.common.util.concurrent.Service
+import com.google.inject.Key
+import kotlin.reflect.KClass
+
+data class ServiceDependencyOverride(
+  val service: KClass<out Service>,
+  val extraDependencies: Set<Key<*>>
+)

--- a/misk/src/test/kotlin/misk/CoordinatedServiceTest.kt
+++ b/misk/src/test/kotlin/misk/CoordinatedServiceTest.kt
@@ -15,7 +15,36 @@ class CoordinatedServiceTest {
     val c = AppendingService(target, "Service C", consumed = setOf("a", "b"))
     val b = AppendingService(target, "Service B", produced = setOf("b"))
 
-    val serviceManager = CoordinatedService.coordinate(listOf(a, b, c))
+    val serviceManager = CoordinatedService.coordinate(listOf(a, b, c), listOf())
+    serviceManager.startAsync()
+    serviceManager.awaitHealthy()
+    target.append("healthy\n")
+    serviceManager.stopAsync()
+    serviceManager.awaitStopped()
+
+    assertThat(target.toString()).isEqualTo("""
+        |starting Service A
+        |starting Service B
+        |starting Service C
+        |healthy
+        |stopping Service C
+        |stopping Service A
+        |stopping Service B
+        |""".trimMargin())
+  }
+
+  @Test fun overrideDependencies() {
+    val target = StringBuilder()
+
+    val a = AppendingService(target, "Service A", produced = setOf("a"))
+    val c = NoDependencyService(target, "Service C")
+    val b = AppendingService(target, "Service B", produced = setOf("b"))
+
+    val extraDeps = ServiceDependencyOverride(
+        NoDependencyService::class,
+        listOf("a", "b").map { nameToKey(it) }.toSet()
+    )
+    val serviceManager = CoordinatedService.coordinate(listOf(a, b, c), listOf(extraDeps))
     serviceManager.startAsync()
     serviceManager.awaitHealthy()
     target.append("healthy\n")
@@ -42,7 +71,7 @@ class CoordinatedServiceTest {
     val d = AppendingService(target, "Service D", produced = setOf("d"), consumed = setOf("b"))
     val e = AppendingService(target, "Service E", produced = setOf("e"), consumed = setOf("d"))
 
-    val serviceManager = CoordinatedService.coordinate(listOf(a, b, c, d, e))
+    val serviceManager = CoordinatedService.coordinate(listOf(a, b, c, d, e), listOf())
     serviceManager.startAsync()
     serviceManager.awaitHealthy()
     target.append("healthy\n")
@@ -73,7 +102,7 @@ class CoordinatedServiceTest {
     val d = AppendingService(target, "Service D", produced = setOf("d"), consumed = setOf("c", "e"))
     val e = AppendingService(target, "Service E", produced = setOf("e"), consumed = setOf("a", "c"))
 
-    val serviceManager = CoordinatedService.coordinate(listOf(a, b, c, d, e))
+    val serviceManager = CoordinatedService.coordinate(listOf(a, b, c, d, e), listOf())
     serviceManager.startAsync()
     serviceManager.awaitHealthy()
     target.append("healthy\n")
@@ -102,7 +131,7 @@ class CoordinatedServiceTest {
     val c = AppendingService(target, "Service C", consumed = setOf("a", "b"))
 
     assertThat(assertFailsWith<IllegalArgumentException> {
-      CoordinatedService.coordinate(listOf(a, c))
+      CoordinatedService.coordinate(listOf(a, c), listOf())
     }).hasMessage("""
         |Service dependency graph has problems:
         |  Service C requires ${nameToKey("b")} but no service produces it""".trimMargin())
@@ -116,7 +145,7 @@ class CoordinatedServiceTest {
     val b = AppendingService(target, "Service B", produced = setOf("a"))
 
     assertThat(assertFailsWith<IllegalArgumentException> {
-      CoordinatedService.coordinate(listOf(a, b, c))
+      CoordinatedService.coordinate(listOf(a, b, c), listOf())
     }).hasMessage("""
         |Service dependency graph has problems:
         |  multiple services produce ${nameToKey("a")}: Service A and Service B""".trimMargin())
@@ -131,7 +160,7 @@ class CoordinatedServiceTest {
     val d = AppendingService(target, "Service D", produced = setOf("d"), consumed = setOf("c"))
 
     assertThat(assertFailsWith<IllegalArgumentException> {
-      CoordinatedService.coordinate(listOf(a, b, c, d))
+      CoordinatedService.coordinate(listOf(a, b, c, d), listOf())
     }).hasMessage("""
         |Service dependency graph has problems:
         |  dependency cycle: Service A -> Service D -> Service C -> Service A""".trimMargin())
@@ -150,7 +179,7 @@ class CoordinatedServiceTest {
 
     val b = AppendingService(target, "Service B", consumed = setOf("a"))
 
-    val serviceManager = CoordinatedService.coordinate(listOf(a, b))
+    val serviceManager = CoordinatedService.coordinate(listOf(a, b), listOf())
     serviceManager.startAsync()
     assertFailsWith<IllegalStateException> {
       serviceManager.awaitHealthy()
@@ -170,6 +199,30 @@ class CoordinatedServiceTest {
 
     override val producedKeys: Set<Key<*>>
       get() = produced.map { nameToKey(it) }.toSet()
+
+    override fun doStart() {
+      target.append("starting $name\n")
+      notifyStarted()
+    }
+
+    override fun doStop() {
+      target.append("stopping $name\n")
+      notifyStopped()
+    }
+
+    override fun toString() = name
+  }
+
+  /** NoDependencyService is the same as AppendingService but has no dependencies. */
+  class NoDependencyService(
+    val target: StringBuilder,
+    val name: String
+  ) : AbstractService(), DependentService {
+    override val consumedKeys: Set<Key<*>>
+      get() = setOf()
+
+    override val producedKeys: Set<Key<*>>
+      get() = setOf()
 
     override fun doStart() {
       target.append("starting $name\n")


### PR DESCRIPTION
ServiceTestingModule is a hard to use because it doesn't override the Service it is adding extra dependencies to, since you can't override a Multibinding. Instead, it binds a new service with extra `consumedKeys`. It's on the developer to refactor their modules so that in tests they don't bind the original service, because otherwise the service graph will complain about having 2 services producing the same key.

This adds support to `CoordinatedService` for explicitly overriding service dependencies. There is a limitation with this approach that it targets all instances of a service, not a specific binding, since overrides can only target by Class, not Key.