### PR TITLE
Deprecate CoordinatedService and clarify SGBuilder API

### DIFF
--- a/misk/src/main/kotlin/misk/CoordinatedService.kt
+++ b/misk/src/main/kotlin/misk/CoordinatedService.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package misk
 
 import com.google.common.util.concurrent.AbstractService
@@ -14,6 +16,7 @@ import com.google.inject.Key
  * starts up. Symmetrically it stalls in `STOPPING` until all downstream services are `TERMINATED`,
  * then it actually shuts down.
  */
+@Deprecated("Replaced by CoordinatedService2.")
 internal class CoordinatedService(val service: Service) : AbstractService(), DependentService {
   override val producedKeys = (service as? DependentService)?.producedKeys ?: setOf()
   override val consumedKeys = (service as? DependentService)?.consumedKeys ?: setOf()

--- a/misk/src/main/kotlin/misk/CoordinatedService2.kt
+++ b/misk/src/main/kotlin/misk/CoordinatedService2.kt
@@ -138,7 +138,7 @@ internal class CoordinatedService2(val service: Service) : AbstractService() {
   }
 
   /** Adds [services] as dependents downstream. */
-  fun addDependencies(vararg services: CoordinatedService2) {
+  fun addDependentServices(vararg services: CoordinatedService2) {
     // Check that this service and all dependent services are new before modifying the graph.
     this.checkNew()
     for (service in services) {

--- a/misk/src/main/kotlin/misk/MiskServiceModule.kt
+++ b/misk/src/main/kotlin/misk/MiskServiceModule.kt
@@ -131,7 +131,7 @@ class MiskCommonServiceModule : KAbstractModule() {
       builder.addService(entry.key, service)
     }
     for (edge in dependencies) {
-      builder.addDependency(dependent = edge.service, dependsOn = edge.dependsOn)
+      builder.addDependency(dependent = edge.dependent, dependsOn = edge.dependsOn)
     }
     for (edge in enhancements) {
       builder.enhanceService(toBeEnhanced = edge.toBeEnhanced, enhancement = edge.enhancement)
@@ -179,23 +179,9 @@ class MiskCommonServiceModule : KAbstractModule() {
     val serviceSetKey = Key.get(Types.setOf(Service::class.java)) as Key<Set<Service>>
     private val log = KotlinLogging.logger {}
   }
-
 }
 
-/**
- * Normal dependency edge in the service dependency graph.
- *
- * @param service Identifier for the dependent service.
- * @param dependsOn Identifier for the service that [service] depends on.
- */
-internal data class DependencyEdge(val service: Key<*>, val dependsOn: Key<*>)
-
-/**
- * Enhancement edge in the service dependency graph.
- *
- * @param toBeEnhanced The key of the service to be enhanced.
- * @param enhancement The key of the service that enhances [toBeEnhanced].
- */
+internal data class DependencyEdge(val dependent: Key<*>, val dependsOn: Key<*>)
 internal data class EnhancementEdge(val toBeEnhanced: Key<*>, val enhancement: Key<*>)
 internal data class ServiceEntry(val key: Key<out Service>)
 
@@ -241,7 +227,7 @@ class ServiceModule(
 
     for (dependsOnKey in dependsOn) {
       multibind<DependencyEdge>().toInstance(
-          DependencyEdge(service = key, dependsOn = dependsOnKey)
+          DependencyEdge(dependent = key, dependsOn = dependsOnKey)
       )
     }
     for (enhancedByKey in enhancedBy) {

--- a/misk/src/main/kotlin/misk/ServiceGraphBuilder.kt
+++ b/misk/src/main/kotlin/misk/ServiceGraphBuilder.kt
@@ -22,6 +22,9 @@ class ServiceGraphBuilder {
    * Keys must be unique. If a key is reused, then the original key-service pair will be replaced.
    */
   fun addService(key: Key<*>, service: Service) {
+    check(serviceMap[key] == null) {
+      "Service $key cannot be registered more than once"
+    }
     serviceMap[key] = CoordinatedService2(service)
   }
 

--- a/misk/src/test/kotlin/misk/CoordinatedService2Test.kt
+++ b/misk/src/test/kotlin/misk/CoordinatedService2Test.kt
@@ -16,10 +16,10 @@ class CoordinatedService2Test {
     runningService.startAsync()
 
     assertFailsWith<IllegalStateException> {
-      newService.addDependencies(runningService)
+      newService.addDependentServices(runningService)
     }
     assertFailsWith<IllegalStateException> {
-      newService.addDependencies(runningService)
+      newService.addDependentServices(runningService)
     }
 
     runningService.stopAsync()

--- a/misk/src/test/kotlin/misk/CoordinatedServiceTest.kt
+++ b/misk/src/test/kotlin/misk/CoordinatedServiceTest.kt
@@ -1,12 +1,16 @@
+@file:Suppress("DEPRECATION")
+
 package misk
 
 import com.google.common.util.concurrent.AbstractService
 import com.google.inject.Key
 import com.google.inject.name.Names
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.Ignore
 import org.junit.jupiter.api.Test
 import kotlin.test.assertFailsWith
 
+@Ignore("CoordinatedService is deprecated and no longer used.")
 class CoordinatedServiceTest {
   @Test fun happyPath() {
     val target = StringBuilder()


### PR DESCRIPTION
`CoordinatedService` usages have been fully removed and replaced by `ServiceGraphBuilder`. It is now deprecated, and associated tests have been disabled.

The `provideServiceManager` provider method follows the keys specified by `DependentService`s and has optional support for usage of the `install(ServiceModule<...>())` API.

The API and documentation for `ServiceGraphBuilder` has been clarfied because I found myself tripping over it before. Hopefully it is easier to use now. 

