### PR TITLE
Changed the way this module is initialized

### DIFF
--- a/misk-crypto/README.md
+++ b/misk-crypto/README.md
@@ -17,7 +17,7 @@ In one of your app's module files:
 ```$kotlin
 class MyAppModule : KAbstractModule {
   override fun configure() {
-    val kmsClient = AwsKmsClient().withDefaultCredentials()
+    install(AwsKmsClientModule()) // will provide an AWS client with default credentials
     install(CryptoModule(kmsClient, cryptoConfig))
   }
 }

--- a/misk-crypto/README.md
+++ b/misk-crypto/README.md
@@ -18,7 +18,7 @@ In one of your app's module files:
 class MyAppModule : KAbstractModule {
   override fun configure() {
     install(AwsKmsClientModule()) // will provide an AWS client with default credentials
-    install(CryptoModule(kmsClient, cryptoConfig))
+    install(CryptoModule(cryptoConfig))
   }
 }
 ```

--- a/misk-crypto/src/main/kotlin/misk/crypto/CryptoModule.kt
+++ b/misk-crypto/src/main/kotlin/misk/crypto/CryptoModule.kt
@@ -10,7 +10,6 @@ import com.google.inject.Provider
 import com.google.inject.name.Names
 import misk.config.Secret
 import misk.inject.KAbstractModule
-import misk.inject.asSingleton
 
 /**
  * Configures and registers the keys listed in the configuration file.
@@ -26,7 +25,6 @@ class CryptoModule(
     check(!(config.gcp_key_uri == null && config.aws_kms_key_alias == null))
     AeadConfig.register()
 
-    bind<KeyManager>().asSingleton()
     config.keys?.forEach { key ->
       val keyUri = config.gcp_key_uri ?: "aws-kms://alias/${config.aws_kms_key_alias}"
       bind<Cipher>()

--- a/misk-crypto/src/main/kotlin/misk/crypto/CryptoModule.kt
+++ b/misk-crypto/src/main/kotlin/misk/crypto/CryptoModule.kt
@@ -5,35 +5,50 @@ import com.google.crypto.tink.JsonKeysetReader
 import com.google.crypto.tink.KeysetHandle
 import com.google.crypto.tink.KmsClient
 import com.google.crypto.tink.aead.AeadConfig
+import com.google.inject.Inject
+import com.google.inject.Provider
 import com.google.inject.name.Names
 import misk.config.Secret
 import misk.inject.KAbstractModule
+import misk.inject.asSingleton
 
 /**
  * Configures and registers the keys listed in the configuration file.
  * Each key is read, decrypted, and then bound via Google Guice and added to the [KeyManager].
  */
 class CryptoModule(
-  private val config: CryptoConfig,
-  private val kmsClient: KmsClient
+  private val config: CryptoConfig
 ) : KAbstractModule() {
 
   override fun configure() {
+    requireBinding(KmsClient::class.java)
     check(!(config.gcp_key_uri != null && config.aws_kms_key_alias != null))
     check(!(config.gcp_key_uri == null && config.aws_kms_key_alias == null))
     AeadConfig.register()
-    val keyManager = KeyManager()
-    bind<KeyManager>().toInstance(keyManager)
+
+    bind<KeyManager>().asSingleton()
     config.keys?.forEach { key ->
       val keyUri = config.gcp_key_uri ?: "aws-kms://alias/${config.aws_kms_key_alias}"
-      val cipher = key.encrypted_key.let { readKey(it, kmsClient.getAead(keyUri)) }
-      keyManager[key.key_name] = cipher
-      bind<Cipher>().annotatedWith(Names.named(key.key_name)).toInstance(cipher)
+      bind<Cipher>()
+          .annotatedWith(Names.named(key.key_name))
+          .toProvider(CipherProvider(keyUri, key))
+          .asEagerSingleton()
     }
   }
 
-  private fun readKey(keyConfig: Secret<String>, masterKey: Aead): Cipher {
-    val keysetHandle = KeysetHandle.read(JsonKeysetReader.withString(keyConfig.value), masterKey)
-    return RealCipher(keysetHandle, masterKey)
+  private class CipherProvider(val keyUri: String, val key: Key) : Provider<Cipher> {
+    @Inject lateinit var keyManager: KeyManager
+    @Inject lateinit var kmsClient: KmsClient
+
+    override fun get(): Cipher {
+      val cipher = readKey(key.encrypted_key, kmsClient.getAead(keyUri))
+      keyManager[key.key_name] = cipher
+      return cipher
+    }
+
+    private fun readKey(keyConfig: Secret<String>, masterKey: Aead): Cipher {
+      val keysetHandle = KeysetHandle.read(JsonKeysetReader.withString(keyConfig.value), masterKey)
+      return RealCipher(keysetHandle, masterKey)
+    }
   }
 }

--- a/misk-crypto/src/main/kotlin/misk/crypto/CryptoTestModule.kt
+++ b/misk-crypto/src/main/kotlin/misk/crypto/CryptoTestModule.kt
@@ -5,6 +5,7 @@ import com.google.crypto.tink.aead.AeadConfig
 import com.google.crypto.tink.aead.AeadKeyTemplates
 import com.google.inject.name.Names
 import misk.inject.KAbstractModule
+import misk.inject.asSingleton
 
 /**
  * This module should be used for testing purposes only.
@@ -21,13 +22,11 @@ class CryptoTestModule(
 
   override fun configure() {
     AeadConfig.register()
-    val keyManager = KeyManager()
-    bind<KeyManager>().toInstance(keyManager)
+    bind<KeyManager>().asSingleton()
     val masterKey = FakeKmsClient().getAead(config.gcp_key_uri ?: config.aws_kms_key_alias)
     config.keys?.forEach { key ->
       val keysetHandle = KeysetHandle.generateNew(AeadKeyTemplates.AES256_GCM)
       val cipher = RealCipher(keysetHandle, masterKey)
-      keyManager[key.key_name] = cipher
       bind<Cipher>().annotatedWith(Names.named(key.key_name)).toInstance(cipher)
     }
   }

--- a/misk-crypto/src/main/kotlin/misk/crypto/KeyManager.kt
+++ b/misk-crypto/src/main/kotlin/misk/crypto/KeyManager.kt
@@ -5,7 +5,6 @@ import javax.inject.Singleton
 
 /**
  * Singleton class used as a map of key name to its corresponding [Cipher] implementation.
- * It's being populated by the [CryptoModule] class when loaded.
  */
 @Singleton
 class KeyManager @Inject constructor() {

--- a/misk-crypto/src/main/kotlin/misk/crypto/KmsClientModule.kt
+++ b/misk-crypto/src/main/kotlin/misk/crypto/KmsClientModule.kt
@@ -1,0 +1,34 @@
+package misk.crypto
+
+import com.google.crypto.tink.KmsClient
+import com.google.crypto.tink.integration.awskms.AwsKmsClient
+import com.google.crypto.tink.integration.gcpkms.GcpKmsClient
+import com.google.inject.Provides
+import com.google.inject.Singleton
+import misk.inject.KAbstractModule
+
+/**
+ * AWS specific KMS client module.
+ * Currently uses a file path to a JSON credentials file to initialize the client.
+ * If no file is provided, tries to initialize the client using the default
+ * credentials path as specified in [AwsKmsClient.withDefaultCredentials]
+ */
+class AwsKmsClientModule(private val credentialsPath: String? = null) : KAbstractModule() {
+  // TODO: Allow initializing an AWS KMS client with a credentials provider
+  // once tink supports it: https://github.com/google/tink/pull/184
+  @Provides @Singleton
+  fun getKmsClient(): KmsClient = credentialsPath?.let { AwsKmsClient().withCredentials(it) } ?:
+      AwsKmsClient().withDefaultCredentials()
+}
+
+/**
+ * GCP specific KMS client module.
+ * Uses a file path to a JSON credentials file to initialize the client.
+ * * If no file is provided, tries to initialize the client using the default
+ * credentials path as specified in [GcpKmsClient.withDefaultCredentials]
+ */
+class GcpKmsClientModule(private val credentialsPath: String? = null) : KAbstractModule() {
+  @Provides @Singleton
+  fun getKmsClient(): KmsClient = credentialsPath?.let { GcpKmsClient().withCredentials(it) } ?:
+      GcpKmsClient().withDefaultCredentials()
+}

--- a/misk-crypto/src/test/kotlin/misk/crypto/CryptoTestModule.kt
+++ b/misk-crypto/src/test/kotlin/misk/crypto/CryptoTestModule.kt
@@ -1,0 +1,21 @@
+package misk.crypto
+
+import com.google.crypto.tink.KmsClient
+import com.google.inject.Provides
+import com.google.inject.Singleton
+import misk.inject.KAbstractModule
+
+/**
+ * Test module that binds [FakeKmsClient] to be used as the [KmsClient]
+ */
+class CryptoTestModule : KAbstractModule() {
+
+  override fun configure() {
+    install(object : KAbstractModule() {
+      @Provides @Singleton
+      fun getKmsClient(): KmsClient {
+        return FakeKmsClient()
+      }
+    })
+  }
+}


### PR DESCRIPTION
The KMS client is now initialized by its own module.
This allows `CryptoModule` to be completely independent of the KMS.

Users may choose to create their own KMS client implementation or use
one of the provided modules for AWS and GCP.