### PR TITLE
Fix flaky tests

### DIFF
--- a/misk-hibernate-testing/src/main/kotlin/misk/jdbc/VitessScaleSafetyChecks.kt
+++ b/misk-hibernate-testing/src/main/kotlin/misk/jdbc/VitessScaleSafetyChecks.kt
@@ -305,10 +305,10 @@ class VitessScaleSafetyChecks(
     val request = Request.Builder()
         .url("http://localhost:27000/debug/vars")
         .build()
-    val response = okHttpClient.newCall(request).execute()
-    val source = response.body()!!.source()
     val adapter = moshi.adapter<Variables>()
-    val variables = adapter.fromJson(source)!!
+    val variables = okHttpClient.newCall(request).execute().use {
+      adapter.fromJson(it.body()!!.source())!!
+    }
     return variables.QueriesProcessed["SelectScatter"] ?: 0
   }
 
@@ -320,9 +320,9 @@ class VitessScaleSafetyChecks(
     val request = Request.Builder()
         .url("http://localhost:27000/debug/query_plans")
         .build()
-    val response = okHttpClient.newCall(request).execute()
-    val source = response.body()!!.source()
-    return parseQueryPlans(source).filter { it.isScatter }.sumBy { it.ExecCount }
+    return okHttpClient.newCall(request).execute().use { r ->
+      parseQueryPlans(r.body()!!.source()).filter { it.isScatter }.sumBy { it.ExecCount }
+    }
   }
 
   private val EMPTY_LINE = "\n\n".encodeUtf8()

--- a/misk-hibernate/src/main/kotlin/misk/hibernate/SchemaMigrationCheckService.kt
+++ b/misk-hibernate/src/main/kotlin/misk/hibernate/SchemaMigrationCheckService.kt
@@ -1,0 +1,27 @@
+package misk.hibernate
+
+import com.google.common.util.concurrent.AbstractIdleService
+import com.google.inject.Key
+import misk.DependentService
+import misk.inject.toKey
+import javax.inject.Singleton
+
+/**
+ * Validates that all migrations have been applied
+ */
+@Singleton
+class SchemaMigrationCheckService internal constructor(
+  qualifier: kotlin.reflect.KClass<out kotlin.Annotation>,
+  private val schemaMigratorProvider: javax.inject.Provider<misk.hibernate.SchemaMigrator> // Lazy!
+) : DependentService, AbstractIdleService() {
+
+  override val consumedKeys = setOf<Key<*>>(SchemaMigratorService::class.toKey(qualifier))
+  override val producedKeys = setOf<Key<*>>()
+
+  override fun startUp() {
+    schemaMigratorProvider.get().requireAll()
+  }
+
+  override fun shutDown() {
+  }
+}

--- a/misk-hibernate/src/main/kotlin/misk/hibernate/SchemaValidatorService.kt
+++ b/misk-hibernate/src/main/kotlin/misk/hibernate/SchemaValidatorService.kt
@@ -13,14 +13,10 @@ import kotlin.reflect.KClass
 internal class SchemaValidatorService internal constructor(
   qualifier: KClass<out Annotation>,
   private val sessionFactoryServiceProvider: Provider<SessionFactoryService>,
-  private val transacterProvider: Provider<Transacter>,
-  private val config: DataSourceConfig
+  private val transacterProvider: Provider<Transacter>
 ) : AbstractIdleService(), DependentService {
 
-  override val consumedKeys = setOf<Key<*>>(
-      SchemaMigratorService::class.toKey(qualifier),
-      SessionFactoryService::class.toKey(qualifier)
-  )
+  override val consumedKeys = setOf<Key<*>>(SchemaMigratorService::class.toKey(qualifier))
   override val producedKeys = setOf<Key<*>>(SchemaValidatorService::class.toKey(qualifier))
 
   override fun startUp() {

--- a/misk-hibernate/src/main/kotlin/misk/vitess/StartVitessService.kt
+++ b/misk-hibernate/src/main/kotlin/misk/vitess/StartVitessService.kt
@@ -21,10 +21,12 @@ import misk.backoff.retry
 import misk.environment.Environment
 import misk.environment.Environment.DEVELOPMENT
 import misk.environment.Environment.TESTING
+import misk.hibernate.SchemaMigratorService
+import misk.hibernate.SessionFactoryService
+import misk.inject.toKey
 import misk.jdbc.DataSourceConfig
 import misk.jdbc.DataSourceType
 import misk.jdbc.uniqueInt
-import misk.jdbc.uniqueString
 import misk.moshi.adapter
 import misk.resources.ResourceLoader
 import mu.KotlinLogging
@@ -321,7 +323,7 @@ class StartVitessService(
 ) : AbstractIdleService(), DependentService {
 
   override val consumedKeys: Set<Key<*>> = setOf()
-  override val producedKeys: Set<Key<*>> = setOf(Key.get(StartVitessService::class.java))
+  override val producedKeys: Set<Key<*>> = setOf(StartVitessService::class.toKey(qualifier))
 
   var cluster: DockerVitessCluster? = null
 
@@ -440,5 +442,25 @@ class StartVitessService(
       dockerCluster.start()
     }
 
+  }
+
+  /**
+   * A work around to block Services that are dependent on [SchemaMigratorService] since
+   * [StartVitessService] performs migrations in tests.
+   */
+  class MigrationsAlreadyAppliedService(qualifier: kotlin.reflect.KClass<out kotlin.Annotation>) :
+      DependentService,
+      AbstractIdleService() {
+
+    override val consumedKeys = setOf<Key<*>>(
+        SessionFactoryService::class.toKey(qualifier),
+        StartVitessService::class.toKey(qualifier))
+    override val producedKeys = setOf<Key<*>>(SchemaMigratorService::class.toKey(qualifier))
+
+    override fun startUp() {
+    }
+
+    override fun shutDown() {
+    }
   }
 }


### PR DESCRIPTION
This dependency wiring could use love and rework. I think we should stop producing keys that map 1:1 with actually services, and instead start producing logical keys like `PersistenceLayerReady`. so `StartVitessService` would produce `PersistenceLayerReady`, but also if you're not in tests or not using vitess, you would install a no-op service that also produces `PersistenceLayerReady`. 

For now I just wanted to fix the flakes :)