### PR TITLE
Log the root cause of startup failures up front

### DIFF
--- a/misk-testing/src/main/kotlin/misk/testing/MiskTestExtension.kt
+++ b/misk-testing/src/main/kotlin/misk/testing/MiskTestExtension.kt
@@ -78,7 +78,13 @@ internal class MiskTestExtension : BeforeEachCallback, AfterEachCallback {
 
     override fun beforeEach(context: ExtensionContext) {
       if (context.startService()) {
-        serviceManager.startAsync().awaitHealthy(60, TimeUnit.SECONDS)
+        try {
+          serviceManager.startAsync().awaitHealthy(60, TimeUnit.SECONDS)
+        } catch (e: IllegalStateException) {
+          // Unearth the root cause so we can see it in logs easily.
+          log.error("Startup failure -- ${e.cause!!.message}")
+          throw e
+        }
       }
     }
   }


### PR DESCRIPTION
otherwise it's buried under a mountain of:

```java
java.lang.IllegalStateException: Expected to be healthy after starting. The following services are not running: {FAILED=[SchemaValidatorService [FAILED]]}

	at com.google.common.util.concurrent.ServiceManager$ServiceManagerState.checkHealthy(ServiceManager.java:741)
	at com.google.common.util.concurrent.ServiceManager$ServiceManagerState.awaitHealthy(ServiceManager.java:568)
	at com.google.common.util.concurrent.ServiceManager.awaitHealthy(ServiceManager.java:329)
```