### PR TITLE
Support DAEAD encryption

### DIFF
--- a/misk-crypto/src/main/kotlin/misk/crypto/CryptoConfig.kt
+++ b/misk-crypto/src/main/kotlin/misk/crypto/CryptoConfig.kt
@@ -45,6 +45,7 @@ data class Key(
  */
 enum class KeyType {
   AEAD,
+  DAEAD,
   MAC,
   DIGITAL_SIGNATURE
 }

--- a/misk-crypto/src/main/kotlin/misk/crypto/CryptoModule.kt
+++ b/misk-crypto/src/main/kotlin/misk/crypto/CryptoModule.kt
@@ -1,6 +1,7 @@
 package misk.crypto
 
 import com.google.crypto.tink.Aead
+import com.google.crypto.tink.DeterministicAead
 import com.google.crypto.tink.KmsClient
 import com.google.crypto.tink.aead.AeadConfig
 import com.google.crypto.tink.mac.MacConfig
@@ -42,6 +43,12 @@ class CryptoModule(
           bind<Aead>()
               .annotatedWith(Names.named(key.key_name))
               .toProvider(AeadEnvelopeProvider(key, config.kms_uri))
+              .`in`(Singleton::class.java)
+        }
+        KeyType.DAEAD -> {
+          bind<DeterministicAead>()
+              .annotatedWith(Names.named(key.key_name))
+              .toProvider(DeterministicAeadProvider(key, config.kms_uri))
               .`in`(Singleton::class.java)
         }
         KeyType.MAC -> {

--- a/misk-crypto/src/main/kotlin/misk/crypto/CryptoModule.kt
+++ b/misk-crypto/src/main/kotlin/misk/crypto/CryptoModule.kt
@@ -10,6 +10,7 @@ import misk.inject.KAbstractModule
 import com.google.crypto.tink.Mac
 import com.google.crypto.tink.PublicKeySign
 import com.google.crypto.tink.PublicKeyVerify
+import com.google.crypto.tink.daead.DeterministicAeadConfig
 import com.google.inject.Singleton
 import com.google.inject.name.Names
 import okio.ByteString
@@ -28,6 +29,7 @@ class CryptoModule(
     config.keys ?: return
     requireBinding(KmsClient::class.java)
     AeadConfig.register()
+    DeterministicAeadConfig.register()
     MacConfig.register()
     SignatureConfig.register()
 

--- a/misk-crypto/src/main/kotlin/misk/crypto/CryptoTestModule.kt
+++ b/misk-crypto/src/main/kotlin/misk/crypto/CryptoTestModule.kt
@@ -1,6 +1,7 @@
 package misk.crypto
 
 import com.google.crypto.tink.Aead
+import com.google.crypto.tink.DeterministicAead
 import com.google.crypto.tink.KmsClient
 import com.google.crypto.tink.Mac
 import com.google.crypto.tink.PublicKeySign
@@ -10,7 +11,6 @@ import com.google.crypto.tink.mac.MacConfig
 import com.google.crypto.tink.signature.SignatureConfig
 import com.google.inject.name.Names
 import misk.inject.KAbstractModule
-import misk.resources.ResourceLoaderModule
 
 /**
  * This module should be used for testing purposes only.
@@ -39,6 +39,12 @@ class CryptoTestModule(
           bind<Aead>()
               .annotatedWith(Names.named(key.key_name))
               .toProvider(AeadEnvelopeProvider(key,null))
+              .asEagerSingleton()
+        }
+        KeyType.DAEAD -> {
+          bind<DeterministicAead>()
+              .annotatedWith(Names.named(key.key_name))
+              .toProvider(DeterministicAeadProvider(key, null))
               .asEagerSingleton()
         }
         KeyType.MAC -> {

--- a/misk-crypto/src/main/kotlin/misk/crypto/CryptoTestModule.kt
+++ b/misk-crypto/src/main/kotlin/misk/crypto/CryptoTestModule.kt
@@ -7,6 +7,7 @@ import com.google.crypto.tink.Mac
 import com.google.crypto.tink.PublicKeySign
 import com.google.crypto.tink.PublicKeyVerify
 import com.google.crypto.tink.aead.AeadConfig
+import com.google.crypto.tink.daead.DeterministicAeadConfig
 import com.google.crypto.tink.mac.MacConfig
 import com.google.crypto.tink.signature.SignatureConfig
 import com.google.inject.name.Names
@@ -28,6 +29,7 @@ class CryptoTestModule(
   override fun configure() {
 
     AeadConfig.register()
+    DeterministicAeadConfig.register()
     MacConfig.register()
     SignatureConfig.register()
 

--- a/misk-crypto/src/main/kotlin/misk/crypto/KeyManager.kt
+++ b/misk-crypto/src/main/kotlin/misk/crypto/KeyManager.kt
@@ -1,6 +1,7 @@
 package misk.crypto
 
 import com.google.crypto.tink.Aead
+import com.google.crypto.tink.DeterministicAead
 import com.google.crypto.tink.Mac
 import com.google.crypto.tink.PublicKeySign
 import com.google.crypto.tink.PublicKeyVerify
@@ -52,6 +53,24 @@ sealed class MappedKeyManager<KeyT> constructor(
 class AeadKeyManager @Inject internal constructor(
   injector: Injector
 ) : MappedKeyManager<Aead>(injector, Aead::class.java)
+
+/**
+ * Holds a map of every [DeterministicAead] key name to its primitive listed in the configuration for this app.
+ * Users may use this object to obtain an [DeterministicAead] dynamically:
+ *
+ * ```
+ * val myKey: DeterministicAead = deterministicAeadKeyManager["myKey"]
+ * ```
+ *
+ * Note, that DeterministicAead objects do not provide secrecy to the same level as AEAD do, since
+ * multiple plaintexts encrypted with the same key will produce identical ciphertext. This behavior
+ * is desirable when querying data via its ciphertext (i.e. equality will hold), but an attacker can
+ * detect repeated plaintexts.
+ */
+@Singleton
+class DeterministicAeadKeyManager @Inject internal constructor(
+  injector: Injector
+) : MappedKeyManager<DeterministicAead>(injector, DeterministicAead::class.java)
 
 /**
  * Holds a map of every [Mac] key name to its primitive listed in the configuration for this app.

--- a/misk-crypto/src/main/kotlin/misk/crypto/KeyProviders.kt
+++ b/misk-crypto/src/main/kotlin/misk/crypto/KeyProviders.kt
@@ -2,6 +2,7 @@ package misk.crypto
 
 import com.google.crypto.tink.Aead
 import com.google.crypto.tink.CleartextKeysetHandle
+import com.google.crypto.tink.DeterministicAead
 import com.google.crypto.tink.KmsClient
 import com.google.crypto.tink.Mac
 import com.google.crypto.tink.PublicKeySign
@@ -15,6 +16,7 @@ import com.google.crypto.tink.KeysetHandle
 import com.google.crypto.tink.aead.AeadFactory
 import com.google.crypto.tink.aead.AeadKeyTemplates
 import com.google.crypto.tink.aead.KmsEnvelopeAead
+import com.google.crypto.tink.daead.DeterministicAeadFactory
 import com.google.inject.Inject
 import com.google.inject.Provider
 import misk.logging.getLogger
@@ -38,6 +40,18 @@ internal class AeadEnvelopeProvider(val key: Key, val kmsUri: String?) : Provide
 
   companion object {
     val DEK_TEMPLATE: KeyTemplate = AeadKeyTemplates.AES128_GCM
+  }
+}
+
+internal class DeterministicAeadProvider(val key: Key, val kmsUri: String?) : Provider<DeterministicAead> {
+  @Inject lateinit var keyManager: DeterministicAeadKeyManager
+  @Inject lateinit var kmsClient: KmsClient
+
+  override fun get(): DeterministicAead {
+    val keysetHandle = readKey(key, kmsUri, kmsClient)
+    val daeadKey = DeterministicAeadFactory.getPrimitive(keysetHandle)
+
+    return daeadKey.also { keyManager[key.key_name] = it }
   }
 }
 

--- a/misk-hibernate/src/main/kotlin/misk/hibernate/SecretColumn.kt
+++ b/misk-hibernate/src/main/kotlin/misk/hibernate/SecretColumn.kt
@@ -25,12 +25,17 @@ package misk.hibernate
  *   id BIGINT NOT NULL AUTO_INCREMENT,
  *   secret VARBINARY(500)
  * ```
- * - It cannot be a part of an index
  * - It cannot be annotates with any other custom column annotations like [ProtoColumn] or [JsonColumn].
  *
- * *Note*: the resulting ciphertext that is persisted in the database may be much larger in size
- * than the original plaintext because it also contains some metadata.
- * Please make sure to allocate enough space when defining the column using `VARBINARY()`.
+ * *Note*:
+ *
+ *  1. the resulting ciphertext that is persisted in the database may be much larger in size than
+ *     the original plaintext because it also contains some metadata. Please make sure to allocate
+ *     enough space when defining the column using `VARBINARY()`.
+ *
+ *  2. SecretColumn uses deterministic encryption. This means that multiple plaintexts encrypted
+ *     with the same key will result in identical ciphertext. This does not preserve secrecy, but
+ *     does permit searching for encrypted values.
  */
 @Target(AnnotationTarget.FIELD)
 annotation class SecretColumn(val keyName: String)

--- a/misk-hibernate/src/main/kotlin/misk/hibernate/SecretColumn.kt
+++ b/misk-hibernate/src/main/kotlin/misk/hibernate/SecretColumn.kt
@@ -1,7 +1,7 @@
 package misk.hibernate
 
 /**
- * [SecretColumn] is an annotation used to get Hibernate to encrypt a field before writing it  to the database.
+ * [SecretColumn] is an annotation used to get Hibernate to encrypt a field before writing it to the database.
  *
  * The [keyName] string is used to specify the name of the key to be used to encrypt and decrypt the value.
  *
@@ -35,9 +35,9 @@ package misk.hibernate
  *
  * *Note*:
  *
- *  1. the resulting ciphertext that is persisted in the database may be much larger in size than
- *     the original plaintext because it also contains some metadata. Please make sure to allocate
- *     enough space when defining the column using `VARBINARY()`.
+ *  The resulting ciphertext that is persisted in the database may be much larger in size than
+ *  the original plaintext because it also contains some metadata. Please make sure to allocate
+ *  enough space when defining the column using `VARBINARY()`.
  *
  */
 @Target(AnnotationTarget.FIELD)

--- a/misk-hibernate/src/main/kotlin/misk/hibernate/SecretColumn.kt
+++ b/misk-hibernate/src/main/kotlin/misk/hibernate/SecretColumn.kt
@@ -1,9 +1,15 @@
 package misk.hibernate
 
 /**
- * [SecretColumn] is an annotation used to get Hibernate to encrypt a field before writing it
- * to the database.
+ * [SecretColumn] is an annotation used to get Hibernate to encrypt a field before writing it  to the database.
+ *
  * The [keyName] string is used to specify the name of the key to be used to encrypt and decrypt the value.
+ *
+ * The [indexable] attribute controls whether or not this data will be able to be indexed, defaulted to true. This
+ * uses deterministic encryption: encrypting the same plaintext will produce the same ciphertext. This is weaker than
+ * non-deterministic encryption, but makes searching for encrypted values possible. If searching for ciphertexts is
+ * not something your use case requires, set [indexable] to false for stronger security.
+ *
  * Install [misk.crypto.CryptoModule] to configure the keys the app uses.
  * Example:
  * In app-common.yaml:
@@ -33,10 +39,7 @@ package misk.hibernate
  *     the original plaintext because it also contains some metadata. Please make sure to allocate
  *     enough space when defining the column using `VARBINARY()`.
  *
- *  2. SecretColumn uses deterministic encryption. This means that multiple plaintexts encrypted
- *     with the same key will result in identical ciphertext. This does not preserve secrecy, but
- *     does permit searching for encrypted values.
  */
 @Target(AnnotationTarget.FIELD)
-annotation class SecretColumn(val keyName: String)
+annotation class SecretColumn(val keyName: String, val indexable: Boolean = true)
 

--- a/misk-hibernate/src/main/kotlin/misk/hibernate/SecretColumnType.kt
+++ b/misk-hibernate/src/main/kotlin/misk/hibernate/SecretColumnType.kt
@@ -138,9 +138,8 @@ internal class DeterministicAeadAdapter(typeConfig: TypeConfiguration, keyName: 
     }
   }
 
-  // DeterministicAEAD throws if associatedData is null, so we pass an empty array if it is.
-
   override fun encrypt(plaintext: ByteArray, associatedData: ByteArray?) : ByteArray {
+    // DeterministicAEAD throws if associatedData is null, so we pass an empty array if it is.
     return daead.encryptDeterministically(plaintext, associatedData ?: byteArrayOf())
   }
 
@@ -148,4 +147,3 @@ internal class DeterministicAeadAdapter(typeConfig: TypeConfiguration, keyName: 
     return daead.decryptDeterministically(ciphertext, associatedData ?: byteArrayOf())
   }
 }
-

--- a/misk-hibernate/src/main/kotlin/misk/hibernate/SessionFactoryService.kt
+++ b/misk-hibernate/src/main/kotlin/misk/hibernate/SessionFactoryService.kt
@@ -170,6 +170,8 @@ internal class SessionFactoryService(
       }
       value.typeParameters.setProperty(SecretColumnType.FIELD_ENCRYPTION_KEY_NAME,
           field.getAnnotation(SecretColumn::class.java).keyName)
+      value.typeParameters.setProperty(SecretColumnType.FIELD_ENCRYPTION_INDEXABLE,
+          field.getAnnotation(SecretColumn::class.java).indexable.toString())
     }
   }
 

--- a/misk-hibernate/src/test/kotlin/misk/hibernate/SecretColumnTest.kt
+++ b/misk-hibernate/src/test/kotlin/misk/hibernate/SecretColumnTest.kt
@@ -201,9 +201,9 @@ class SecretColumnTest {
   fun testEncryptedIndxedQueryMultiple() {
     val reviewer = "Some Reviewer".toByteArray()
     transacter.transaction { session ->
-        session.save(DbJerryGarciaSong("title 1", 123, "album".toByteArray(), reviewer))
-        session.save(DbJerryGarciaSong("title 2", 124, "another album".toByteArray(), reviewer))
-        session.save(DbJerryGarciaSong("title 3", 125, "yet another".toByteArray(), reviewer))
+        session.save(DbJerryGarciaSong("Sugaree", 123, "Steal Your Face".toByteArray(), reviewer))
+        session.save(DbJerryGarciaSong("Truckin'", 124, "American Beauty".toByteArray(), reviewer))
+        session.save(DbJerryGarciaSong("Eyes of the World", 125, "Wake of the Flood".toByteArray(), reviewer))
 
         val songs = queryFactory.newQuery<JerryGarciaSongQuery>()
                 .reviewer(reviewer)

--- a/misk-hibernate/src/test/resources/encryptedcolumn-common.yaml
+++ b/misk-hibernate/src/test/resources/encryptedcolumn-common.yaml
@@ -10,3 +10,6 @@ crypto:
     - key_name: albumKey
       key_type: AEAD
       encrypted_key: "classpath:/secrets/albumKey.txt"
+    - key_name: reviewerKey
+      key_type: DAEAD
+      encrypted_key: "classpath:/secrets/reviewerKey.txt"

--- a/misk-hibernate/src/test/resources/misk/hibernate/encryptedcolumn-migrations/v1__create_table.sql
+++ b/misk-hibernate/src/test/resources/misk/hibernate/encryptedcolumn-migrations/v1__create_table.sql
@@ -2,5 +2,6 @@ CREATE TABLE jerry_garcia_songs(
   id BIGINT NOT NULL PRIMARY KEY AUTO_INCREMENT,
   title VARCHAR(64) NOT NULL,
   length INT NOT NULL,
-  album VARBINARY(250)
+  album VARBINARY(250),
+  reviewer VARBINARY(250)
 )

--- a/misk-hibernate/src/test/resources/secrets/reviewerKey.txt
+++ b/misk-hibernate/src/test/resources/secrets/reviewerKey.txt
@@ -1,0 +1,13 @@
+{
+    "primaryKeyId": 442722984,
+    "key": [{
+        "keyData": {
+            "typeUrl": "type.googleapis.com/google.crypto.tink.AesSivKey",
+            "keyMaterialType": "SYMMETRIC",
+            "value": "EkA4BnizgcudU5HRWv/h/SgaW87hge7zli+UgiNqucaKTNRv72Idx8MBgLXetljPWFTyW0Q4ogOwWFuyzJOXNhv+"
+        },
+        "outputPrefixType": "TINK",
+        "keyId": 442722984,
+        "status": "ENABLED"
+    }]
+}


### PR DESCRIPTION
This PR updates `SecretColumn` to:
 1. Encrypt its values with Deterministic AEAD by default. This sacrifices semantic security for improved usability. Using DAEAD implies that multiple identical plaintexts will encrypt to identical ciphertexts. This makes encrypted rows queryable, but leaks some information about ciphertexts. 
 2. Accept a parameter to the attribute (`indexable`) that a user can set to `false` to enable use of non-deterministic AEAD. This attribute is defaulted to `true` for usability.