### PR TITLE
Add ExternalDependency support to MiskTestExtension

### DIFF
--- a/misk-testing/src/main/kotlin/misk/testing/ExternalDependency.kt
+++ b/misk-testing/src/main/kotlin/misk/testing/ExternalDependency.kt
@@ -1,0 +1,34 @@
+package misk.testing
+
+/**
+ * An external dependency of the Misk Application that needs to be started for test, like Redis,
+ * Vitess, MySQL, SQS, etc.
+ */
+interface ExternalDependency {
+  /**
+   * Starts the dependency.
+   */
+  fun startup()
+
+  /**
+   * Stops the dependency.
+   */
+  fun shutdown()
+
+  /**
+   * Called before each test run
+   */
+  fun beforeEach()
+
+  /**
+   * Called before each test run
+   */
+  fun afterEach()
+
+  /**
+   * Unique ID for the dependency, used as a stable key across tests. Can be overridden if more
+   * than one instance of the dependency is supported.
+   */
+  val id: String get() = javaClass.name
+}
+

--- a/misk-testing/src/main/kotlin/misk/testing/MiskTest.kt
+++ b/misk-testing/src/main/kotlin/misk/testing/MiskTest.kt
@@ -24,3 +24,6 @@ annotation class MiskTest(val startService: Boolean = false)
 
 @Target(AnnotationTarget.FIELD)
 annotation class MiskTestModule
+
+@Target(AnnotationTarget.FIELD)
+annotation class MiskExternalDependency


### PR DESCRIPTION
We currently spin up external dependencies like Vitess and SQS in tests,
by inserting additional services into the service dependency graph. It
has forced us to use different workarounds, like ServiceTestingModule
which modifies the service graph in tests, and StartVitessService which
is a production dependency but really doesn't belong there.

@ryanhall07 had the idea that we could have the MiskTestExtension start up
external dependencies instead, since they really are just test fixtures
and are better handled by the testing framework.

It converts the DockerSqs service, which is
simple but is a good enough demonstration.