### PR TITLE
Add clients for calling other members in an app's cluster

### DIFF
--- a/misk/src/main/kotlin/misk/client/PeerClientFactory.kt
+++ b/misk/src/main/kotlin/misk/client/PeerClientFactory.kt
@@ -1,0 +1,113 @@
+package misk.client
+
+import com.google.common.cache.CacheBuilder
+import com.google.common.cache.CacheLoader
+import com.google.inject.Provides
+import misk.clustering.Cluster
+import misk.config.AppName
+import misk.inject.KAbstractModule
+import misk.security.cert.X500Name
+import misk.web.WebConfig
+import misk.web.jetty.JettyService
+import okhttp3.OkHttpClient
+import java.security.cert.X509Certificate
+import java.util.concurrent.TimeUnit
+import javax.inject.Singleton
+
+/**
+ * Binds a [PeerClientFactory] that calls peers on the HTTPS port of this process's server,
+ * as determined by the SSL port in the [WebConfig].
+ */
+class PeerClientModule : KAbstractModule() {
+  @Provides @Singleton fun peerClientFactory(
+    @AppName appName: String,
+    httpClientsConfig: HttpClientsConfig,
+    httpClientFactory: HttpClientFactory,
+    webConfig: WebConfig
+  ): PeerClientFactory {
+    check(webConfig.ssl?.port ?: 0 > 0) { "server must have static HTTPS port" }
+
+    return PeerClientFactory(
+        appName = appName,
+        httpClientsConfig = httpClientsConfig,
+        httpClientFactory = httpClientFactory,
+        httpsPort = webConfig.ssl!!.port
+    )
+  }
+}
+
+/**
+ * For testing.
+ *
+ * Binds a [PeerClientFactory] that calls peers on the HTTPS port of this process's server,
+ * as determined by the Jetty server's port.
+ */
+class JettyPortPeerClientModule : KAbstractModule() {
+  @Provides @Singleton fun peerClientFactory(
+    @AppName appName: String,
+    httpClientsConfig: HttpClientsConfig,
+    httpClientFactory: HttpClientFactory,
+    jetty: JettyService
+  ): PeerClientFactory {
+    return PeerClientFactory(
+        appName = appName,
+        httpClientsConfig = httpClientsConfig,
+        httpClientFactory = httpClientFactory,
+        httpsPort = jetty.httpsServerUrl!!.port()
+    )
+  }
+}
+
+/**
+ * Factory that creates [OkHttpClient]s for connecting to another instance of the same application
+ * running in the same cluster.
+ *
+ * An [OkHttpClient] is cached for each peer.
+ */
+class PeerClientFactory(
+  private val appName: String,
+  private val httpClientsConfig: HttpClientsConfig,
+  private val httpClientFactory: HttpClientFactory,
+  private val httpsPort: Int
+) {
+
+  private val cache = CacheBuilder.newBuilder()
+      .expireAfterAccess(5, TimeUnit.MINUTES)
+      .build<Cluster.Member, OkHttpClient>(object : CacheLoader<Cluster.Member, OkHttpClient>() {
+        override fun load(peer: Cluster.Member): OkHttpClient {
+          val config = httpClientsConfig[appName].copy(
+              url = baseUrl(peer),
+              envoy = null
+          )
+
+          return httpClientFactory.create(config).newBuilder()
+              .hostnameVerifier { _, session ->
+                val ou =
+                    (session.peerCertificates.firstOrNull() as? X509Certificate)?.let { peerCert ->
+                      X500Name.parse(peerCert.subjectX500Principal.name).organizationalUnit
+                    }
+                appName == ou
+              }
+              .build()
+        }
+      })
+
+  init {
+    require(httpsPort > 0) { "port must be a positive integer " }
+
+    // There must be web client config. The URL and Envoy config are ultimately ignored.
+    httpClientsConfig[appName] // This throws if config is missing
+  }
+
+  /** Get the base URL for calling the given peer cluster member. */
+  fun baseUrl(peer: Cluster.Member): String {
+    return "https://${peer.ipAddress}:$httpsPort"
+  }
+
+  /**
+   * Get a client to call the given peer cluster member.
+   * This client will fail when calling different services, as determined by the OU in the certificate
+   * returned by the called service.
+   */
+  fun client(peer: Cluster.Member): OkHttpClient = cache[peer]
+}

--- a/misk/src/main/kotlin/misk/client/TypedHttpClientModule.kt
+++ b/misk/src/main/kotlin/misk/client/TypedHttpClientModule.kt
@@ -4,8 +4,10 @@ import com.google.inject.Inject
 import com.google.inject.Key
 import com.google.inject.Provider
 import com.google.inject.name.Names
+import com.google.inject.util.Types
 import com.squareup.moshi.Moshi
 import io.opentracing.Tracer
+import misk.clustering.Cluster
 import misk.inject.KAbstractModule
 import okhttp3.EventListener
 import okhttp3.OkHttpClient
@@ -46,58 +48,124 @@ class TypedHttpClientModule<T : Any>(
   }
 
   private class TypedClientProvider<T : Any>(
-    private val kclass: KClass<T>,
+    kclass: KClass<T>,
     private val name: String,
     private val httpClientProvider: Provider<OkHttpClient>
-  ) : Provider<T> {
-    @Inject
-    private lateinit var httpClientsConfig: HttpClientsConfig
+  ) : TypedClientFactory<T>(kclass, name), Provider<T> {
 
-    // Use Providers for the interceptors so Guice can properly detect cycles when apps inject
-    // an HTTP Client in an Interceptor.
-    // https://gist.github.com/ryanhall07/e3eac6d2d47b72a4c37bce87219d7ced
-    @Inject
-    private lateinit var clientNetworkInterceptorFactories: Provider<List<ClientNetworkInterceptor.Factory>>
-
-    @Inject
-    private lateinit var clientApplicationInterceptorFactories: Provider<List<ClientApplicationInterceptor.Factory>>
-
-    @Inject
-    private lateinit var moshi: Moshi
-
-    @Inject(optional = true)
-    private val tracer: Tracer? = null
-
-    @Inject(optional = true)
-    private val eventListenerFactory: EventListener.Factory? = null
-
-    @Inject
-    private lateinit var httpClientConfigUrlProvider: HttpClientConfigUrlProvider
+    @Inject private lateinit var httpClientsConfig: HttpClientsConfig
+    @Inject private lateinit var httpClientConfigUrlProvider: HttpClientConfigUrlProvider
 
     override fun get(): T {
-      val okhttp = httpClientProvider.get()
+      val client = httpClientProvider.get()
       val endpointConfig = httpClientsConfig[name]
-      val retrofit = Retrofit.Builder()
-          .baseUrl(httpClientConfigUrlProvider.getUrl(endpointConfig))
-          .build()
+      val baseUrl = httpClientConfigUrlProvider.getUrl(endpointConfig)
 
-      val invocationHandler = ClientInvocationHandler(
-          kclass,
-          name,
-          retrofit,
-          okhttp,
-          clientNetworkInterceptorFactories,
-          clientApplicationInterceptorFactories,
-          eventListenerFactory,
-          tracer,
-          moshi)
-
-      @Suppress("UNCHECKED_CAST")
-      return Proxy.newProxyInstance(
-          ClassLoader.getSystemClassLoader(),
-          arrayOf(kclass.java),
-          invocationHandler
-      ) as T
+      return typedClient(client, baseUrl)
     }
+  }
+}
+
+/**
+ * Factory for creating typed clients that call other members of a cluster.
+ */
+interface TypedPeerClientFactory<T> {
+  fun client(peer: Cluster.Member): T
+}
+
+/**
+ * Creates a retrofit-backed typed client factory given an API interface and an HTTP configuration.
+ *
+ * The factory returned typed clients that can be used to call other members of the cluster.
+ */
+class TypedPeerHttpClientModule<T : Any>(
+  private val kclass: KClass<T>,
+  private val name: String
+) : KAbstractModule() {
+
+  override fun configure() {
+    // Initialize empty sets for our multibindings.
+    newMultibinder<ClientNetworkInterceptor.Factory>()
+    newMultibinder<ClientApplicationInterceptor.Factory>()
+
+    @Suppress("UNCHECKED_CAST")
+    val key = Key.get(
+        Types.newParameterizedType(TypedPeerClientFactory::class.java,
+            kclass.java)) as Key<TypedPeerClientFactory<T>>
+
+    bind(key).toProvider(PeerTypedClientProvider(kclass, name))
+  }
+
+  companion object {
+    inline fun <reified T : Any> create(name: String): TypedPeerHttpClientModule<T> {
+      return TypedPeerHttpClientModule(T::class, name)
+    }
+  }
+
+  private class PeerTypedClientProvider<T : Any>(
+    kclass: KClass<T>,
+    name: String
+  ) : TypedClientFactory<T>(kclass, name), Provider<TypedPeerClientFactory<T>> {
+
+    @Inject private lateinit var peerClientFactory: PeerClientFactory
+
+    override fun get(): TypedPeerClientFactory<T> {
+      return object : TypedPeerClientFactory<T> {
+        override fun client(peer: Cluster.Member): T {
+          return typedClient(peerClientFactory.client(peer), peerClientFactory.baseUrl(peer))
+        }
+      }
+    }
+  }
+}
+
+private abstract class TypedClientFactory<T : Any>(
+  private val kclass: KClass<T>,
+  private val name: String
+) {
+
+  @Inject
+  private lateinit var httpClientsConfig: HttpClientsConfig
+
+  // Use Providers for the interceptors so Guice can properly detect cycles when apps inject
+  // an HTTP Client in an Interceptor.
+  // https://gist.github.com/ryanhall07/e3eac6d2d47b72a4c37bce87219d7ced
+  @Inject
+  private lateinit var clientNetworkInterceptorFactories: Provider<List<ClientNetworkInterceptor.Factory>>
+
+  @Inject
+  private lateinit var clientApplicationInterceptorFactories: Provider<List<ClientApplicationInterceptor.Factory>>
+
+  @Inject
+  private lateinit var moshi: Moshi
+
+  @Inject(optional = true)
+  private val tracer: Tracer? = null
+
+  @Inject(optional = true)
+  private val eventListenerFactory: EventListener.Factory? = null
+
+  fun typedClient(client: OkHttpClient, baseUrl: String): T {
+    val retrofit = Retrofit.Builder()
+        .baseUrl(baseUrl)
+        .build()
+
+    val invocationHandler = ClientInvocationHandler(
+        kclass,
+        name,
+        retrofit,
+        client,
+        clientNetworkInterceptorFactories,
+        clientApplicationInterceptorFactories,
+        eventListenerFactory,
+        tracer,
+        moshi)
+
+    @Suppress("UNCHECKED_CAST")
+    return Proxy.newProxyInstance(
+        ClassLoader.getSystemClassLoader(),
+        arrayOf(kclass.java),
+        invocationHandler
+    ) as T
   }
 }

--- a/misk/src/test/kotlin/misk/client/TypedPeerHttpClientTest.kt
+++ b/misk/src/test/kotlin/misk/client/TypedPeerHttpClientTest.kt
@@ -1,0 +1,166 @@
+package misk.client
+
+import com.google.inject.Guice
+import com.google.inject.Injector
+import com.google.inject.Key
+import com.google.inject.Provides
+import com.google.inject.TypeLiteral
+import helpers.protos.Dinosaur
+import misk.MiskTestingServiceModule
+import misk.clustering.Cluster
+import misk.clustering.ClusterWatch
+import misk.clustering.fake.ExplicitClusterResourceMapper
+import misk.config.AppName
+import misk.inject.KAbstractModule
+import misk.security.ssl.CertStoreConfig
+import misk.security.ssl.SslLoader
+import misk.security.ssl.TrustStoreConfig
+import misk.testing.MiskTest
+import misk.testing.MiskTestModule
+import misk.web.Post
+import misk.web.RequestBody
+import misk.web.RequestContentType
+import misk.web.ResponseContentType
+import misk.web.WebActionModule
+import misk.web.WebConfig
+import misk.web.WebSslConfig
+import misk.web.WebTestingModule
+import misk.web.actions.WebAction
+import misk.web.jetty.JettyService
+import misk.web.mediatype.MediaTypes
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import retrofit2.Call
+import retrofit2.http.Body
+import retrofit2.http.POST
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@MiskTest(startService = true)
+internal class TypedPeerHttpClientTest {
+  @MiskTestModule val module = TestModule()
+
+  @Inject private lateinit var jetty: JettyService
+
+  @Inject private lateinit var cluster: Cluster
+
+  private lateinit var clientInjector: Injector
+
+  @BeforeEach
+  fun createClient() {
+    clientInjector = Guice.createInjector(ClientModule(jetty))
+  }
+
+  @Test
+  fun useTypedClient() {
+    val clientFactory = clientInjector.getInstance(
+        Key.get(object : TypeLiteral<TypedPeerClientFactory<ReturnADinosaur>>() {}))
+
+    val snapshot = cluster.snapshot
+    val client: ReturnADinosaur = clientFactory.client(snapshot.self)
+
+    val response = client.getDinosaur(Dinosaur.Builder().name("trex").build()).execute()
+    assertThat(response.code()).isEqualTo(200)
+    assertThat(response.body()).isNotNull()
+    assertThat(response.body()?.name!!).isEqualTo("supertrex")
+  }
+
+  interface ReturnADinosaur {
+    @POST("/cooldinos")
+    fun getDinosaur(@Body request: Dinosaur): Call<Dinosaur>
+  }
+
+  class ReturnADinosaurAction @Inject constructor() : WebAction {
+    @Post("/cooldinos")
+    @RequestContentType(MediaTypes.APPLICATION_JSON)
+    @ResponseContentType(MediaTypes.APPLICATION_JSON)
+    fun getDinosaur(@RequestBody request: Dinosaur):
+        Dinosaur = request.newBuilder().name("super${request.name}").build()
+  }
+
+  class FakeCluster @Inject constructor(
+    memberIp: String = "127.0.0.1"
+  ) : Cluster {
+
+    override val snapshot: Cluster.Snapshot
+
+    init {
+      val self = Cluster.Member(name = "self-name", ipAddress = memberIp)
+      val resourceMapper = ExplicitClusterResourceMapper()
+
+      resourceMapper.setDefaultMapping(self)
+
+      snapshot = Cluster.Snapshot(
+          self = self,
+          readyMembers = setOf(),
+          selfReady = true,
+          resourceMapper = resourceMapper
+      )
+    }
+
+    override fun watch(watch: ClusterWatch) {
+      throw UnsupportedOperationException()
+    }
+  }
+
+  class TestModule : KAbstractModule() {
+    override fun configure() {
+      // Run a server using a cert that has OU of "Server"
+      install(WebTestingModule(WebConfig(
+          port = 0,
+          idle_timeout = 500000,
+          host = "127.0.0.1",
+          ssl = WebSslConfig(0,
+              cert_store = CertStoreConfig(
+                  resource = "classpath:/ssl/server_cert_key_combo.pem",
+                  passphrase = "serverpassword",
+                  format = SslLoader.FORMAT_PEM
+              ),
+              trust_store = TrustStoreConfig(
+                  resource = "classpath:/ssl/client_cert.pem",
+                  format = SslLoader.FORMAT_PEM
+              ),
+              mutual_auth = WebSslConfig.MutualAuth.REQUIRED)
+      )))
+
+      bind<Cluster>().toInstance(FakeCluster())
+      install(WebActionModule.create<ReturnADinosaurAction>())
+    }
+  }
+
+  inner class ClientModule(val jetty: JettyService) : KAbstractModule() {
+    override fun configure() {
+      install(MiskTestingServiceModule())
+      install(TypedPeerHttpClientModule.create<ReturnADinosaur>("dinosaur"))
+
+      bind<JettyService>().toInstance(jetty)
+
+      install(JettyPortPeerClientModule())
+    }
+
+    // "Server" is the OU of the cert used by the test server
+    @Provides @AppName fun appName() = "Server"
+
+    @Provides
+    @Singleton
+    fun provideHttpClientConfig(): HttpClientsConfig {
+      return HttpClientsConfig(
+          endpoints = mapOf(
+              "Server" to HttpClientEndpointConfig(
+                  jetty.httpsServerUrl!!.toString(),
+                  ssl = HttpClientSSLConfig(
+                      cert_store = CertStoreConfig(
+                          resource = "classpath:/ssl/client_cert_key_combo.pem",
+                          passphrase = "clientpassword",
+                          format = SslLoader.FORMAT_PEM
+                      ),
+                      trust_store = TrustStoreConfig(
+                          resource = "classpath:/ssl/server_cert.pem",
+                          format = SslLoader.FORMAT_PEM
+                      )
+                  ))
+          ))
+    }
+  }
+}


### PR DESCRIPTION
An app running in a cluster may want to call specific peers in the cluster group. This builds on top of the `Cluster` abstraction to create both untyped and retrofit-typed clients, using mTLS to validate that the peer's OU is the same as the calling app's OU.

Example using this to have a specific cluster member handle all `foo`-related requests:
```
@Inject lateinit var cluster: Cluster
@Inject lateinit var clientFactory: TypedPeerClientFactory<ReturnADinosaur>

@Test fun demo() {
  val client: ReturnADinosaur = clientFactory.client(cluster.snapshot.resourceMapper["foo"])
}
```