### PR TITLE
Removed eager initialization

### DIFF
--- a/misk-crypto/src/main/kotlin/misk/crypto/CryptoModule.kt
+++ b/misk-crypto/src/main/kotlin/misk/crypto/CryptoModule.kt
@@ -27,7 +27,6 @@ class CryptoModule(
       bind<Cipher>()
           .annotatedWith(Names.named(key.key_name))
           .toProvider(CipherProvider(config.kms_uri, key))
-          .asEagerSingleton()
     }
   }
 


### PR DESCRIPTION
When running in STAGING or PRODUCTION environemnts, this object needs to
communicate with a live KMS, which makes it very difficult to test -
specifically the InjectorTest which loads each env's complete
configuration and makes sure Guice can initialize it.
Removing the `.asEagerSingleton()` part means that when the `Cipher`
object is constructed it won't need the `KmsClient` until first use.

There are other ways to exercise all the relevant code paths in `Cipher`
for testing without using a real KMS.