### PR TITLE
Guice EDSL for ServiceGraphBuilder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .gradle
+.gradletasknamecache
 **/out/
 build
 .idea

--- a/misk/src/main/kotlin/misk/MiskServiceModule.kt
+++ b/misk/src/main/kotlin/misk/MiskServiceModule.kt
@@ -258,7 +258,6 @@ class ServiceModule(
   }
 
   fun dependsOn(upstream: Key<out Service>): ServiceModule {
-
     return ServiceModule(key, dependsOn + upstream, enhancedBy)
   }
 

--- a/misk/src/main/kotlin/misk/ServiceGraphBuilder.kt
+++ b/misk/src/main/kotlin/misk/ServiceGraphBuilder.kt
@@ -1,9 +1,6 @@
 package misk
 
-import com.google.common.collect.HashMultimap
 import com.google.common.collect.LinkedHashMultimap
-import com.google.common.collect.Multimap
-import com.google.common.collect.SetMultimap
 import com.google.common.util.concurrent.Service
 import com.google.common.util.concurrent.ServiceManager
 import com.google.inject.Key
@@ -22,9 +19,6 @@ class ServiceGraphBuilder {
    *
    * A service should be added before dependencies or enhancements are specified.
    * Keys must be unique. If a key is reused, then the original key-service pair will be replaced.
-   *
-   * @param key A Guice Key used to identify the service.
-   * @param service The Service to register with this ServiceGraphBuilder.
    */
   fun addService(key: Key<*>, service: Service) {
     serviceMap[key] = CoordinatedService2(service)


### PR DESCRIPTION
Follow-up for #984. This PR introduces a small EDSL to specify Service dependencies and enhancements.

This provides a `ServiceModule` which can be installed to other modules, providing an easy way to build Service dependency graphs with Guice.

The new provider method `provideServiceGraphBuilder` creates a builder for the graph. It is intended to supercede the `provideServiceManager` method (see note) as we migrate from CoordinatedService to CoordinatedService2.

Next steps will be to deprecate CoordinatedService and DependentService, then migrate modules to specify their graphs using the EDSL, like in the simple example below:

```kotlin
class ExampleModule : KAbstractModule() {
  override configure() {
    // Creates Service graph where ExampleService depends on Provider, and start-up order is:
    // Provider -> ExampleService -> Enhancer; and shut-down order is:
    // Enhancer -> ExampleService -> Provider.
    // Enhancer and Provider services may be installed in this module, or in another module by
    // install(service<X>()).
    install(ServiceModule<ExampleService>()
      .enhancedBy<Enhancer>()
      .dependsOn<Provider>()
    )
  }
}
```