### PR TITLE
Refactor key providers

### DIFF
--- a/misk-crypto/src/main/kotlin/misk/crypto/CryptoTestModule.kt
+++ b/misk-crypto/src/main/kotlin/misk/crypto/CryptoTestModule.kt
@@ -48,9 +48,6 @@ class CryptoTestModule(
               .asEagerSingleton()
         }
         KeyType.DIGITAL_SIGNATURE -> {
-          // val keysetHandle = KeysetHandle.generateNew(SignatureKeyTemplates.ED25519)
-          // val signer = PublicKeySignFactory.getPrimitive(keysetHandle)
-          // val verifier = PublicKeyVerifyFactory.getPrimitive(keysetHandle.publicKeysetHandle)
           bind<PublicKeySign>()
               .annotatedWith(Names.named(key.key_name))
               .toProvider(DigitalSignatureSignerProvider(key, null))

--- a/misk-crypto/src/main/kotlin/misk/crypto/CryptoTestModule.kt
+++ b/misk-crypto/src/main/kotlin/misk/crypto/CryptoTestModule.kt
@@ -1,6 +1,7 @@
 package misk.crypto
 
 import com.google.crypto.tink.Aead
+import com.google.crypto.tink.KmsClient
 import com.google.crypto.tink.Mac
 import com.google.crypto.tink.PublicKeySign
 import com.google.crypto.tink.PublicKeyVerify
@@ -29,6 +30,8 @@ class CryptoTestModule(
     AeadConfig.register()
     MacConfig.register()
     SignatureConfig.register()
+
+    bind<KmsClient>().toInstance(FakeKmsClient())
 
     keyNames.forEach { key ->
       when (key.key_type) {

--- a/misk-crypto/src/main/kotlin/misk/crypto/CryptoTestModule.kt
+++ b/misk-crypto/src/main/kotlin/misk/crypto/CryptoTestModule.kt
@@ -1,25 +1,15 @@
 package misk.crypto
 
 import com.google.crypto.tink.Aead
-import com.google.crypto.tink.KeysetHandle
 import com.google.crypto.tink.Mac
 import com.google.crypto.tink.PublicKeySign
 import com.google.crypto.tink.PublicKeyVerify
 import com.google.crypto.tink.aead.AeadConfig
-import com.google.crypto.tink.aead.AeadFactory
-import com.google.crypto.tink.aead.AeadKeyTemplates
 import com.google.crypto.tink.mac.MacConfig
-import com.google.crypto.tink.aead.KmsEnvelopeAead
-import com.google.crypto.tink.mac.MacFactory
-import com.google.crypto.tink.mac.MacKeyTemplates
-import com.google.crypto.tink.signature.PublicKeySignFactory
-import com.google.crypto.tink.signature.PublicKeyVerifyFactory
 import com.google.crypto.tink.signature.SignatureConfig
-import com.google.crypto.tink.signature.SignatureKeyTemplates
 import com.google.inject.name.Names
 import misk.inject.KAbstractModule
-import javax.inject.Inject
-import javax.inject.Provider
+import misk.resources.ResourceLoaderModule
 
 /**
  * This module should be used for testing purposes only.
@@ -35,68 +25,40 @@ class CryptoTestModule(
 ) : KAbstractModule() {
 
   override fun configure() {
+
     AeadConfig.register()
     MacConfig.register()
     SignatureConfig.register()
 
     keyNames.forEach { key ->
-      when(key.key_type) {
+      when (key.key_type) {
         KeyType.AEAD -> {
           bind<Aead>()
               .annotatedWith(Names.named(key.key_name))
-              .toProvider(CipherProvider(key.key_name))
+              .toProvider(AeadEnvelopeProvider(key,null))
               .asEagerSingleton()
         }
         KeyType.MAC -> {
           bind<Mac>()
               .annotatedWith(Names.named(key.key_name))
-              .toProvider(MacProvider(key.key_name))
+              .toProvider(MacProvider(key, null))
               .asEagerSingleton()
         }
         KeyType.DIGITAL_SIGNATURE -> {
-          val keysetHandle = KeysetHandle.generateNew(SignatureKeyTemplates.ED25519)
-          val signer = PublicKeySignFactory.getPrimitive(keysetHandle)
-          val verifier = PublicKeyVerifyFactory.getPrimitive(keysetHandle.publicKeysetHandle)
+          // val keysetHandle = KeysetHandle.generateNew(SignatureKeyTemplates.ED25519)
+          // val signer = PublicKeySignFactory.getPrimitive(keysetHandle)
+          // val verifier = PublicKeyVerifyFactory.getPrimitive(keysetHandle.publicKeysetHandle)
           bind<PublicKeySign>()
               .annotatedWith(Names.named(key.key_name))
-              .toProvider(DigitalSignatureSignerProvider(signer, verifier, key.key_name))
+              .toProvider(DigitalSignatureSignerProvider(key, null))
               .asEagerSingleton()
           bind<PublicKeyVerify>()
               .annotatedWith(Names.named(key.key_name))
-              .toInstance(verifier)
+              .toProvider(DigitalSignatureVerifierProvider(key, null))
+              .asEagerSingleton()
+          }
         }
       }
     }
-  }
-
-  private class CipherProvider(val keyName: String) : Provider<Aead> {
-    @Inject lateinit var keyManager: AeadKeyManager
-
-    override fun get(): Aead {
-      val keysetHandle = KeysetHandle.generateNew(AeadKeyTemplates.AES256_GCM)
-      val kek = AeadFactory.getPrimitive(keysetHandle)
-      val envelopeKey = KmsEnvelopeAead(AeadKeyTemplates.AES128_GCM, kek)
-      return envelopeKey.also { keyManager[keyName] = it }
-    }
-  }
-
-  private class MacProvider(val keyName: String) : Provider<Mac> {
-    @Inject lateinit var keyManager: MacKeyManager
-
-    override fun get(): Mac {
-      val keysetHandle = KeysetHandle.generateNew(MacKeyTemplates.HMAC_SHA256_256BITTAG)
-      return MacFactory.getPrimitive(keysetHandle)
-          .also { keyManager[keyName] = it }
-    }
-  }
-
-  private class DigitalSignatureSignerProvider(val signer: PublicKeySign,
-    val verifier: PublicKeyVerify, val name: String) : Provider<PublicKeySign> {
-    @Inject lateinit var keyManager: DigitalSignatureKeyManager
-
-    override fun get(): PublicKeySign {
-      keyManager[name] = DigitalSignature(signer, verifier)
-      return signer
-    }
-  }
 }
+

--- a/misk-crypto/src/main/kotlin/misk/crypto/KeyProviders.kt
+++ b/misk-crypto/src/main/kotlin/misk/crypto/KeyProviders.kt
@@ -1,0 +1,98 @@
+package misk.crypto
+
+import com.google.crypto.tink.Aead
+import com.google.crypto.tink.CleartextKeysetHandle
+import com.google.crypto.tink.KmsClient
+import com.google.crypto.tink.Mac
+import com.google.crypto.tink.PublicKeySign
+import com.google.crypto.tink.PublicKeyVerify
+import com.google.crypto.tink.mac.MacFactory
+import com.google.crypto.tink.proto.KeyTemplate
+import com.google.crypto.tink.signature.PublicKeySignFactory
+import com.google.crypto.tink.signature.PublicKeyVerifyFactory
+import com.google.crypto.tink.JsonKeysetReader
+import com.google.crypto.tink.KeysetHandle
+import com.google.crypto.tink.aead.AeadFactory
+import com.google.crypto.tink.aead.AeadKeyTemplates
+import com.google.crypto.tink.aead.KmsEnvelopeAead
+import com.google.inject.Inject
+import com.google.inject.Provider
+import misk.logging.getLogger
+
+val logger by lazy { getLogger<CryptoModule>() }
+
+/**
+ * We only support AEAD keys via envelope encryption.
+ */
+internal class AeadEnvelopeProvider(val key: Key, val kmsUri: String?) : Provider<Aead> {
+  @Inject lateinit var keyManager: AeadKeyManager
+  @Inject lateinit var kmsClient: KmsClient
+
+  override fun get(): Aead {
+    val keysetHandle = readKey(key, kmsUri, kmsClient)
+    val kek = AeadFactory.getPrimitive(keysetHandle)
+    val envelopeKey = KmsEnvelopeAead(DEK_TEMPLATE, kek)
+
+    return envelopeKey.also { keyManager[key.key_name] = it }
+  }
+
+  companion object {
+    val DEK_TEMPLATE: KeyTemplate = AeadKeyTemplates.AES128_GCM
+  }
+}
+
+internal class MacProvider(val key: Key, val kmsUri: String?) : Provider<Mac> {
+  @Inject lateinit var keyManager: MacKeyManager
+  @Inject lateinit var kmsClient: KmsClient
+
+  override fun get(): Mac {
+    val keysetHandle = readKey(key, kmsUri, kmsClient)
+    return MacFactory.getPrimitive(keysetHandle)
+        .also { keyManager[key.key_name] = it }
+  }
+}
+
+internal class DigitalSignatureSignerProvider(
+  val key: Key,
+  val kmsUri: String?
+) : Provider<PublicKeySign> {
+  @Inject lateinit var keyManager: DigitalSignatureKeyManager
+  @Inject lateinit var kmsClient: KmsClient
+
+  override fun get(): PublicKeySign {
+    val keysetHandle = readKey(key, kmsUri, kmsClient)
+    val signer = PublicKeySignFactory.getPrimitive(keysetHandle)
+    val verifier = PublicKeyVerifyFactory.getPrimitive(keysetHandle.publicKeysetHandle)
+    keyManager[key.key_name] = DigitalSignature(signer, verifier)
+    return signer
+  }
+}
+
+internal class DigitalSignatureVerifierProvider(
+  val key: Key,
+  val kmsUri: String?
+) : Provider<PublicKeyVerify> {
+  @Inject lateinit var keyManager: DigitalSignatureKeyManager
+  @Inject lateinit var kmsClient: KmsClient
+
+  override fun get(): PublicKeyVerify {
+    val keysetHandle = readKey(key, kmsUri, kmsClient)
+    val signer = PublicKeySignFactory.getPrimitive(keysetHandle)
+    val verifier = PublicKeyVerifyFactory.getPrimitive(keysetHandle.publicKeysetHandle)
+    keyManager[key.key_name] = DigitalSignature(signer, verifier)
+    return verifier
+  }
+}
+
+private fun readKey(key: Key, kmsUri: String?, kmsClient: KmsClient): KeysetHandle {
+  val keyJson = JsonKeysetReader.withString(key.encrypted_key.value)
+
+  return if (kmsUri != null) {
+    val masterKey = kmsClient.getAead(kmsUri)
+    KeysetHandle.read(keyJson, masterKey)
+  } else {
+    logger.warn { "Reading a plaintext key" }
+    CleartextKeysetHandle.read(keyJson)
+  }
+}
+

--- a/misk-hibernate/src/test/kotlin/misk/hibernate/SecretColumnTest.kt
+++ b/misk-hibernate/src/test/kotlin/misk/hibernate/SecretColumnTest.kt
@@ -165,16 +165,16 @@ class SecretColumnTest {
   }
 
   @Test
-  fun testGetRecordByEncryptedColumn() {
+  fun testGetRecordByEncryptedColumnFails() {
     val title = "Dark Star"
     val length = 2918
     val album = "Live/Dead".toByteArray()
     transacter.transaction { session ->
       session.save(DbJerryGarciaSong(title, length, album))
-      val song = queryFactory.newQuery<JerryGarciaSongQuery>()
+      val songs = queryFactory.newQuery<JerryGarciaSongQuery>()
           .album(album)
           .query(session)
-      assertNotNull(song)
+      assertThat(songs.size).isEqualTo(0)
     }
   }
 

--- a/misk-hibernate/src/test/resources/secrets/albumKey.txt
+++ b/misk-hibernate/src/test/resources/secrets/albumKey.txt
@@ -1,0 +1,13 @@
+{
+    "primaryKeyId": 823648974,
+    "key": [{
+        "keyData": {
+            "typeUrl": "type.googleapis.com/google.crypto.tink.AesGcmKey",
+            "keyMaterialType": "SYMMETRIC",
+            "value": "GiCX75KhxNgGsi5APr8/bjyzku+m94MY1B58HuTNwPFABA=="
+        },
+        "outputPrefixType": "TINK",
+        "keyId": 823648974,
+        "status": "ENABLED"
+    }]
+}


### PR DESCRIPTION
This change unifies test and non-test versions of the various key providers to make them usable in both environments. After some discussion, we settled on using actual keys for testing and development, removing the need for diverging code paths and hard-coded keys.

This might supersede #972