### PR TITLE
Wrap SQS exceptions info identifying the queue

### DIFF
--- a/misk-aws/src/main/kotlin/misk/jobqueue/sqs/ResolvedQueue.kt
+++ b/misk-aws/src/main/kotlin/misk/jobqueue/sqs/ResolvedQueue.kt
@@ -1,7 +1,9 @@
 package misk.jobqueue.sqs
 
+import com.amazonaws.AmazonClientException
 import com.amazonaws.services.sqs.AmazonSQS
 import misk.cloud.aws.AwsAccountId
+import misk.cloud.aws.AwsRegion
 import misk.jobqueue.QueueName
 
 /** [ResolvedQueue] provides information needed to reach an SQS queue */
@@ -9,6 +11,28 @@ internal class ResolvedQueue(
   val name: QueueName,
   val sqsQueueName: QueueName,
   val url: String,
+  val region: AwsRegion,
   val accountId: AwsAccountId,
   val client: AmazonSQS
-)
+) {
+
+  /**
+   * Invokes the lambda with this queue's [AmazonSQS] client. Exceptions thrown by the client
+   * are wrapped in a [SQSException].
+   */
+  fun <T> call(lambda: (AmazonSQS) -> T): T {
+    try {
+      return lambda.invoke(client)
+    } catch (e: AmazonClientException) {
+      throw SQSException(e, this)
+    }
+  }
+
+  /** Wraps AWS client errors, adding queue metadata to the exception message */
+  class SQSException(
+    cause: AmazonClientException,
+    queue: ResolvedQueue
+  ) : RuntimeException(
+      "${cause.message} (sqsQueue=${queue.sqsQueueName} region=${queue.region})",
+      cause)
+}


### PR DESCRIPTION
Exceptions thrown by the SQS SDK don't indicate the related queue, which makes debugging more difficult. This wraps calls to the SQS library so that exceptions include queue metadata.