### PR TITLE
Changed crypto configuration

### DIFF
--- a/misk-crypto/README.md
+++ b/misk-crypto/README.md
@@ -34,6 +34,7 @@ tinkey create-keyset --key-template AES256-GCM --master-key-uri aws-kms://arn:km
 Then, to specify a new `Cipher` key called "myKey", add the following in your app's configuration file:
 ```$yaml
 crypto:
+  kms_uri: "aws-kms://arn:kms:<region>:<account-id>:key/<key-id>"
   keys:
     - key_name: "my_payment_token_key"
       encrypted_kek: [key encrypted using the same KMS used by the app encoded in base64] 

--- a/misk-crypto/src/main/kotlin/misk/crypto/CryptoConfig.kt
+++ b/misk-crypto/src/main/kotlin/misk/crypto/CryptoConfig.kt
@@ -8,8 +8,7 @@ import misk.config.Secret
  */
 data class CryptoConfig(
   val keys: List<Key>?,
-  val aws_kms_key_alias: String? = null,
-  val gcp_key_uri: String? = null
+  val kms_uri: String
 ) : Config
 
 data class Key(

--- a/misk-crypto/src/main/kotlin/misk/crypto/CryptoModule.kt
+++ b/misk-crypto/src/main/kotlin/misk/crypto/CryptoModule.kt
@@ -21,15 +21,12 @@ class CryptoModule(
 
   override fun configure() {
     requireBinding(KmsClient::class.java)
-    check(!(config.gcp_key_uri != null && config.aws_kms_key_alias != null))
-    check(!(config.gcp_key_uri == null && config.aws_kms_key_alias == null))
     AeadConfig.register()
 
     config.keys?.forEach { key ->
-      val keyUri = config.gcp_key_uri ?: "aws-kms://alias/${config.aws_kms_key_alias}"
       bind<Cipher>()
           .annotatedWith(Names.named(key.key_name))
-          .toProvider(CipherProvider(keyUri, key))
+          .toProvider(CipherProvider(config.kms_uri, key))
           .asEagerSingleton()
     }
   }

--- a/misk-crypto/src/main/kotlin/misk/crypto/CryptoTestModule.kt
+++ b/misk-crypto/src/main/kotlin/misk/crypto/CryptoTestModule.kt
@@ -19,17 +19,17 @@ import javax.inject.Provider
  * Instead, it'll generate a random keyset handle for each named key.
  */
 class CryptoTestModule(
-  private val config: CryptoConfig
+  private val keyNames: List<String>
 ) : KAbstractModule() {
 
   override fun configure() {
     AeadConfig.register()
 
     val masterKey = FakeKmsClient().getAead(null)
-    config.keys?.forEach { key ->
+    keyNames.forEach { key ->
       bind<Cipher>()
-          .annotatedWith(Names.named(key.key_name))
-          .toProvider(CipherProvider(key.key_name, masterKey))
+          .annotatedWith(Names.named(key))
+          .toProvider(CipherProvider(key, masterKey))
           .asEagerSingleton()
     }
   }

--- a/misk-crypto/src/test/kotlin/misk/crypto/CryptoModuleTest.kt
+++ b/misk-crypto/src/test/kotlin/misk/crypto/CryptoModuleTest.kt
@@ -35,20 +35,6 @@ class CryptoModuleTest {
     assertThat(cipher).isNotNull()
   }
 
-  @Test
-  fun testInvalidConfig() {
-    val config = CryptoConfig(listOf(), "AWS master key alias", "GCP master key URI")
-    assertThatThrownBy { Guice.createInjector(CryptoTestModule(), CryptoModule(config)) }
-        .isInstanceOf(CreationException::class.java)
-  }
-
-  @Test
-  fun testMissingMasterKey() {
-    val config = CryptoConfig(listOf())
-    assertThatThrownBy { Guice.createInjector(CryptoTestModule(), CryptoModule(config)) }
-        .isInstanceOf(CreationException::class.java)
-  }
-
   private fun generateEncryptedKey(keyHandle: KeysetHandle): Secret<String> {
     val masterKey = FakeMasterEncryptionKey()
     val keyOutputStream = ByteArrayOutputStream()


### PR DESCRIPTION
Now there's only one place to specify the KMS URI.
This makes the module environment agnostic.

Users now must specify the full KMS URI to use with their encrypted keys.