### PR TITLE
Allow passing a ResourceLoader when loading a Config

### DIFF
--- a/misk/src/main/kotlin/misk/config/ConfigMetadataAction.kt
+++ b/misk/src/main/kotlin/misk/config/ConfigMetadataAction.kt
@@ -2,6 +2,7 @@ package misk.config
 
 import com.google.inject.Inject
 import misk.environment.Environment
+import misk.resources.ResourceLoader
 import misk.web.Get
 import misk.web.RequestContentType
 import misk.web.ResponseContentType
@@ -49,7 +50,7 @@ class ConfigMetadataAction @Inject constructor(
       config: Config
     ): Map<String, String?> {
       val rawYamlFiles = MiskConfig.loadConfigYamlMap(appName, environment, listOf())
-      val yamlFiles = linkedMapOf<String, String?>("Effective Config" to MiskConfig.toYaml(config))
+      val yamlFiles = linkedMapOf<String, String?>("Effective Config" to MiskConfig.toYaml(config, ResourceLoader.SYSTEM))
       rawYamlFiles.map { yamlFiles.put("classpath:/${it.key}", it.value) }
       return yamlFiles
     }

--- a/misk/src/main/kotlin/misk/resources/FakeFilesModule.kt
+++ b/misk/src/main/kotlin/misk/resources/FakeFilesModule.kt
@@ -1,0 +1,16 @@
+package misk.resources
+
+import misk.inject.KAbstractModule
+
+/**
+ * Adds the provided fake files to the map used by [FilesystemLoaderBackend].
+ */
+class FakeFilesModule(private val fakeFiles : Map<String, String>) : KAbstractModule() {
+  override fun configure() {
+    fakeFiles.forEach {
+        newMapBinder<String, String>(ForFakeFiles::class)
+            .addBinding(it.key)
+            .toInstance(it.value)
+    }
+  }
+}

--- a/misk/src/test/kotlin/misk/config/MiskConfigTest.kt
+++ b/misk/src/test/kotlin/misk/config/MiskConfigTest.kt
@@ -3,11 +3,13 @@ package misk.config
 import com.google.inject.util.Modules
 import misk.environment.Environment
 import misk.environment.EnvironmentModule
+import misk.resources.ResourceLoader
 import misk.testing.MiskTest
 import misk.testing.MiskTestModule
 import misk.web.WebConfig
 import misk.web.exceptions.ActionExceptionLogLevelConfig
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.slf4j.event.Level
 import java.io.File
@@ -54,7 +56,7 @@ class MiskConfigTest {
   @Test
   fun friendlyErrorMessagesWhenFilesNotFound() {
     val exception = assertFailsWith<IllegalStateException> {
-      MiskConfig.load<TestConfig>(TestConfig::class.java, "missing", defaultEnv)
+      MiskConfig.load<TestConfig>("missing", defaultEnv)
     }
 
     assertThat(exception).hasMessageContaining("could not find configuration files -" +
@@ -64,7 +66,7 @@ class MiskConfigTest {
   @Test
   fun friendlyErrorMessageWhenConfigPropertyMissing() {
     val exception = assertFailsWith<IllegalStateException> {
-      MiskConfig.load<TestConfig>(TestConfig::class.java, "partial_test_app", defaultEnv)
+      MiskConfig.load<TestConfig>("partial_test_app", defaultEnv)
     }
 
     assertThat(exception).hasMessageContaining(
@@ -74,7 +76,7 @@ class MiskConfigTest {
   @Test
   fun friendlyErrorMessagesWhenFileUnparseable() {
     val exception = assertFailsWith<IllegalStateException> {
-      MiskConfig.load<TestConfig>(TestConfig::class.java, "unparsable", defaultEnv)
+      MiskConfig.load<TestConfig>("unparsable", defaultEnv)
     }
 
     assertThat(exception).hasMessageContaining("could not parse unparsable-common.yaml")
@@ -83,7 +85,7 @@ class MiskConfigTest {
   @Test
   fun friendlyErrorMessagesWhenPropertiesNotFound() {
     val exception = assertFailsWith<IllegalStateException> {
-      MiskConfig.load<TestConfig>(TestConfig::class.java, "unknownproperty", defaultEnv)
+      MiskConfig.load<TestConfig>("unknownproperty", defaultEnv)
     }
 
     assertThat(exception).hasMessageContaining("'consumer_b.blue_items' not found")
@@ -92,7 +94,7 @@ class MiskConfigTest {
   @Test
   fun friendlyErrorMessagesWhenPropertiesMisspelled() {
     val exception = assertFailsWith<IllegalStateException> {
-      MiskConfig.load<TestConfig>(TestConfig::class.java, "misspelledproperty", defaultEnv)
+      MiskConfig.load<TestConfig>("misspelledproperty", defaultEnv)
     }
 
     assertThat(exception).hasMessageContaining("Did you mean")

--- a/misk/src/test/resources/secret_config_app-common.yaml
+++ b/misk/src/test/resources/secret_config_app-common.yaml
@@ -1,5 +1,5 @@
 string_value: "this is not a secret"
-secret_information: "classpath:/misk/resources/secrets/secret_information_values.yaml"
+secret_information: "filesystem:/misk/resources/secrets/secret_information_values.yaml"
 secrets_list: "classpath:/misk/resources/secrets/secret_information_list_values.yaml"
 secrets_list_map: "classpath:/misk/resources/secrets/secret_information_list_values.yaml"
 nested_secret:  "classpath:/misk/resources/secrets/secret_information_nested_values.yaml"

--- a/samples/exemplar/src/main/java/com/squareup/exemplar/ExemplarJavaApp.java
+++ b/samples/exemplar/src/main/java/com/squareup/exemplar/ExemplarJavaApp.java
@@ -7,13 +7,14 @@ import misk.config.ConfigModule;
 import misk.config.MiskConfig;
 import misk.environment.Environment;
 import misk.environment.EnvironmentModule;
+import misk.resources.ResourceLoader;
 import misk.web.MiskWebModule;
 
 public class ExemplarJavaApp {
   public static void main(String[] args) {
     Environment environment = Environment.fromEnvironmentVariable();
     ExemplarJavaConfig config = MiskConfig.load(ExemplarJavaConfig.class, "exemplar",
-        environment, ImmutableList.of());
+        environment, ImmutableList.of(), ResourceLoader.Companion.getSYSTEM());
 
     new MiskApplication(
         new MiskRealServiceModule(),


### PR DESCRIPTION
This allows apps to use a ResourceLoader with fake files in tests, so
they can read Secrets that are not on the local filesystem.