### PR TITLE
manually shard tests by hibernate/non-hibernate

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,9 @@
 version: 2.1
 jobs:
-  java-non-hibernate:
+  java:
     machine:
       image: circleci/classic:latest
+    parallelism: 2
     working_directory: ~/misk
     steps:
       - checkout # check out source code to working directory
@@ -23,39 +24,25 @@ jobs:
           name: "Dump environment variables"
           command: env
       - run:
-          name: "Build and test"
-          command: ./gradlew testShardNonHibernate -i --scan --parallel --build-cache
-  java-hibernate:
-    machine:
-      image: circleci/classic:latest
-    working_directory: ~/misk
-    steps:
-      - checkout # check out source code to working directory
-      - run:
-          name: "Download and extract OpenJDK 11"
-          command: "mkdir -p ~/openjdk-11 && cd ~/openjdk-11 && curl -sSL https://download.java.net/java/GA/jdk11/9/GPL/openjdk-11.0.2_linux-x64_bin.tar.gz | tar -xz --strip-components 1"
-      - run:
-          name: "Set environment variables"
-          command: |
-            echo '
-              export PATH="$JAVA_HOME/bin:$PATH"
-              export JAVA_HOME="$HOME/openjdk-11"
-              export ENVIRONMENT=TESTING
-              # Not sure if this actually gets applied on the daemon
-              export GRADLE_OPTS=-Xmx4096m
-            ' >> $BASH_ENV
-      - run:
-          name: "Dump environment variables"
-          command: env
-      - run:
-          name: "Start MySQL"
+          name: "Start MySQL if needed"
           # There's a race condition here, where it's possible that MySQL hasn't finished starting
           # up before we try to connect to it. But Kotlin builds are so damn slow it'll never
           # happen in practice.
-          command: docker run -d -p 3306:3306 --name mysql -e MYSQL_ALLOW_EMPTY_PASSWORD=1 mysql:5.7
+          command: |
+            # Only run MySQL for the hibernate tests.
+            if [ "$CIRCLE_NODE_INDEX" -eq 1 ]; then
+              docker run -d -p 3306:3306 --name mysql -e MYSQL_ALLOW_EMPTY_PASSWORD=1 mysql:5.7
+            else
+              echo "Not starting MySQL"
+            fi
       - run:
           name: "Build and test"
-          command: ./gradlew testShardHibernate -i --scan --parallel --build-cache
+          command: |
+            if [ "$CIRCLE_NODE_INDEX" -eq 1 ]; then
+              ./gradlew testShardHibernate -i --scan --parallel --build-cache
+            else
+              ./gradlew testShardNonHibernate -i --scan --parallel --build-cache
+            fi
   node:
     working_directory: ~/misk
     docker:
@@ -67,13 +54,11 @@ workflows:
   version: 2
   on_commit:
     jobs:
-      - java-non-hibernate
-      - java-hibernate
+      - java
       - node
   nightly:
     jobs:
-      - java-non-hibernate
-      - java-hibernate
+      - java
       - node
     triggers:
       - schedule:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,31 @@
 version: 2.1
 jobs:
-  java:
+  java-non-hibernate:
+    machine:
+      image: circleci/classic:latest
+    working_directory: ~/misk
+    steps:
+      - checkout # check out source code to working directory
+      - run:
+          name: "Download and extract OpenJDK 11"
+          command: "mkdir -p ~/openjdk-11 && cd ~/openjdk-11 && curl -sSL https://download.java.net/java/GA/jdk11/9/GPL/openjdk-11.0.2_linux-x64_bin.tar.gz | tar -xz --strip-components 1"
+      - run:
+          name: "Set environment variables"
+          command: |
+            echo '
+              export PATH="$JAVA_HOME/bin:$PATH"
+              export JAVA_HOME="$HOME/openjdk-11"
+              export ENVIRONMENT=TESTING
+              # Not sure if this actually gets applied on the daemon
+              export GRADLE_OPTS=-Xmx4096m
+            ' >> $BASH_ENV
+      - run:
+          name: "Dump environment variables"
+          command: env
+      - run:
+          name: "Build and test"
+          command: ./gradlew testShardNonHibernate -i --scan --parallel --build-cache
+  java-hibernate:
     machine:
       image: circleci/classic:latest
     working_directory: ~/misk
@@ -30,7 +55,7 @@ jobs:
           command: docker run -d -p 3306:3306 --name mysql -e MYSQL_ALLOW_EMPTY_PASSWORD=1 mysql:5.7
       - run:
           name: "Build and test"
-          command: ./gradlew test -i --scan --parallel --build-cache
+          command: ./gradlew testShardHibernate -i --scan --parallel --build-cache
   node:
     working_directory: ~/misk
     docker:
@@ -42,11 +67,13 @@ workflows:
   version: 2
   on_commit:
     jobs:
-      - java
+      - java-non-hibernate
+      - java-hibernate
       - node
   nightly:
     jobs:
-      - java
+      - java-non-hibernate
+      - java-hibernate
       - node
     triggers:
       - schedule:

--- a/build.gradle
+++ b/build.gradle
@@ -16,6 +16,20 @@ ext {
 
 apply from: file("./dependencies.gradle")
 
+tasks.register("testShardNonHibernate") {
+  group = "Continuous integration"
+  description = "Runs all tests that don't depend on misk-hibernate. " +
+          "This target is intended for manually sharding tests to make CI faster."
+}
+
+// Runs all tests that depend on misk-hibernate
+// This target is intended for manually sharding tests to make CI faster.
+tasks.register("testShardHibernate") {
+  group = "Continuous integration"
+  description = "Runs all tests that depend on misk-hibernate. " +
+          "This target is intended for manually sharding tests to make CI faster."
+}
+
 subprojects {
   apply plugin: "java"
   apply plugin: 'kotlin'
@@ -64,5 +78,10 @@ subprojects {
   if (rootProject.file("hooks.gradle").exists()) {
     apply from: rootProject.file("hooks.gradle")
   }
-}
 
+  if (["misk-aws","misk-events","misk-jobqueue","misk-hibernate","misk-hibernate-testing"].contains(name)) {
+    rootProject.getTasksByName("testShardHibernate", false)[0].dependsOn.add(test)
+  } else {
+    rootProject.getTasksByName("testShardNonHibernate", false)[0].dependsOn.add(test)
+  }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -22,8 +22,6 @@ tasks.register("testShardNonHibernate") {
           "This target is intended for manually sharding tests to make CI faster."
 }
 
-// Runs all tests that depend on misk-hibernate
-// This target is intended for manually sharding tests to make CI faster.
 tasks.register("testShardHibernate") {
   group = "Continuous integration"
   description = "Runs all tests that depend on misk-hibernate. " +
@@ -80,8 +78,8 @@ subprojects {
   }
 
   if (["misk-aws","misk-events","misk-jobqueue","misk-hibernate","misk-hibernate-testing"].contains(name)) {
-    rootProject.getTasksByName("testShardHibernate", false)[0].dependsOn.add(test)
+    rootProject.getTasksByName("testShardHibernate", false).first().dependsOn.add(test)
   } else {
-    rootProject.getTasksByName("testShardNonHibernate", false)[0].dependsOn.add(test)
+    rootProject.getTasksByName("testShardNonHibernate", false).first().dependsOn.add(test)
   }
 }


### PR DESCRIPTION
Cuts CI time down from ~10min to ~7min https://circleci.com/workflow-run/5732206a-0754-4da1-9a07-cd7e2500de11

I have no idea what I'm doing here in gradle-land. The idea is to have a target that runs all tests for modules that use hibernate, and thus have to spin up mysql/vitess, and another target for all tests that don't, and have the 2 run in parallel.