### PR TITLE
Use FixedThreadPool instead of CashedThreadPool in ExecutorServiceModule

### DIFF
--- a/misk-aws/src/main/kotlin/misk/jobqueue/sqs/AwsSqsJobQueueModule.kt
+++ b/misk-aws/src/main/kotlin/misk/jobqueue/sqs/AwsSqsJobQueueModule.kt
@@ -31,7 +31,7 @@ class AwsSqsJobQueueModule(
     bind<TransactionalJobQueue>().to<SqsTransactionalJobQueue>()
     multibind<Service>().to<SqsJobConsumer>()
 
-    install(ExecutorServiceModule.withCachedThreadPool(ForSqsConsumer::class, "sqs-consumer-%d"))
+    install(ExecutorServiceModule.withFixedThreadPool(ForSqsConsumer::class, "sqs-consumer-%d", 4))
 
     // Bind a map of AmazonSQS clients for each external region that we need to contact
     val regionSpecificClientBinder = newMapBinder<AwsRegion, AmazonSQS>()

--- a/misk/src/main/kotlin/misk/concurrent/ExecutorServiceModule.kt
+++ b/misk/src/main/kotlin/misk/concurrent/ExecutorServiceModule.kt
@@ -15,12 +15,16 @@ class ExecutorServiceModule(
   }
 
   companion object {
-    fun withCachedThreadPool(
+    fun withFixedThreadPool(
       annotation: KClass<out Annotation>,
-      nameFormat: String
+      nameFormat: String,
+      nThreads: Int
     ): ExecutorServiceModule {
-      val threadFactory = ThreadFactoryBuilder().setNameFormat(nameFormat).build()
-      return ExecutorServiceModule(annotation, Executors.newCachedThreadPool(threadFactory))
+      return ExecutorServiceModule(
+          annotation,
+          Executors.newFixedThreadPool(
+              nThreads,
+              ThreadFactoryBuilder().setNameFormat(nameFormat).build()))
     }
   }
 }


### PR DESCRIPTION
- Since it's not really good to use CashedThreadPool, we use FixedThreadPool.[1]
- Also, we add a new line at the EOF.

[1] feedback: https://github.com/square/misk/pull/964#discussion_r280903015

issue #284 