### PR TITLE
overwrite leftover copies of the plaintext

### DIFF
--- a/misk-crypto/src/main/kotlin/misk/crypto/Cipher.kt
+++ b/misk-crypto/src/main/kotlin/misk/crypto/Cipher.kt
@@ -46,13 +46,22 @@ class RealCipher internal constructor(
   private val aead = AeadFactory.getPrimitive(keysetHandle)
 
   override fun encrypt(plaintext: ByteString): ByteString {
-    val encrypted = aead.encrypt(plaintext.toByteArray(), null)
+    // .toByteArray() creates a copy of the receiver ByteString.
+    val plaintextBytes = plaintext.toByteArray()
+    val encrypted = aead.encrypt(plaintextBytes, null)
+    // We want to make sure this code doesn't leave behind any unnecessary copies of the plaintext.
+    // So before retuning, make sure we override the extra copy of the plaintext with 0's.
+    plaintextBytes.fill(0)
     return encrypted.toByteString()
   }
 
   override fun decrypt(ciphertext: ByteString): ByteString {
-    val decrypted = aead.decrypt(ciphertext.toByteArray(), null)
-    return decrypted.toByteString()
+    val decryptedBytes = aead.decrypt(ciphertext.toByteArray(), null)
+    // .toByteString() creates a copy of the receiver object
+    val decrypted = decryptedBytes.toByteString()
+    // Make sure we don't leave any unnecessary copies of the decrypted data laying around.
+    decryptedBytes.fill(0)
+    return decrypted
   }
 
   override val keyInfo: KeyInfo

--- a/misk-crypto/src/main/kotlin/misk/crypto/CryptoModule.kt
+++ b/misk-crypto/src/main/kotlin/misk/crypto/CryptoModule.kt
@@ -1,7 +1,6 @@
 package misk.crypto
 
 import com.google.crypto.tink.Aead
-import com.google.crypto.tink.BinaryKeysetReader
 import com.google.crypto.tink.JsonKeysetReader
 import com.google.crypto.tink.KeysetHandle
 import com.google.crypto.tink.KmsClient
@@ -9,7 +8,6 @@ import com.google.crypto.tink.aead.AeadConfig
 import com.google.inject.name.Names
 import misk.config.Secret
 import misk.inject.KAbstractModule
-import java.util.Base64
 
 /**
  * Configures and registers the keys listed in the configuration file.


### PR DESCRIPTION
Subtle fix to the Cipher object.
When using `ByteString.toByteArray()` and `ByteArray.toByteString()`, the underlying implementation creates a copy of the `byte[]` that holds the data.
This PR makes sure that copies of the plaintext data created in the `Cipher` class are being overwritten with `0`'s before returning.