### PR TITLE
Made the test/development configuration hardcoded

### DIFF
--- a/misk-crypto/src/main/kotlin/misk/crypto/CryptoConfig.kt
+++ b/misk-crypto/src/main/kotlin/misk/crypto/CryptoConfig.kt
@@ -15,7 +15,7 @@ data class CryptoConfig(
    * For AWS users that the Key URI looks like:
    * aws-kms://arn:aws:kms:<region>:<account-id>:key/<key-id>
    */
-  val kms_uri: String
+  val kms_uri: String?
 ) : Config
 
 /**
@@ -37,7 +37,7 @@ data class Key(
   /**
    * Path to a file containing the encrypted key material in Tink's JSON format.
    */
-  val encrypted_key: Secret<String>
+  val encrypted_key: Secret<String>?
 ) : Config
 
 /**

--- a/misk-crypto/src/main/kotlin/misk/crypto/CryptoConfig.kt
+++ b/misk-crypto/src/main/kotlin/misk/crypto/CryptoConfig.kt
@@ -14,6 +14,8 @@ data class CryptoConfig(
    * gcp-kms://projects/<project>/locations/<location>/keyRings/<keyRing>/cryptoKeys/<key>
    * For AWS users that the Key URI looks like:
    * aws-kms://arn:aws:kms:<region>:<account-id>:key/<key-id>
+   *
+   * When using [CryptoTestModule] this value can be omitted, it'll be replaces by a [FakeKmsClient]
    */
   val kms_uri: String?
 ) : Config
@@ -36,6 +38,8 @@ data class Key(
   val key_type: KeyType,
   /**
    * Path to a file containing the encrypted key material in Tink's JSON format.
+   *
+   * When using [CryptoTestModule] this value can be omitted, it'll be replaced by a hardcoded keyset.
    */
   val encrypted_key: Secret<String>?
 ) : Config

--- a/misk-crypto/src/main/kotlin/misk/crypto/CryptoTestModule.kt
+++ b/misk-crypto/src/main/kotlin/misk/crypto/CryptoTestModule.kt
@@ -1,6 +1,7 @@
 package misk.crypto
 
 import com.google.crypto.tink.Aead
+import com.google.crypto.tink.JsonKeysetReader
 import com.google.crypto.tink.KeysetHandle
 import com.google.crypto.tink.Mac
 import com.google.crypto.tink.PublicKeySign
@@ -11,11 +12,9 @@ import com.google.crypto.tink.aead.AeadKeyTemplates
 import com.google.crypto.tink.mac.MacConfig
 import com.google.crypto.tink.aead.KmsEnvelopeAead
 import com.google.crypto.tink.mac.MacFactory
-import com.google.crypto.tink.mac.MacKeyTemplates
 import com.google.crypto.tink.signature.PublicKeySignFactory
 import com.google.crypto.tink.signature.PublicKeyVerifyFactory
 import com.google.crypto.tink.signature.SignatureConfig
-import com.google.crypto.tink.signature.SignatureKeyTemplates
 import com.google.inject.name.Names
 import misk.inject.KAbstractModule
 import javax.inject.Inject
@@ -23,16 +22,68 @@ import javax.inject.Provider
 
 /**
  * This module should be used for testing purposes only.
- * It generates random keys for each key name specified in the configuration
+ * It uses the hardcoded keys defined in [TEST_AEAD_KEYSET], [TEST_MAC_KEYSET] and [TEST_SIGNATURE_KEYSET]
  * and uses [FakeKmsClient] instead of a real KMS service.
  *
  * This module **will** read the exact same configuration files as the real application,
  * but **will not** use the key material specified in the configuration.
- * Instead, it'll generate a random keyset handle for each named key.
+ * Instead, it'll generate a predefined [KeysetHandle] for each named key.
  */
 class CryptoTestModule(
   private val keyNames: List<Key>
 ) : KAbstractModule() {
+
+  private companion object {
+    /**
+     * Fake master key to be used instead of a real [com.google.crypto.tink.KmsClient]
+     */
+    val masterKey = FakeMasterEncryptionKey()
+    /**
+     * Hardcoded [Aead] [KeysetHandle] that's loaded and used by [AeadProvider]
+     */
+    const val TEST_AEAD_KEYSET = "{\n" +
+        "    \"keysetInfo\": {\n" +
+        "        \"primaryKeyId\": 1739368145,\n" +
+        "        \"keyInfo\": [{\n" +
+        "            \"typeUrl\": \"type.googleapis.com/google.crypto.tink.AesGcmKey\",\n" +
+        "            \"outputPrefixType\": \"TINK\",\n" +
+        "            \"keyId\": 1739368145,\n" +
+        "            \"status\": \"ENABLED\"\n" +
+        "        }]\n" +
+        "    },\n" +
+        "    \"encryptedKeyset\": \"Q05ITnNyMEdFbVFLV0Fvd2RIbHdaUzVuYjI5bmJHVmhjR2x6TG1OdmJTOW5iMjluYkdVdVkzSjVjSFJ2TG5ScGJtc3VRV1Z6UjJOdFMyVjVFaUlhSUtjNWVJdkxZRUp1Y2RROTFNQjU0RWc5dVo3cTg2ZzM5aWZhQUhveWhIVTVHQUVRQVJqUnpiSzlCaUFC\"\n" +
+        "}"
+    /**
+     * Hardcoded [Mac] [KeysetHandle] that's loaded and used by [MacProvider]
+     */
+    const val TEST_MAC_KEYSET = "{\n" +
+        "    \"keysetInfo\": {\n" +
+        "        \"primaryKeyId\": 785905445,\n" +
+        "        \"keyInfo\": [{\n" +
+        "            \"typeUrl\": \"type.googleapis.com/google.crypto.tink.HmacKey\",\n" +
+        "            \"outputPrefixType\": \"TINK\",\n" +
+        "            \"keyId\": 785905445,\n" +
+        "            \"status\": \"ENABLED\"\n" +
+        "        }]\n" +
+        "    },\n" +
+        "    \"encryptedKeyset\": \"Q0tYdTMvWUNFbWdLWEFvdWRIbHdaUzVuYjI5bmJHVmhjR2x6TG1OdmJTOW5iMjluYkdVdVkzSjVjSFJ2TG5ScGJtc3VTRzFoWTB0bGVSSW9FZ1FJQXhBZ0dpQ2lJbVNYM21mMU1PQUhuMjh6TVoveG5aczNBWkUydFNTQTFuRFBEVjJjaHhnQkVBRVlwZTdmOWdJZ0FRPT0=\"\n" +
+        "}"
+    /**
+     * Hardcoded digital signature [KeysetHandle] that's loaded and used by [DigitalSignatureSignerProvider]
+     */
+    const val TEST_SIGNATURE_KEYSET = "{\n" +
+        "    \"keysetInfo\": {\n" +
+        "        \"primaryKeyId\": 582162020,\n" +
+        "        \"keyInfo\": [{\n" +
+        "            \"typeUrl\": \"type.googleapis.com/google.crypto.tink.Ed25519PrivateKey\",\n" +
+        "            \"outputPrefixType\": \"TINK\",\n" +
+        "            \"keyId\": 582162020,\n" +
+        "            \"status\": \"ENABLED\"\n" +
+        "        }]\n" +
+        "    },\n" +
+        "    \"encryptedKeyset\": \"Q09Tc3pKVUNFcEVCQ29RQkNqaDBlWEJsTG1kdmIyZHNaV0Z3YVhNdVkyOXRMMmR2YjJkc1pTNWpjbmx3ZEc4dWRHbHVheTVGWkRJMU5URTVVSEpwZG1GMFpVdGxlUkpHRWlCZzBBUTd6QzJVT2IrN2pPKzJYUTZtT1IyYTB1ZlAzV1pkZjdVZk9zWHdpUm9pRWlCVmFsQUwrdFB5bG01NlluLzNzNTZqVGluY1V6bXoycGV6c0JwZnRlOUMzUmdDRUFFWTVLek1sUUlnQVE9PQ==\"\n" +
+        "}"
+  }
 
   override fun configure() {
     AeadConfig.register()
@@ -44,7 +95,7 @@ class CryptoTestModule(
         KeyType.AEAD -> {
           bind<Aead>()
               .annotatedWith(Names.named(key.key_name))
-              .toProvider(CipherProvider(key.key_name))
+              .toProvider(AeadProvider(key.key_name))
               .asEagerSingleton()
         }
         KeyType.MAC -> {
@@ -54,7 +105,7 @@ class CryptoTestModule(
               .asEagerSingleton()
         }
         KeyType.DIGITAL_SIGNATURE -> {
-          val keysetHandle = KeysetHandle.generateNew(SignatureKeyTemplates.ED25519)
+          val keysetHandle = KeysetHandle.read(JsonKeysetReader.withString(TEST_SIGNATURE_KEYSET), masterKey)
           val signer = PublicKeySignFactory.getPrimitive(keysetHandle)
           val verifier = PublicKeyVerifyFactory.getPrimitive(keysetHandle.publicKeysetHandle)
           bind<PublicKeySign>()
@@ -69,11 +120,11 @@ class CryptoTestModule(
     }
   }
 
-  private class CipherProvider(val keyName: String) : Provider<Aead> {
+  private class AeadProvider(val keyName: String) : Provider<Aead> {
     @Inject lateinit var keyManager: AeadKeyManager
 
     override fun get(): Aead {
-      val keysetHandle = KeysetHandle.generateNew(AeadKeyTemplates.AES256_GCM)
+      val keysetHandle = KeysetHandle.read(JsonKeysetReader.withString(TEST_AEAD_KEYSET), masterKey)
       val kek = AeadFactory.getPrimitive(keysetHandle)
       val envelopeKey = KmsEnvelopeAead(AeadKeyTemplates.AES128_GCM, kek)
       return envelopeKey.also { keyManager[keyName] = it }
@@ -84,7 +135,7 @@ class CryptoTestModule(
     @Inject lateinit var keyManager: MacKeyManager
 
     override fun get(): Mac {
-      val keysetHandle = KeysetHandle.generateNew(MacKeyTemplates.HMAC_SHA256_256BITTAG)
+      val keysetHandle = KeysetHandle.read(JsonKeysetReader.withString(TEST_MAC_KEYSET), masterKey)
       return MacFactory.getPrimitive(keysetHandle)
           .also { keyManager[keyName] = it }
     }

--- a/misk-crypto/src/main/kotlin/misk/crypto/CryptoTestModule.kt
+++ b/misk-crypto/src/main/kotlin/misk/crypto/CryptoTestModule.kt
@@ -39,7 +39,16 @@ class CryptoTestModule(
      */
     val masterKey = FakeMasterEncryptionKey()
     /**
-     * Hardcoded [Aead] [KeysetHandle] that's loaded and used by [AeadProvider]
+     * Hardcoded [Aead] [KeysetHandle] that's loaded and used by [AeadProvider].
+     *
+     * This string was generated using the following snippet:
+     * ```
+     * val kh = KeysetHandle.generateNew(AeadKeyTemplates.AES256_GCM)
+     * val output = ByteArrayOutputStream()
+     * val writer = JsonKeysetWriter.withOutputStream(output)
+     * kh.write(writer, masterKey)
+     * output.toString()
+     * ```
      */
     const val TEST_AEAD_KEYSET = "{\n" +
         "    \"keysetInfo\": {\n" +


### PR DESCRIPTION
Also, changed the 'key_uri' and 'encrypted_key' configuration values
optional so that the test and development configuration yamls won't have
to specify filler values.