### PR TITLE
Allow specifying number of retries in Transacter

### DIFF
--- a/misk-hibernate/src/main/kotlin/misk/hibernate/RealTransacter.kt
+++ b/misk-hibernate/src/main/kotlin/misk/hibernate/RealTransacter.kt
@@ -135,7 +135,7 @@ internal class RealTransacter private constructor(
     }
   }
 
-  override fun retries(): Transacter = withOptions(options.copy(maxAttempts = 2))
+  override fun retries(maxAttempts: Int): Transacter = withOptions(options.copy(maxAttempts = maxAttempts))
 
   override fun noRetries(): Transacter = withOptions(options.copy(maxAttempts = 1))
 

--- a/misk-hibernate/src/main/kotlin/misk/hibernate/Transacter.kt
+++ b/misk-hibernate/src/main/kotlin/misk/hibernate/Transacter.kt
@@ -20,7 +20,7 @@ interface Transacter {
    */
   fun <T> transaction(lambda: (session: Session) -> T): T
 
-  fun retries(): Transacter
+  fun retries(maxAttempts: Int): Transacter
 
   fun noRetries(): Transacter
 

--- a/misk-hibernate/src/main/kotlin/misk/hibernate/Transacter.kt
+++ b/misk-hibernate/src/main/kotlin/misk/hibernate/Transacter.kt
@@ -20,7 +20,7 @@ interface Transacter {
    */
   fun <T> transaction(lambda: (session: Session) -> T): T
 
-  fun retries(maxAttempts: Int): Transacter
+  fun retries(maxAttempts: Int = 2): Transacter
 
   fun noRetries(): Transacter
 


### PR DESCRIPTION
Quick change to allow us to specify the number of retries in `Transacter`.