### PR TITLE
Add Session.loadOrNull

### DIFF
--- a/misk-hibernate/src/main/kotlin/misk/hibernate/RealTransacter.kt
+++ b/misk-hibernate/src/main/kotlin/misk/hibernate/RealTransacter.kt
@@ -247,6 +247,10 @@ internal class RealTransacter private constructor(
       return session.get(type.java, gid)
     }
 
+    override fun <T : DbEntity<T>> loadOrNull(id: Id<T>, type: KClass<T>): T? {
+      return session.get(type.java, id)
+    }
+
     override fun shards(): Set<Shard> {
       return if (config.type == DataSourceType.VITESS) {
         useConnection { connection ->

--- a/misk-hibernate/src/main/kotlin/misk/hibernate/Session.kt
+++ b/misk-hibernate/src/main/kotlin/misk/hibernate/Session.kt
@@ -11,6 +11,7 @@ interface Session {
   fun <T : DbEntity<T>> save(entity: T): Id<T>
 
   fun <T : DbEntity<T>> load(id: Id<T>, type: KClass<T>): T
+  fun <T : DbEntity<T>> loadOrNull(id: Id<T>, type: KClass<T>): T?
   fun <R : DbRoot<R>, T : DbSharded<R, T>> loadSharded(gid: Gid<R, T>, type: KClass<T>): T
   fun shards(): Set<Shard>
   fun <T> target(shard: Shard, function: () -> T): T
@@ -41,6 +42,7 @@ interface Session {
 
 inline fun <reified T : DbEntity<T>> Session.load(id: Id<T>): T = load(id, T::class)
 inline fun <R : DbRoot<R>, reified S : DbSharded<R, S>> Session.loadSharded(gid: Gid<R, S>): S = loadSharded(gid, S::class)
+inline fun <reified T : DbEntity<T>> Session.loadOrNull(id: Id<T>): T? = loadOrNull(id, T::class)
 
 fun checkValidShardIdentifier(identifier: String) {
   check(!identifier.isBlank())

--- a/misk-hibernate/src/test/kotlin/misk/hibernate/TransacterTest.kt
+++ b/misk-hibernate/src/test/kotlin/misk/hibernate/TransacterTest.kt
@@ -77,6 +77,21 @@ class TransacterTest {
   }
 
   @Test
+  fun loadOrNullReturnsEntity() {
+    transacter.transaction { session ->
+      val ld = session.save(DbActor("Laura Dern", LocalDate.of(1967, 2, 10)))
+      assertThat(session.loadOrNull(ld)).isNotNull()
+    }
+  }
+
+  @Test
+  fun loadOrNullMissingEntityReturnsNull() {
+    transacter.transaction { session ->
+      assertThat(session.loadOrNull(Id<DbActor>(123))).isNull()
+    }
+  }
+
+  @Test
   fun exceptionCausesTransactionToRollback() {
     assertFailsWith<UnauthorizedException> {
       transacter.transaction { session ->


### PR DESCRIPTION
Motivation: I need to load by id, but handle missing entities. The id comes from user input.

`session.load()` can already return null from java code, but it's not marked `T?` in kotlin. Thanks kotlin.

Ideally we'd make `load()` return `T?` but that would break a lot of code.