### PR TITLE
Added support for digital signatures

### DIFF
--- a/misk-crypto/src/main/kotlin/misk/crypto/CryptoConfig.kt
+++ b/misk-crypto/src/main/kotlin/misk/crypto/CryptoConfig.kt
@@ -45,5 +45,6 @@ data class Key(
  */
 enum class KeyType {
   AEAD,
-  MAC
+  MAC,
+  DIGITAL_SIGNATURE
 }

--- a/misk-crypto/src/main/kotlin/misk/crypto/CryptoModule.kt
+++ b/misk-crypto/src/main/kotlin/misk/crypto/CryptoModule.kt
@@ -5,15 +5,21 @@ import com.google.crypto.tink.JsonKeysetReader
 import com.google.crypto.tink.KeysetHandle
 import com.google.crypto.tink.KmsClient
 import com.google.crypto.tink.Mac
+import com.google.crypto.tink.PublicKeySign
+import com.google.crypto.tink.PublicKeyVerify
 import com.google.crypto.tink.aead.AeadConfig
 import com.google.crypto.tink.aead.AeadFactory
 import com.google.crypto.tink.mac.MacConfig
 import com.google.crypto.tink.mac.MacFactory
+import com.google.crypto.tink.signature.PublicKeySignFactory
+import com.google.crypto.tink.signature.PublicKeyVerifyFactory
+import com.google.crypto.tink.signature.SignatureConfig
 import com.google.inject.Inject
 import com.google.inject.Provider
 import com.google.inject.Singleton
 import com.google.inject.name.Names
 import misk.config.Secret
+import misk.crypto.DigitalSignatureKeyManager.DigitalSignature
 import misk.inject.KAbstractModule
 import okio.ByteString
 import okio.ByteString.Companion.toByteString
@@ -32,8 +38,10 @@ class CryptoModule(
     requireBinding(KmsClient::class.java)
     AeadConfig.register()
     MacConfig.register()
+    SignatureConfig.register()
 
-    val duplicateNames = config.keys - config.keys.map { it.key_name }.distinct().iterator()
+    val keyNames = config.keys.map { it.key_name }
+    val duplicateNames = keyNames - config.keys.map { it.key_name }.distinct().toList()
     check(duplicateNames.isEmpty()) {
       "Found duplicate keys: [$duplicateNames]"
     }
@@ -49,6 +57,16 @@ class CryptoModule(
           bind<Mac>()
               .annotatedWith(Names.named(key.key_name))
               .toProvider(MacProvider(config.kms_uri, key))
+              .`in`(Singleton::class.java)
+        }
+        KeyType.DIGITAL_SIGNATURE -> {
+          bind<PublicKeySign>()
+              .annotatedWith(Names.named(key.key_name))
+              .toProvider(DigitalSignatureSignerProvider(config.kms_uri, key))
+              .`in`(Singleton::class.java)
+          bind<PublicKeyVerify>()
+              .annotatedWith(Names.named(key.key_name))
+              .toProvider(DigitalSignatureVerifierProvider(config.kms_uri, key))
               .`in`(Singleton::class.java)
         }
       }
@@ -75,6 +93,34 @@ class CryptoModule(
       val keysetHandle = readKey(key.encrypted_key, kmsClient.getAead(keyUri))
       return MacFactory.getPrimitive(keysetHandle)
           .also { keyManager[key.key_name] = it }
+    }
+  }
+
+  private class DigitalSignatureSignerProvider(val keyUri: String, val key: Key
+  ) : Provider<PublicKeySign> {
+    @Inject lateinit var keyManager: DigitalSignatureKeyManager
+    @Inject lateinit var kmsClient: KmsClient
+
+    override fun get(): PublicKeySign {
+      val keysetHandle = readKey(key.encrypted_key, kmsClient.getAead(keyUri))
+      val signer = PublicKeySignFactory.getPrimitive(keysetHandle)
+      val verifier = PublicKeyVerifyFactory.getPrimitive(keysetHandle.publicKeysetHandle)
+      keyManager[key.key_name] = DigitalSignature(signer, verifier)
+      return signer
+    }
+  }
+
+  private class DigitalSignatureVerifierProvider(val keyUri: String, val key: Key
+  ) : Provider<PublicKeyVerify> {
+    @Inject lateinit var keyManager: DigitalSignatureKeyManager
+    @Inject lateinit var kmsClient: KmsClient
+
+    override fun get(): PublicKeyVerify {
+      val keysetHandle = readKey(key.encrypted_key, kmsClient.getAead(keyUri))
+      val signer = PublicKeySignFactory.getPrimitive(keysetHandle)
+      val verifier = PublicKeyVerifyFactory.getPrimitive(keysetHandle.publicKeysetHandle)
+      keyManager[key.key_name] = DigitalSignature(signer, verifier)
+      return verifier
     }
   }
 

--- a/misk-crypto/src/main/kotlin/misk/crypto/CryptoModule.kt
+++ b/misk-crypto/src/main/kotlin/misk/crypto/CryptoModule.kt
@@ -19,7 +19,6 @@ import com.google.inject.Provider
 import com.google.inject.Singleton
 import com.google.inject.name.Names
 import misk.config.Secret
-import misk.crypto.DigitalSignatureKeyManager.DigitalSignature
 import misk.inject.KAbstractModule
 import okio.ByteString
 import okio.ByteString.Companion.toByteString

--- a/misk-crypto/src/main/kotlin/misk/crypto/KeyManager.kt
+++ b/misk-crypto/src/main/kotlin/misk/crypto/KeyManager.kt
@@ -119,6 +119,7 @@ class DigitalSignatureKeyManager @Inject internal constructor(
     }
     return verifier
   }
-  data class DigitalSignature(val signer: PublicKeySign, val verifier: PublicKeyVerify)
 }
+
+internal data class DigitalSignature(val signer: PublicKeySign, val verifier: PublicKeyVerify)
 

--- a/misk-crypto/src/main/kotlin/misk/crypto/KeyManager.kt
+++ b/misk-crypto/src/main/kotlin/misk/crypto/KeyManager.kt
@@ -2,6 +2,8 @@ package misk.crypto
 
 import com.google.crypto.tink.Aead
 import com.google.crypto.tink.Mac
+import com.google.crypto.tink.PublicKeySign
+import com.google.crypto.tink.PublicKeyVerify
 import com.google.inject.ConfigurationException
 import com.google.inject.Inject
 import com.google.inject.Injector
@@ -41,7 +43,7 @@ class AeadKeyManager @Inject internal constructor(
 
 /**
  * Holds a map of every [Mac] key name to its primitive listed in the configuration for this app.
- * Users may use htis objecy to obtain a [Mac] object dynamically:
+ * Users may use this class to obtain a [Mac] object dynamically:
  * ```
  * val hmac: Mac? = macKeyManager["myHmac"]
  * ```
@@ -68,3 +70,55 @@ class MacKeyManager @Inject internal constructor(
     return mac
   }
 }
+
+/**
+ * Holds a map of every key name to its corresponding [PublicKeySign] and [PublicKeyVerify] primitives.
+ * Users may use this class to obtain a [PublicKeySign] to sign data
+ * or [PublicKeyVerify] to verify the integrity of a message dynamically:
+ * ```
+ * val signer: PublicKeySign? = keyManager.getSigner("myDigitalSignatureKey")
+ * val verifier: PublicKeyVerify? = keyManager.getVerifier("mySigitalSignatureKey")
+ * val signature = signer.sign(data)
+ * verifier.verify(signature, data)
+ * ```
+ */
+@Singleton
+class DigitalSignatureKeyManager @Inject internal constructor(
+  private val injector: Injector
+) {
+  private val signers: HashMap<String, DigitalSignature> = LinkedHashMap()
+
+  internal operator fun set(name: String, signerAndVerifier: DigitalSignature) {
+    if (!signers.containsKey(name)) {
+      signers[name] = signerAndVerifier
+    }
+  }
+
+  fun getSigner(name: String): PublicKeySign? {
+    var signer = signers[name]?.signer
+    if (signer == null) {
+      try {
+        signer = injector.getInstance(Key.get(PublicKeySign::class.java, Names.named(name)))
+        val verifier = injector.getInstance(Key.get(PublicKeyVerify::class.java, Names.named(name)))
+        this[name] = DigitalSignature(signer, verifier)
+      } catch (e: ConfigurationException) {
+      }
+    }
+    return signer
+  }
+
+  fun getVerifier(name: String): PublicKeyVerify? {
+    var verifier = signers[name]?.verifier
+    if (verifier == null) {
+      try {
+        verifier = injector.getInstance(Key.get(PublicKeyVerify::class.java, Names.named(name)))
+        val signer = injector.getInstance(Key.get(PublicKeySign::class.java, Names.named(name)))
+        this[name] = DigitalSignature(signer, verifier)
+      } catch (e: ConfigurationException) {
+      }
+    }
+    return verifier
+  }
+  data class DigitalSignature(val signer: PublicKeySign, val verifier: PublicKeyVerify)
+}
+


### PR DESCRIPTION
`misk.crypto` now also has support for providing Tink primitives for signing and verifying signed data.
