### PR TITLE
Revert "Upgrade to the latest publish plugin"

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ buildscript {
 
 plugins {
   id "org.jetbrains.kotlin.jvm" version "1.3.21" apply false
-  id "com.vanniktech.maven.publish" version "0.8.0" apply false
+  id "com.vanniktech.maven.publish" version "0.4.0" apply false
   id 'com.gradle.build-scan' version "2.1"
 }
 


### PR DESCRIPTION
This reverts commit f0856c237a3ec1914e9b6d553cc6be950ca59d92.
Fix for broader Misk ecosystem later this week will restore the plugin bump.