### PR TITLE
Bump MySQL connector

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -52,7 +52,7 @@ ext.dep = [
   "loggingApi": "io.github.microutils:kotlin-logging:1.4.9",
   "mockitoCore": "org.mockito:mockito-core:2.23.4",
   "moshi": "com.squareup.moshi:moshi-kotlin:1.8.0",
-  "mysql": "mysql:mysql-connector-java:5.1.16",
+  "mysql": "mysql:mysql-connector-java:5.1.47",
   "okHttp": "com.squareup.okhttp3:okhttp:3.12.1",
   "okHttpMockWebServer": "com.squareup.okhttp3:mockwebserver:3.12.1",
   "okio": "com.squareup.okio:okio:2.2.2",


### PR DESCRIPTION
Having an `val x: Instant? = null` in an entity caused the timestamp to not be updated. This is fixed after bumping the mysql-connector.