### PR TITLE
ServiceGraphBuilder

### DIFF
--- a/misk/src/main/kotlin/misk/CoordinatedService2.kt
+++ b/misk/src/main/kotlin/misk/CoordinatedService2.kt
@@ -4,54 +4,26 @@ import com.google.common.util.concurrent.AbstractService
 import com.google.common.util.concurrent.MoreExecutors
 import com.google.common.util.concurrent.Service
 import com.google.common.util.concurrent.Service.*
-import misk.CoordinatedService2.Companion.CycleValidity
 
+/**
+ * CoordinatedService2 wraps a Service to defer its start up and shut down until its dependent
+ * services are ready.
+ *
+ * This Service will stall in the `STARTING` state until all upstream services are `RUNNING`.
+ * Symmetrically it stalls in the `STOPPING` state until all dependent services are `TERMINATED`.
+ *
+ * This Service may be "enhanced" by other services. That is to say that if there exists a
+ * complementary service that is dependent on this service, it will be started after this service
+ * starts, and stopped after this service stops. Information about this service's enhancements is
+ * hidden from its dependent services.
+ *
+ * @param service The Service to wrap.
+ */
 internal class CoordinatedService2(val service: Service) : AbstractService() {
-  val upstream = mutableSetOf<CoordinatedService2>()      // upstream services dependent on me
-  val downstream = mutableSetOf<CoordinatedService2>()    // downstream dependencies
-  val enhancements = mutableSetOf<CoordinatedService2>()  // services that enhance me (depend on me)
-  var target: CoordinatedService2? = null                 // service I enhance
-
-  fun getServicesThatINeed(): Set<CoordinatedService2> {
-    // target
-    // upstream providers
-    val neededServices = mutableSetOf<CoordinatedService2>()
-    if (target != null) {
-      neededServices.add(target!!)
-    }
-    for (provider in upstream) {
-      neededServices.add(provider)
-      neededServices.addAll(provider.getTransitiveEnhancements())
-    }
-    return neededServices
-  }
-
-  // obtains all dependencies and enhancements (and their dependencies and enhancements)
-  // for this service
-  fun getServicesThatNeedMe(): Set<CoordinatedService2> {
-    // my enhancements
-    // my target's dependencies
-    // my target's target's dependencies
-    // etc.
-
-    val needsMe = mutableSetOf<CoordinatedService2>()
-    needsMe.addAll(enhancements)
-    var t: CoordinatedService2? = this
-    while (t != null) {
-      needsMe.addAll(t.downstream)
-      t = t.target
-    }
-    return needsMe
-  }
-
-  private fun getTransitiveEnhancements() : Set<CoordinatedService2> {
-    val list = mutableSetOf<CoordinatedService2>()
-    list.addAll(enhancements)
-    for (enhancement in enhancements) {
-      list.addAll(enhancement.getTransitiveEnhancements())
-    }
-    return list
-  }
+  private val upstream = mutableSetOf<CoordinatedService2>()      // upstream services dependent on me
+  private val downstream = mutableSetOf<CoordinatedService2>()    // downstream dependencies
+  private val enhancements = mutableSetOf<CoordinatedService2>()  // services that enhance me (depend on me)
+  private var target: CoordinatedService2? = null                 // service I enhance
 
   init {
     service.addListener(object : Listener() {
@@ -59,14 +31,14 @@ internal class CoordinatedService2(val service: Service) : AbstractService() {
         synchronized(this) {
           notifyStarted()
         }
-        getServicesThatNeedMe().forEach { it.startIfReady() }
+        getReliantServices().forEach { it.startIfReady() }
       }
 
       override fun terminated(from: State?) {
         synchronized(this) {
           notifyStopped()
         }
-        getServicesThatINeed().forEach { it.stopIfReady() }
+        getRequiredServices().forEach { it.stopIfReady() }
       }
 
       override fun failed(from: State, failure: Throwable) {
@@ -75,16 +47,85 @@ internal class CoordinatedService2(val service: Service) : AbstractService() {
     }, MoreExecutors.directExecutor())
   }
 
+  /**
+   * Returns a set of services that are required by this service.
+   *
+   * This set consists of the target, all first-level dependencies and each dependency's transitive
+   * enhancements. This is the set of services that block start-up of this service.
+   */
+  fun getRequiredServices(): Set<CoordinatedService2> {
+    val requiredServices = mutableSetOf<CoordinatedService2>()
+    if (target != null) {
+      requiredServices.add(target!!)
+    }
+    for (provider in upstream) {
+      requiredServices.add(provider)
+      requiredServices.addAll(provider.getTransitiveEnhancements())
+    }
+    return requiredServices
+  }
+
+  /**
+   * Returns a set of all services which rely on this service.
+   *
+   * This set consists of this service's enhancements, and the entire chain of its target's
+   * downstream dependencies. This is the set of services that block shut-down of this service.
+   */
+  // for this service
+  fun getReliantServices(): Set<CoordinatedService2> {
+    val reliantServices = mutableSetOf<CoordinatedService2>()
+    reliantServices.addAll(enhancements)
+    var t: CoordinatedService2? = this
+    while (t != null) {
+      reliantServices.addAll(t.downstream)
+      t = t.target
+    }
+    return reliantServices
+  }
+
+  // Recursively obtains all enhancements of a service.
+  private fun getTransitiveEnhancements(): Set<CoordinatedService2> {
+    val list = mutableSetOf<CoordinatedService2>()
+    list.addAll(enhancements)
+    for (enhancement in enhancements) {
+      list.addAll(enhancement.getTransitiveEnhancements())
+    }
+    return list
+  }
+
+  /**
+   * Adds the provided list of services as dependents downstream.
+   *
+   * @param services List of dependencies for this service.
+   */
+  fun addToDownstream(services: List<CoordinatedService2>) {
+    // Satisfy all consumers with a producer (maintain bi-directional links up/down-stream)
+    downstream.addAll(services)
+    services.forEach { it.upstream.add(this) }
+  }
+
+  /**
+   * Adds indicated services as "enhancements" to this service.
+   *
+   * Enhancements will start after the coordinated service is running, and stop before it stops.
+   *
+   * @param services List of "enhancements" for this service.
+   */
+  fun enhanceWith(services: List<CoordinatedService2>) {
+    enhancements.addAll(services)
+    services.forEach { it.target = this }
+  }
+
   private fun isTerminated(): Boolean {
     return state() == State.TERMINATED
   }
 
   private fun canStart(): Boolean {
-    return getServicesThatINeed().all { it.isRunning() }
+    return getRequiredServices().all { it.isRunning() }
   }
 
   private fun canStop(): Boolean {
-    return getServicesThatNeedMe().all { it.isTerminated() }
+    return getReliantServices().all { it.isTerminated() }
   }
 
   fun isUpstreamRunning(): Boolean = upstream.all { it.isRunningWithEnhancements() }
@@ -126,79 +167,49 @@ internal class CoordinatedService2(val service: Service) : AbstractService() {
   override fun toString() = service.toString()
 
   /**
-   * Adds the provided list of services as dependents downstream.
-   */
-  fun addToDownstream(services: List<CoordinatedService2>) {
-    // Satisfy all consumers with a producer (maintain bi-directional links up/down-stream)
-    downstream.addAll(services)
-    services.forEach { it.upstream.add(this) }
-  }
-
-  /**
-   * Adds indicated services as "enhancements" to this service.
+   * Traverses the dependency/enhancement graph to detect cycles. If a cycle is found, then a
+   * list of services that forms this cycle is returned.
    *
-   * Enhancements will start after the coordinated service is running, and stop before it stops.
+   * @param validityMap: A map that is used to track traversal of this service's dependency graph.
    */
-  fun enhanceWith(services: List<CoordinatedService2>) {
-    enhancements.addAll(services)
-    services.forEach { it.target = this }
+  fun findCycle(
+    validityMap: MutableMap<CoordinatedService2, CycleValidity>
+  ): MutableList<CoordinatedService2>? {
+    when (validityMap[this]) {
+      CycleValidity.NO_CYCLES -> return null // We checked this node already.
+      CycleValidity.CHECKING_FOR_CYCLES -> return mutableListOf(this) // We found a cycle!
+      else -> {
+        validityMap[this] = CycleValidity.CHECKING_FOR_CYCLES
+        // first check there are no cycles in the enhancements that could cause
+        // getReliantServices() to get stuck
+        for (enhancement in enhancements) {
+          val cycle = enhancement.findCycle(validityMap)
+          if (cycle != null) {
+            cycle.add(this)
+            return cycle
+          }
+        }
+        // now check that there are no mixed enhancement-dependency cycles
+        for (dependency in getReliantServices()) {
+          val cycle = dependency.findCycle(validityMap)
+          if (cycle != null) {
+            cycle.add(this)
+            return cycle
+          }
+        }
+        validityMap[this] = CycleValidity.NO_CYCLES
+        return null
+      }
+    }
   }
-
-  /**
-   * Checks for dependency cycles and throws if one is detected.
-   */
-//  fun requireNoCycles() {
-//    val validityMap = mutableMapOf<CoordinatedService2, CycleValidity>()
-//    val cycle = this.findCycle(validityMap)
-//    if (cycle != null) {
-//      throw IllegalStateException("Detected cycle: ${cycle.joinToString(" -> ")}")
-//    }
-//  }
 
   companion object {
+    /**
+     * CycleValidity provides states used to track dependency graph traversal and cycle detection.
+     */
     enum class CycleValidity {
-      UNKNOWN,
       CHECKING_FOR_CYCLES,
       NO_CYCLES,
-    }
-
-    /**
-     * Returns the elements of a dependency cycle, or null if there are no cycles originating at
-     * a given node.
-     */
-    fun CoordinatedService2.findCycle(
-      validityMap: MutableMap<CoordinatedService2, CycleValidity>
-    ): MutableList<CoordinatedService2>? {
-      when (validityMap[this]) {
-        CycleValidity.NO_CYCLES -> return null // We checked this node already.
-        CycleValidity.CHECKING_FOR_CYCLES -> return mutableListOf(this) // We found a cycle!
-        else -> {
-          validityMap[this] = CycleValidity.CHECKING_FOR_CYCLES
-//          if (target != null) {
-//            val cycle = target!!.findCycle(validityMap)
-//            if (cycle != null) {
-//              cycle.add(this)
-//              return cycle
-//            }
-//          }
-          for (enhancement in enhancements) {
-            val cycle = enhancement.findCycle(validityMap)
-            if (cycle != null) {
-              cycle.add(this)
-              return cycle
-            }
-          }
-          for (dependency in getServicesThatNeedMe()) {
-            val cycle = dependency.findCycle(validityMap)
-            if (cycle != null) {
-              cycle.add(this)
-              return cycle
-            }
-          }
-          validityMap[this] = CycleValidity.NO_CYCLES
-          return null
-        }
-      }
     }
   }
 }

--- a/misk/src/main/kotlin/misk/CoordinatedService2.kt
+++ b/misk/src/main/kotlin/misk/CoordinatedService2.kt
@@ -137,7 +137,7 @@ internal class CoordinatedService2(val service: Service) : AbstractService() {
   }
 
   /** Adds [services] as dependents downstream. */
-  fun addDependencies(services: List<CoordinatedService2>) {
+  fun addDependencies(vararg services: CoordinatedService2) {
     directDependencies += services
     services.forEach { it.directDependsOn += this }
   }
@@ -146,7 +146,7 @@ internal class CoordinatedService2(val service: Service) : AbstractService() {
    * Adds [services] as enhancements to this service. Enhancements will start after the coordinated
    * service is running, and stop before it stops.
    */
-  fun addEnhancements(services: List<CoordinatedService2>) {
+  fun addEnhancements(vararg services: CoordinatedService2) {
     enhancements.addAll(services)
     services.forEach { it.enhancementTarget = this }
   }

--- a/misk/src/main/kotlin/misk/CoordinatedService2.kt
+++ b/misk/src/main/kotlin/misk/CoordinatedService2.kt
@@ -14,7 +14,6 @@ internal class CoordinatedService2(val service: Service) : AbstractService() {
   init {
     service.addListener(object : Listener() {
       override fun running() {
-        println("$service is running!")
         synchronized(this) {
           notifyStarted()
         }
@@ -22,8 +21,6 @@ internal class CoordinatedService2(val service: Service) : AbstractService() {
       }
 
       override fun terminated(from: State?) {
-        println("$service is stopping!")
-
         synchronized(this) {
           notifyStopped()
         }
@@ -140,17 +137,12 @@ internal class CoordinatedService2(val service: Service) : AbstractService() {
    * Checks for dependency cycles and throws if one is detected.
    */
   fun requireNoCycles() {
-    val errors = mutableListOf<String>()
     val validityMap = mutableMapOf<CoordinatedService2, CycleValidity>()
     for (service in this.downstream) {
       val cycle = service.findCycle(validityMap)
       if (cycle != null) {
-        errors.add("dependency cycle: ${cycle.joinToString("->")}")
-        break
+        throw IllegalStateException("Dependency cycle: ${cycle.joinToString(" -> ")}")
       }
-    }
-    require(errors.isEmpty()) {
-      "Service dependency graph has problems:\n  ${errors.joinToString("\n  ")}"
     }
   }
 

--- a/misk/src/main/kotlin/misk/CoordinatedService2.kt
+++ b/misk/src/main/kotlin/misk/CoordinatedService2.kt
@@ -1,0 +1,164 @@
+package misk
+
+import com.google.common.util.concurrent.AbstractService
+import com.google.common.util.concurrent.MoreExecutors
+import com.google.common.util.concurrent.Service
+import com.google.common.util.concurrent.Service.*
+
+internal class CoordinatedService2(val service: Service) : AbstractService() {
+  val upstream = mutableSetOf<CoordinatedService2>()   // upstream services dependent on me
+  val downstream = mutableSetOf<CoordinatedService2>() // downstream dependencies
+  val enhancements = mutableSetOf<CoordinatedService2>()
+
+  init {
+    service.addListener(object : Listener() {
+      override fun running() {
+        println("$service is running!")
+        synchronized(this) {
+          notifyStarted()
+        }
+        for (service in downstream) {
+          service.startIfReady()
+        }
+      }
+
+      override fun terminated(from: State?) {
+        synchronized(this) {
+          notifyStopped()
+        }
+        for (service in upstream) {
+          service.stopIfReady()
+        }
+      }
+
+      override fun failed(from: State, failure: Throwable) {
+        notifyFailed(failure)
+      }
+    }, MoreExecutors.directExecutor())
+  }
+
+  val isUpstreamRunning: Boolean
+    get() = upstream.none { it.state() == State.RUNNING }
+
+  val isDownstreamTerminated: Boolean
+    get() = downstream.none { it.state() == State.TERMINATED }
+
+  val enhancementsAreRunning: Boolean get() = TODO()
+
+  val enhancementsAreTerminated: Boolean get() = TODO()
+
+  override fun doStart() {
+    startIfReady()
+  }
+
+  fun startIfReady() {
+    synchronized(this) {
+      if (state() != State.STARTING || service.state() != State.NEW) return
+
+      // Make sure upstream is ready for us to start.
+      if (!isUpstreamRunning) return
+
+      // Actually start.
+      service.startAsync()
+    }
+  }
+
+  override fun doStop() {
+    stopIfReady()
+  }
+
+  fun stopIfReady() {
+    synchronized(this) {
+      if (state() != State.STOPPING || service.state() != State.RUNNING) return
+
+      // Make sure downstream is ready for us to stop.
+      if (!isDownstreamTerminated) return
+
+      // Actually stop.
+      service.stopAsync()
+    }
+  }
+
+  override fun toString() = service.toString()
+
+  /**
+   * Adds the provided list of services as dependents downstream.
+   */
+  fun addToDownstream(services: List<CoordinatedService2>) {
+    // Satisfy all consumers with a producer (maintain bi-directional links up/down-stream)
+    downstream.addAll(services)
+    services.forEach { it.upstream.add(this) }
+  }
+
+  /**
+   * Adds the provided list of services as producers upstream.
+   *
+   * I am not sure if this is useful to have?
+   */
+  fun addToUpstream(services: List<CoordinatedService2>) {
+    // Satisfy all producers with this consumer
+    upstream.addAll(services)
+    services.forEach { it.downstream.add(this) }
+  }
+
+  /**
+   * Adds indicated services as "enhancements" to this service.
+   *
+   * Enhancements will start after the coordinated service is running, and stop before it stops.
+   */
+  fun enhanceWith(services: List<CoordinatedService2>) {
+    enhancements.addAll(services)
+    services.forEach { it.addToDownstream(listOf(this)) }
+  }
+
+  /**
+   * Checks for dependency cycles and throws if one is detected.
+   */
+  fun requireNoCycles() {
+    val errors = mutableListOf<String>()
+    val validityMap = mutableMapOf<CoordinatedService2, CycleValidity>()
+    for (service in this.downstream) {
+      val cycle = service.findCycle(validityMap)
+      if (cycle != null) {
+        errors.add("dependency cycle: ${cycle.joinToString("->")}")
+        break
+      }
+    }
+    require(errors.isEmpty()) {
+      "Service dependency graph has problems:\n  ${errors.joinToString("\n  ")}"
+    }
+  }
+
+  companion object {
+    enum class CycleValidity {
+      UNKNOWN,
+      CHECKING_FOR_CYCLES,
+      NO_CYCLES,
+    }
+
+    /**
+     * Returns the elements of a dependency cycle, or null if there are no cycles originating at
+     * a given node.
+     */
+    fun CoordinatedService2.findCycle(
+      validityMap: MutableMap<CoordinatedService2, CycleValidity>
+    ): MutableList<CoordinatedService2>? {
+      when (validityMap[this]) {
+        CycleValidity.NO_CYCLES -> return null // We checked this node already.
+        CycleValidity.CHECKING_FOR_CYCLES -> return mutableListOf(this) // We found a cycle!
+        else -> {
+          validityMap[this] = CycleValidity.CHECKING_FOR_CYCLES
+          for (service in downstream) {
+            val cycle = service.findCycle(validityMap)
+            if (cycle != null) {
+              cycle.add(this)
+              return cycle
+            }
+          }
+          validityMap[this] = CycleValidity.NO_CYCLES
+          return null
+        }
+      }
+    }
+  }
+}

--- a/misk/src/main/kotlin/misk/CoordinatedService2.kt
+++ b/misk/src/main/kotlin/misk/CoordinatedService2.kt
@@ -181,6 +181,13 @@ internal class CoordinatedService2(val service: Service) : AbstractService() {
 //              return cycle
 //            }
 //          }
+          for (enhancement in enhancements) {
+            val cycle = enhancement.findCycle(validityMap)
+            if (cycle != null) {
+              cycle.add(this)
+              return cycle
+            }
+          }
           for (dependency in getServicesThatNeedMe()) {
             val cycle = dependency.findCycle(validityMap)
             if (cycle != null) {

--- a/misk/src/main/kotlin/misk/CoordinatedService2.kt
+++ b/misk/src/main/kotlin/misk/CoordinatedService2.kt
@@ -50,7 +50,7 @@ internal class CoordinatedService2(val service: Service) : AbstractService() {
     target?.stopIfReady()
 
     for (service in upstream) {
-      service.stopDependentServices()
+      service.stopIfReady()
     }
   }
 

--- a/misk/src/main/kotlin/misk/ServiceDependency.kt
+++ b/misk/src/main/kotlin/misk/ServiceDependency.kt
@@ -1,0 +1,4 @@
+package misk
+
+class ServiceDependency {
+}

--- a/misk/src/main/kotlin/misk/ServiceDependency.kt
+++ b/misk/src/main/kotlin/misk/ServiceDependency.kt
@@ -1,4 +1,0 @@
-package misk
-
-class ServiceDependency {
-}

--- a/misk/src/main/kotlin/misk/ServiceGraphBuilder.kt
+++ b/misk/src/main/kotlin/misk/ServiceGraphBuilder.kt
@@ -26,6 +26,7 @@ class ServiceGraphBuilder {
   /**
    * Registers a service with this ServiceGraphBuilder.
    * A service must be added first before it can have dependencies or enhancements applied.
+   * Keys must be unique. If a key is reused, then the original key-service pair will be replaced.
    */
   fun addService(key: Key<*>, service: Service) {
     serviceMap[key] = CoordinatedService2(service)
@@ -65,6 +66,7 @@ class ServiceGraphBuilder {
    */
   fun build(): ServiceManager {
     linkDependencies()
+    checkDependencies()
     return ServiceManager(serviceMap.values)
   }
 
@@ -80,6 +82,12 @@ class ServiceGraphBuilder {
       service.addToDownstream(dependencies)
       service.requireNoCycles() // throws
     }
+  }
+
+  // check that each service has its dependencies met
+  // (i.e. no one service requires a dependency that doesn't exist)
+  private fun checkDependencies() {
+
   }
 
   private fun enhanceService(key: Key<*>) {

--- a/misk/src/main/kotlin/misk/ServiceGraphBuilder.kt
+++ b/misk/src/main/kotlin/misk/ServiceGraphBuilder.kt
@@ -1,0 +1,93 @@
+package misk
+
+import com.google.common.collect.HashMultimap
+import com.google.common.collect.LinkedHashMultimap
+import com.google.common.collect.Multimap
+import com.google.common.collect.SetMultimap
+import com.google.common.util.concurrent.Service
+import com.google.common.util.concurrent.ServiceManager
+import com.google.inject.Key
+
+// MultiMap -> Map of Sets
+
+/**
+ * Builds a graph of CoordinatedService2s which defer start up and shut down until their dependent
+ * services are ready.
+ */
+class ServiceGraphBuilder {
+  internal var serviceMap = mutableMapOf<Key<*>, CoordinatedService2>() // map of all services
+  var dependencyMap = mutableMapOf<Key<*>, MutableSet<Key<*>>>()
+  var enhancementMap = mutableMapOf<Key<*>, MutableSet<Key<*>>>()
+  var dependencyGraph = mutableMapOf<Key<*>, MutableSet<Key<*>>>()
+
+//  var dependencyMultiMap = HashMultimap.create<Key<*>, Key<*>>()
+//  var enhancementMultimap = HashMultimap.create<Key<*>, Key<*>>()
+
+  /**
+   * Registers a service with this ServiceGraphBuilder.
+   * A service must be added first before it can have dependencies or enhancements applied.
+   */
+  fun addService(key: Key<*>, service: Service) {
+    serviceMap[key] = CoordinatedService2(service)
+  }
+
+  /**
+   * Adds the (small) service as a dependency to the (big) provider Service.
+   *
+   * Small depends on big.
+   */
+  fun addDependency(small: Key<*>, big: Key<*>) {
+    // maintain a set of dependents on the provider
+    if (dependencyMap[big] == null) {
+      dependencyMap[big] = mutableSetOf()
+    }
+    val dependencySet = dependencyMap[big]
+    dependencySet!!.add(small)
+  }
+
+  /**
+   * Adds a (small) enhancement to the (big) service. The (big) service depends on its enhancements.
+   *
+   * Service enhancements (small) will be started before the (big) service is started.
+   * They will be stopped before the (big) service is done.
+   */
+  fun addEnhancement(big: Key<*>, small: Key<*>) {
+    // maintain enhancements to be applied to services
+    if (enhancementMap[big] == null) {
+      enhancementMap[big] = mutableSetOf()
+    }
+    val enhancementSet = enhancementMap[big]
+    enhancementSet!!.add(small)
+  }
+
+  /**
+   * Builds a service manager.
+   */
+  fun build(): ServiceManager {
+    linkDependencies()
+    return ServiceManager(serviceMap.values)
+  }
+
+  // builds coordinated services from the instructions provided in the dependency map
+  private fun linkDependencies() {
+    // for each service, add its dependencies and ensure no dependency cycles
+    for ((key, service) in serviceMap) {
+      // first get the enhancements for the service and handle their downstreams
+      enhanceService(key)
+      // now handle regular dependencies
+      val dependencies = dependencyMap[key]?.map { serviceMap[it]!! } ?: listOf()
+
+      service.addToDownstream(dependencies)
+      service.requireNoCycles() // throws
+    }
+  }
+
+  private fun enhanceService(key: Key<*>) {
+    val service = serviceMap[key]!!
+    val enhancements = enhancementMap[key]?.map { serviceMap[it]!! } ?: listOf()
+    // enhancements will have their service to be enhanced downstream
+    enhancements.forEach { it.addToDownstream(listOf(service)) }
+    // any dependents of the enhanced service must depend on enhancers
+    service.downstream.forEach { it.addToDownstream(enhancements) }
+  }
+}

--- a/misk/src/main/kotlin/misk/ServiceGraphBuilder.kt
+++ b/misk/src/main/kotlin/misk/ServiceGraphBuilder.kt
@@ -7,6 +7,7 @@ import com.google.common.collect.SetMultimap
 import com.google.common.util.concurrent.Service
 import com.google.common.util.concurrent.ServiceManager
 import com.google.inject.Key
+import misk.CoordinatedService2.Companion.findCycle
 import java.lang.IllegalStateException
 
 /**
@@ -89,8 +90,14 @@ class ServiceGraphBuilder {
   }
 
   private fun checkCycles() {
+    val validityMap =
+        mutableMapOf<CoordinatedService2, CoordinatedService2.Companion.CycleValidity>()
+
     for ((_, service) in serviceMap) {
-      service.requireNoCycles() // throws
+      val cycle = service.findCycle(validityMap)
+      if (cycle != null) {
+        throw IllegalStateException("Detected cycle: ${cycle.joinToString(" -> ")}")
+      }
     }
   }
 

--- a/misk/src/main/kotlin/misk/ServiceGraphBuilder.kt
+++ b/misk/src/main/kotlin/misk/ServiceGraphBuilder.kt
@@ -61,10 +61,10 @@ class ServiceGraphBuilder {
   }
 
   /**
-   * Validates the Service Graph then builds a ServiceManager.
+   * Validates the Service Graph is a valid DAG, then builds a ServiceManager.
    *
-   * @return ServiceManager coordinating all the services that were registered with this builder.
-   * @throws IllegalStateException
+   * @return ServiceManager that coordinates all services that were registered with this builder.
+   * @throws IllegalStateException if the graph is not valid.
    */
   fun build(): ServiceManager {
     check(serviceMap.isNotEmpty()) {
@@ -79,13 +79,13 @@ class ServiceGraphBuilder {
 
   // Builds CoordinatedServices from the instructions provided in the dependency map.
   private fun linkDependencies() {
-    // for each service, add its dependencies and ensure no dependency cycles
+    // For each service, add its dependencies and ensure no dependency cycles.
     for ((key, service) in serviceMap) {
-      // first get the enhancements for the service and handle their downstream dependencies
+      // First get the enhancements for the service and handle their downstream dependencies.
       val enhancements = enhancementMap[key]?.map { serviceMap[it]!! } ?: listOf()
       service.enhanceWith(enhancements)
 
-      // now handle regular dependencies
+      // Now handle regular dependencies.
       val dependencies = dependencyMap[key]?.map { serviceMap[it]!! } ?: listOf()
       service.addToDownstream(dependencies)
     }

--- a/misk/src/test/kotlin/misk/CoordinatedService2Test.kt
+++ b/misk/src/test/kotlin/misk/CoordinatedService2Test.kt
@@ -1,0 +1,39 @@
+package misk
+
+import misk.ServiceGraphBuilderTest.AppendingService
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.lang.IllegalStateException
+import kotlin.test.assertFailsWith
+
+
+class CoordinatedService2Test {
+  @Test fun cannotAddRunningServiceAsDependency() {
+    val target = StringBuilder()
+    val runningService = CoordinatedService2(AppendingService(target, "I will be running"))
+    val newService = CoordinatedService2(AppendingService(target, "I will not run"))
+
+    runningService.startAsync()
+
+    assertFailsWith<IllegalStateException> {
+      newService.addDependencies(runningService)
+    }
+    assertFailsWith<IllegalStateException> {
+      newService.addDependencies(runningService)
+    }
+
+    runningService.stopAsync()
+  }
+
+  @Test fun cannotWrapRunningService() {
+    val target = StringBuilder()
+    val service = AppendingService(target, "Running Service")
+    service.startAsync()
+
+    val failure = assertFailsWith<IllegalStateException> { CoordinatedService2(service) }
+    assertThat(failure).hasMessage("Running Service must be NEW for it to be coordinated")
+
+    service.stopAsync()
+  }
+
+}

--- a/misk/src/test/kotlin/misk/ServiceGraphBuilderTest.kt
+++ b/misk/src/test/kotlin/misk/ServiceGraphBuilderTest.kt
@@ -6,6 +6,7 @@ import com.google.inject.Key
 import com.google.inject.name.Names
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import kotlin.test.assertFailsWith
 
 class ServiceGraphBuilderTest {
 
@@ -79,7 +80,148 @@ class ServiceGraphBuilderTest {
         |""".trimMargin())
   }
 
-  fun key(name: String): Key<*> = Key.get(Service::class.java, Names.named(name))
+  @Test fun chainsOfDependencies() {
+    val target = StringBuilder()
+
+    val a = AppendingService(target, "Service A")
+    val b = AppendingService(target, "Service B")
+    val c = AppendingService(target, "Service C")
+    val d = AppendingService(target, "Service D")
+    val e = AppendingService(target, "Service E")
+
+    val keyA = key("a")
+    val keyB = key("b")
+    val keyC = key("c")
+    val keyD = key("d")
+    val keyE = key("e")
+
+    val builder = ServiceGraphBuilder()
+    builder.addService(keyA, a)
+    builder.addService(keyB, b)
+    builder.addService(keyC, c)
+    builder.addService(keyD, d)
+    builder.addService(keyE, e)
+
+    builder.addDependency(keyB, keyC)
+    builder.addDependency(keyC, keyA)
+    builder.addDependency(keyD, keyB)
+    builder.addDependency(keyE, keyD)
+
+    val serviceManager = builder.build()
+    serviceManager.startAsync()
+    serviceManager.awaitHealthy()
+    target.append("healthy\n")
+    serviceManager.stopAsync()
+    serviceManager.awaitStopped()
+
+    assertThat(target.toString()).isEqualTo("""
+        |starting Service A
+        |starting Service C
+        |starting Service B
+        |starting Service D
+        |starting Service E
+        |healthy
+        |stopping Service E
+        |stopping Service D
+        |stopping Service B
+        |stopping Service C
+        |stopping Service A
+        |""".trimMargin())
+  }
+
+  @Test fun treesOfDependencies() {
+    TODO()
+//    val target = StringBuilder()
+//
+//    val a = CoordinatedServiceTest.AppendingService(target, "Service A", produced = setOf("a"),
+//        consumed = setOf())
+//    val b = CoordinatedServiceTest.AppendingService(target, "Service B", produced = setOf("b"),
+//        consumed = setOf())
+//    val c = CoordinatedServiceTest.AppendingService(target, "Service C", produced = setOf("c"),
+//        consumed = setOf("a", "b"))
+//    val d = CoordinatedServiceTest.AppendingService(target, "Service D", produced = setOf("d"),
+//        consumed = setOf("c", "e"))
+//    val e = CoordinatedServiceTest.AppendingService(target, "Service E", produced = setOf("e"),
+//        consumed = setOf("a", "c"))
+//
+//    val serviceManager = CoordinatedService.coordinate(listOf(a, b, c, d, e))
+//    serviceManager.startAsync()
+//    serviceManager.awaitHealthy()
+//    target.append("healthy\n")
+//    serviceManager.stopAsync()
+//    serviceManager.awaitStopped()
+//
+//    assertThat(target.toString()).isEqualTo("""
+//        |starting Service A
+//        |starting Service B
+//        |starting Service C
+//        |starting Service E
+//        |starting Service D
+//        |healthy
+//        |stopping Service D
+//        |stopping Service E
+//        |stopping Service C
+//        |stopping Service A
+//        |stopping Service B
+//        |""".trimMargin())
+  }
+
+  @Test fun unsatisfiedDependency() {
+    TODO()
+//    val target = StringBuilder()
+//
+//    val a = CoordinatedServiceTest.AppendingService(target, "Service A", produced = setOf("a"))
+//    val c = CoordinatedServiceTest.AppendingService(target, "Service C", consumed = setOf("a", "b"))
+//
+//    assertThat(assertFailsWith<IllegalArgumentException> {
+//      CoordinatedService.coordinate(listOf(a, c))
+//    }).hasMessage("""
+//        |Service dependency graph has problems:
+//        |  Service C requires ${key("b")} but no service produces it""".trimMargin())
+  }
+
+
+  @Test fun dependencyCycle() {
+    TODO()
+//    val target = StringBuilder()
+//
+//    val a = CoordinatedServiceTest.AppendingService(target, "Service A", produced = setOf("a"),
+//        consumed = setOf("d"))
+//    val b = CoordinatedServiceTest.AppendingService(target, "Service B", produced = setOf("b"),
+//        consumed = setOf("c"))
+//    val c = CoordinatedServiceTest.AppendingService(target, "Service C", produced = setOf("c"),
+//        consumed = setOf("a"))
+//    val d = CoordinatedServiceTest.AppendingService(target, "Service D", produced = setOf("d"),
+//        consumed = setOf("c"))
+//
+//    assertThat(assertFailsWith<IllegalArgumentException> {
+//      CoordinatedService.coordinate(listOf(a, b, c, d))
+//    }).hasMessage("""
+//        |Service dependency graph has problems:
+//        |  dependency cycle: Service A -> Service D -> Service C -> Service A""".trimMargin())
+  }
+
+  @Test fun failuresPropagate() {
+    TODO()
+//    val target = StringBuilder()
+//
+//    val a = object : AbstractService(), DependentService {
+//      override val consumedKeys: Set<Key<*>> = setOf()
+//      override val producedKeys: Set<Key<*>> = setOf(key("a"))
+//      override fun doStart() = throw Exception("boom!")
+//      override fun doStop() = Unit
+//      override fun toString() = "FailingService"
+//    }
+//
+//    val b = CoordinatedServiceTest.AppendingService(target, "Service B", consumed = setOf("a"))
+//
+//    val serviceManager = CoordinatedService.coordinate(listOf(a, b))
+//    serviceManager.startAsync()
+//    assertFailsWith<IllegalStateException> {
+//      serviceManager.awaitHealthy()
+//    }
+  }
+
 
   /** Appends messages to `target` on start up and shut down. */
   class AppendingService(
@@ -99,4 +241,7 @@ class ServiceGraphBuilderTest {
 
     override fun toString() = name
   }
+
+  fun key(name: String): Key<*> = Key.get(Service::class.java, Names.named(name))
+
 }

--- a/misk/src/test/kotlin/misk/ServiceGraphBuilderTest.kt
+++ b/misk/src/test/kotlin/misk/ServiceGraphBuilderTest.kt
@@ -304,8 +304,8 @@ class ServiceGraphBuilderTest {
   ): IllegalStateException {
     val target = StringBuilder()
     val builder = newBuilderWithServices(target, services)
-    builder.block(target)
     return assertFailsWith {
+      builder.block(target)
       builder.build()
     }
   }

--- a/misk/src/test/kotlin/misk/ServiceGraphBuilderTest.kt
+++ b/misk/src/test/kotlin/misk/ServiceGraphBuilderTest.kt
@@ -17,8 +17,6 @@ class ServiceGraphBuilderTest {
   val e = NamedKey("Service E")
   val unregistered = NamedKey("Unregistered Service")
   val enhancementA = NamedKey("Enhancement A")
-  val enhancementB = NamedKey("Enhancement B")
-  val enhancementC = NamedKey("Enhancement C")
 
   @Test
   fun happyPathNoEnhancements() {
@@ -374,7 +372,7 @@ class ServiceGraphBuilderTest {
   }
 
   /**
-   * Service that appends messages to its `target` on start up and shut down.
+   * AppendingService is a Service that appends messages to its `target` on start up and shut down.
    */
   class AppendingService(
     val target: StringBuilder,

--- a/misk/src/test/kotlin/misk/ServiceGraphBuilderTest.kt
+++ b/misk/src/test/kotlin/misk/ServiceGraphBuilderTest.kt
@@ -1,0 +1,102 @@
+package misk
+
+import com.google.common.util.concurrent.AbstractService
+import com.google.common.util.concurrent.Service
+import com.google.inject.Key
+import com.google.inject.name.Names
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class ServiceGraphBuilderTest {
+
+  @Test
+  fun happyPath() {
+    val target = StringBuilder()
+
+    val keyA = key("a")
+    val keyB = key("b")
+    val keyC = key("c")
+
+    val builder = ServiceGraphBuilder()
+    builder.addService(keyA, AppendingService(target, "Service A"))
+    builder.addService(keyB, AppendingService(target, "Service B"))
+    builder.addService(keyC, AppendingService(target, "Service C"))
+
+    builder.addDependency(keyC, keyA)
+    builder.addDependency(keyC, keyB)
+
+    val serviceManager = builder.build()
+
+    serviceManager.startAsync()
+    serviceManager.awaitHealthy()
+    target.append("healthy\n")
+    serviceManager.stopAsync()
+    serviceManager.awaitStopped()
+
+    assertThat(target.toString()).isEqualTo("""
+        |starting Service A
+        |starting Service B
+        |starting Service C
+        |healthy
+        |stopping Service C
+        |stopping Service A
+        |stopping Service B
+        |""".trimMargin())
+  }
+
+  @Test
+  fun enhancer() {
+    val target = StringBuilder()
+
+    val keyA = key("a")
+    val keyAEnhancement = key("a enhancement")
+    val keyC = key("c")
+
+    val builder = ServiceGraphBuilder()
+    builder.addService(keyA, AppendingService(target, "Service A"))
+    builder.addService(keyC, AppendingService(target, "Service C"))
+    builder.addService(keyAEnhancement, AppendingService(target, "Service A enhancement"))
+
+    builder.addEnhancement(keyA, keyAEnhancement)
+    builder.addDependency(keyC, keyA)
+
+    val serviceManager = builder.build()
+
+    serviceManager.startAsync()
+    serviceManager.awaitHealthy()
+    target.append("healthy\n")
+    serviceManager.stopAsync()
+    serviceManager.awaitStopped()
+
+    assertThat(target.toString()).isEqualTo("""
+        |starting Service A
+        |starting Service A enhancement
+        |starting Service C
+        |healthy
+        |stopping Service C
+        |stopping Service A enhancement
+        |stopping Service A
+        |""".trimMargin())
+  }
+
+  fun key(name: String): Key<*> = Key.get(Service::class.java, Names.named(name))
+
+  /** Appends messages to `target` on start up and shut down. */
+  class AppendingService(
+    val target: StringBuilder,
+    val name: String
+  ) : AbstractService() {
+
+    override fun doStart() {
+      target.append("starting $name\n")
+      notifyStarted()
+    }
+
+    override fun doStop() {
+      target.append("stopping $name\n")
+      notifyStopped()
+    }
+
+    override fun toString() = name
+  }
+}


### PR DESCRIPTION
This PR adds two classes:
 - _`CoordinatedService2`_ which is intended to replace the existing `CoordinatedService`
 - _`ServiceGraphBuilder`_ which is a builder class for Guava `ServiceManager`s that manage `CoordinatedService2`s

CoordinatedService2 adds the concept of "enhancements" in addition to the traditional downstream dependencies. Hopefully the documentation is clear as this was tricky to reason about at first!