### PR TITLE
Use ServiceGraphBuilder in Misk Hibernate Module

### DIFF
--- a/misk-hibernate-testing/src/main/kotlin/misk/hibernate/HibernateTestingModule.kt
+++ b/misk-hibernate-testing/src/main/kotlin/misk/hibernate/HibernateTestingModule.kt
@@ -1,8 +1,8 @@
 package misk.hibernate
 
-import com.google.common.util.concurrent.Service
 import com.google.inject.Inject
 import com.squareup.moshi.Moshi
+import misk.ServiceModule
 import misk.inject.KAbstractModule
 import misk.inject.asSingleton
 import misk.inject.toKey
@@ -42,7 +42,8 @@ class HibernateTestingModule(
       bindVitessChecks()
     }
 
-    multibind<Service>().to(truncateTablesServiceKey)
+    install(ServiceModule(truncateTablesServiceKey)
+        .dependsOn<SchemaMigratorService>(qualifier))
     bind(truncateTablesServiceKey).toProvider(object : Provider<TruncateTablesService> {
       @Inject(optional = true) var checks: VitessScaleSafetyChecks? = null
 

--- a/misk-hibernate-testing/src/main/kotlin/misk/jdbc/TruncateTablesService.kt
+++ b/misk-hibernate-testing/src/main/kotlin/misk/jdbc/TruncateTablesService.kt
@@ -2,13 +2,9 @@ package misk.jdbc
 
 import com.google.common.base.Stopwatch
 import com.google.common.util.concurrent.AbstractIdleService
-import com.google.inject.Key
-import misk.DependentService
-import misk.hibernate.SchemaMigratorService
 import misk.hibernate.Transacter
 import misk.hibernate.shards
 import misk.hibernate.transaction
-import misk.inject.toKey
 import misk.logging.getLogger
 import java.util.Locale
 import javax.inject.Provider
@@ -32,11 +28,8 @@ class TruncateTablesService(
   private val checks: VitessScaleSafetyChecks? = null,
   private val startUpStatements: List<String> = listOf(),
   private val shutDownStatements: List<String> = listOf()
-) : AbstractIdleService(), DependentService {
+) : AbstractIdleService() {
   private val persistentTables = setOf("schema_version")
-
-  override val consumedKeys = setOf<Key<*>>(SchemaMigratorService::class.toKey(qualifier))
-  override val producedKeys = setOf<Key<*>>(TruncateTablesService::class.toKey(qualifier))
 
   override fun startUp() {
     if (checks == null) {

--- a/misk-hibernate/src/main/kotlin/misk/hibernate/HibernateModule.kt
+++ b/misk-hibernate/src/main/kotlin/misk/hibernate/HibernateModule.kt
@@ -93,10 +93,9 @@ class HibernateModule(
         .dependsOn<PingDatabaseService>(qualifier))
 
     // Bind SessionFactoryService.
-    val entitiesKey = setOfType(HibernateEntity::class).toKey(qualifier)
-    val entitiesProvider = getProvider(entitiesKey)
-    val eventListenersKey = setOfType(ListenerRegistration::class).toKey(qualifier)
-    val eventListenersProvider = getProvider(eventListenersKey)
+    val entitiesProvider = getProvider(setOfType(HibernateEntity::class).toKey(qualifier))
+    val eventListenersProvider =
+        getProvider(setOfType(ListenerRegistration::class).toKey(qualifier))
     val hibernateInjectorAccessProvider = getProvider(HibernateInjectorAccess::class.java)
     val dataSourceProvider = getProvider(keyOf<DataSource>(qualifier))
 

--- a/misk-hibernate/src/main/kotlin/misk/hibernate/HibernateModule.kt
+++ b/misk-hibernate/src/main/kotlin/misk/hibernate/HibernateModule.kt
@@ -67,8 +67,11 @@ class HibernateModule(
 
     // Bind PingDataBaseService.
     bind(keyOf<PingDatabaseService>(qualifier)).toProvider(Provider<PingDatabaseService> {
-      PingDatabaseService(qualifier, config, environmentProvider.get())
+      PingDatabaseService(config, environmentProvider.get())
     }).asSingleton()
+    // TODO(rhall): depending on Vitess is a hack to simulate Vitess has already been started in the
+    // env. This is to remove flakiness in tests that are not waiting until Vitess is ready.
+    // This should be replaced with an ExternalDependency that manages vitess.
     install(ServiceModule<PingDatabaseService>(qualifier)
         .dependsOn<StartVitessService>(qualifier))
 
@@ -135,7 +138,6 @@ class HibernateModule(
         qualifier)).toProvider(object : Provider<SchemaMigratorService> {
       @Inject lateinit var environment: Environment
       override fun get(): SchemaMigratorService = SchemaMigratorService(
-          qualifier,
           environment,
           schemaMigratorProvider,
           config

--- a/misk-hibernate/src/main/kotlin/misk/hibernate/HibernateModule.kt
+++ b/misk-hibernate/src/main/kotlin/misk/hibernate/HibernateModule.kt
@@ -1,10 +1,12 @@
 package misk.hibernate
 
-import com.google.common.util.concurrent.Service
 import io.opentracing.Tracer
+import misk.ServiceModule
 import misk.environment.Environment
+import misk.hibernate.ReflectionQuery.QueryLimitsConfig
 import misk.inject.KAbstractModule
 import misk.inject.asSingleton
+import misk.inject.keyOf
 import misk.inject.setOfType
 import misk.inject.toKey
 import misk.jdbc.DataSourceConfig
@@ -22,7 +24,7 @@ import javax.sql.DataSource
 import kotlin.reflect.KClass
 
 /**
- * Binds database connectivity for a qualified datasource. This binds the following public types:
+ * Binds database connectivity for a qualified data source. This binds the following public types:
  *
  *  * @Qualifier [misk.jdbc.DataSourceConfig]
  *  * @Qualifier [SessionFactory]
@@ -44,80 +46,79 @@ class HibernateModule(
   val config = config.withDefaults()
 
   override fun configure() {
-    val configKey = DataSourceConfig::class.toKey(qualifier)
+    val sessionFactoryProvider = getProvider(keyOf<SessionFactory>(qualifier))
+    val environmentProvider: Provider<Environment> = getProvider(keyOf<Environment>())
 
-    val entitiesKey = setOfType(HibernateEntity::class).toKey(qualifier)
-    val entitiesProvider = getProvider(entitiesKey)
-
-    val environmentKey = Environment::class.toKey()
-    val environmentProvider = getProvider(environmentKey)
-
-    val eventListenersKey = setOfType(ListenerRegistration::class).toKey(qualifier)
-    val eventListenersProvider = getProvider(eventListenersKey)
-
-    val sessionFactoryKey = SessionFactory::class.toKey(qualifier)
-    val sessionFactoryProvider = getProvider(sessionFactoryKey)
-
-    val sessionFactoryServiceKey = SessionFactoryService::class.toKey(qualifier)
-    val sessionFactoryServiceProvider = getProvider(sessionFactoryServiceKey)
-
-    val dataSourceDecoratorsKey = setOfType(DataSourceDecorator::class).toKey(qualifier)
-    val dataSourceDecoratorsProvider = getProvider(dataSourceDecoratorsKey)
-
-    val schemaMigratorKey = SchemaMigrator::class.toKey(qualifier)
-    val schemaMigratorProvider = getProvider(schemaMigratorKey)
-
-    val transacterKey = Transacter::class.toKey(qualifier)
-    val transacterProvider = getProvider(transacterKey)
-
-    val pingDatabaseServiceKey = PingDatabaseService::class.toKey(qualifier)
-
-    val dataSourceKey = DataSource::class.toKey(qualifier)
-    val dataSourceProvider = getProvider(dataSourceKey)
-
-    val dataSourceServiceKey = DataSourceService::class.toKey(qualifier)
-
-    bindStartVitessService()
-
-    bind(configKey).toInstance(config)
-
-    bind(pingDatabaseServiceKey).toProvider(Provider<PingDatabaseService> {
-      PingDatabaseService(qualifier, config, environmentProvider.get())
-    }).asSingleton()
-    multibind<Service>().to(pingDatabaseServiceKey)
-
-    // Declare the empty set of decorators
     newMultibinder<DataSourceDecorator>(qualifier)
 
-    bind(dataSourceKey).toProvider(dataSourceServiceKey).asSingleton()
-    bind(dataSourceServiceKey).toProvider(object : Provider<DataSourceService> {
+    bind<Query.Factory>().to<ReflectionQuery.Factory>()
+    bind<QueryLimitsConfig>()
+        .toInstance(QueryLimitsConfig(MAX_MAX_ROWS, ROW_COUNT_ERROR_LIMIT, ROW_COUNT_WARNING_LIMIT))
+    bind(keyOf<DataSourceConfig>(qualifier)).toInstance(config)
+
+    // Bind StartVitessService.
+    install(ServiceModule<StartVitessService>(qualifier))
+    bind(keyOf<StartVitessService>(qualifier)).toProvider(object : Provider<StartVitessService> {
+      @Inject lateinit var environment: Environment
+      override fun get(): StartVitessService {
+        return StartVitessService(environment = environment, config = config, qualifier = qualifier)
+      }
+    }).asSingleton()
+
+    // Bind PingDataBaseService.
+    bind(keyOf<PingDatabaseService>(qualifier)).toProvider(Provider<PingDatabaseService> {
+      PingDatabaseService(qualifier, config, environmentProvider.get())
+    }).asSingleton()
+    install(ServiceModule<PingDatabaseService>(qualifier)
+        .dependsOn<StartVitessService>(qualifier))
+
+    // Bind DataSourceService.
+    val dataSourceDecoratorsKey = setOfType(DataSourceDecorator::class).toKey(qualifier)
+    val dataSourceDecoratorsProvider = getProvider(dataSourceDecoratorsKey)
+    bind(keyOf<DataSource>(qualifier)).toProvider(keyOf<DataSourceService>(qualifier)).asSingleton()
+    bind(keyOf<DataSourceService>(qualifier)).toProvider(object : Provider<DataSourceService> {
       @com.google.inject.Inject(optional = true) var metrics: Metrics? = null
       override fun get() = DataSourceService(
-        qualifier,
-        config,
-        environmentProvider.get(),
-        dataSourceDecoratorsProvider.get(),
-        metrics
+          qualifier,
+          config,
+          environmentProvider.get(),
+          dataSourceDecoratorsProvider.get(),
+          metrics
       )
     }).asSingleton()
-    multibind<Service>().to(dataSourceServiceKey)
+    install(ServiceModule<DataSourceService>(qualifier)
+        .dependsOn<PingDatabaseService>(qualifier))
 
-    bind(sessionFactoryKey).toProvider(sessionFactoryServiceKey).asSingleton()
+    // Bind SessionFactoryService.
+    val entitiesKey = setOfType(HibernateEntity::class).toKey(qualifier)
+    val entitiesProvider = getProvider(entitiesKey)
+    val eventListenersKey = setOfType(ListenerRegistration::class).toKey(qualifier)
+    val eventListenersProvider = getProvider(eventListenersKey)
     val hibernateInjectorAccessProvider = getProvider(HibernateInjectorAccess::class.java)
+    val dataSourceProvider = getProvider(keyOf<DataSource>(qualifier))
 
-    bind(sessionFactoryServiceKey).toProvider(Provider<SessionFactoryService> {
+    bind(keyOf<SessionFactory>(qualifier))
+        .toProvider(keyOf<SessionFactoryService>(qualifier))
+        .asSingleton()
+    bind(keyOf<SessionFactoryService>(qualifier)).toProvider(Provider<SessionFactoryService> {
       SessionFactoryService(qualifier, config, dataSourceProvider,
           hibernateInjectorAccessProvider.get(),
           entitiesProvider.get(), eventListenersProvider.get())
     }).asSingleton()
-    multibind<Service>().to(sessionFactoryServiceKey)
+    install(ServiceModule<SessionFactoryService>(qualifier)
+        .dependsOn<DataSourceService>(qualifier))
+
+    // Bind SchemaMigratorService.
+    val transacterKey = Transacter::class.toKey(qualifier)
+    val transacterProvider = getProvider(transacterKey)
+    val schemaMigratorKey = SchemaMigrator::class.toKey(qualifier)
+    val schemaMigratorProvider = getProvider(schemaMigratorKey)
 
     bind(schemaMigratorKey).toProvider(object : Provider<SchemaMigrator> {
       @Inject lateinit var resourceLoader: ResourceLoader
       override fun get(): SchemaMigrator = SchemaMigrator(qualifier, resourceLoader,
           transacterProvider, config)
     }).asSingleton()
-
     bind(transacterKey).toProvider(object : Provider<Transacter> {
       @com.google.inject.Inject(optional = true) val tracer: Tracer? = null
       @Inject lateinit var queryTracingListener: QueryTracingListener
@@ -130,25 +131,35 @@ class HibernateModule(
       )
     }).asSingleton()
 
-    multibind<Service>().toProvider(object : Provider<SchemaMigratorService> {
+    bind(keyOf<SchemaMigratorService>(
+        qualifier)).toProvider(object : Provider<SchemaMigratorService> {
       @Inject lateinit var environment: Environment
       override fun get(): SchemaMigratorService = SchemaMigratorService(
-          qualifier, environment, schemaMigratorProvider, config)
-    }).asSingleton()
-
-    multibind<Service>().toProvider(Provider<SchemaValidatorService> {
-      SchemaValidatorService(
           qualifier,
-          sessionFactoryServiceProvider,
-          transacterProvider,
+          environment,
+          schemaMigratorProvider,
           config
       )
     }).asSingleton()
+    install(ServiceModule<SchemaMigratorService>(qualifier)
+        .dependsOn<SessionFactoryService>(qualifier))
 
-    bind<Query.Factory>().to<ReflectionQuery.Factory>()
-    bind<ReflectionQuery.QueryLimitsConfig>().toInstance(ReflectionQuery.QueryLimitsConfig(
-        MAX_MAX_ROWS, ROW_COUNT_ERROR_LIMIT, ROW_COUNT_WARNING_LIMIT))
+    // Bind SchemaValidatorService.
+    val sessionFactoryServiceProvider = getProvider(keyOf<SessionFactoryService>(qualifier))
+    bind(keyOf<SchemaValidatorService>(qualifier))
+        .toProvider(Provider<SchemaValidatorService> {
+          SchemaValidatorService(
+              qualifier,
+              sessionFactoryServiceProvider,
+              transacterProvider,
+              config
+          )
+        }).asSingleton()
+    install(ServiceModule<SchemaValidatorService>(qualifier)
+        .dependsOn<SchemaMigratorService>(qualifier)
+        .dependsOn<SessionFactoryService>(qualifier))
 
+    // Install other modules.
     install(object : HibernateEntityModule(qualifier) {
       override fun configureHibernate() {
         bindListener(EventType.PRE_INSERT).to<TimestampListener>()
@@ -163,16 +174,5 @@ class HibernateModule(
     })
 
     install(HibernateHealthCheckModule(qualifier, sessionFactoryProvider))
-  }
-
-  private fun bindStartVitessService() {
-    val startVitessServiceKey = StartVitessService::class.toKey(qualifier)
-    multibind<Service>().to(startVitessServiceKey)
-    bind(startVitessServiceKey).toProvider(object : Provider<StartVitessService> {
-      @Inject lateinit var environment : Environment
-      override fun get(): StartVitessService {
-        return StartVitessService(environment = environment, config = config, qualifier = qualifier)
-      }
-    }).asSingleton()
   }
 }

--- a/misk-hibernate/src/main/kotlin/misk/hibernate/SchemaMigratorService.kt
+++ b/misk-hibernate/src/main/kotlin/misk/hibernate/SchemaMigratorService.kt
@@ -1,24 +1,16 @@
 package misk.hibernate
 
 import com.google.common.util.concurrent.AbstractIdleService
-import com.google.inject.Key
-import misk.DependentService
 import misk.environment.Environment
-import misk.inject.toKey
 import misk.jdbc.DataSourceType
 import javax.inject.Singleton
 
 @Singleton
 class SchemaMigratorService internal constructor(
-  qualifier: kotlin.reflect.KClass<out kotlin.Annotation>,
-  private val environment: misk.environment.Environment,
-  private val schemaMigratorProvider: javax.inject.Provider<misk.hibernate.SchemaMigrator>, // Lazy!
+  private val environment: Environment,
+  private val schemaMigratorProvider: javax.inject.Provider<SchemaMigrator>, // Lazy!
   private val config: misk.jdbc.DataSourceConfig
-) : AbstractIdleService(), DependentService {
-
-  override val consumedKeys = setOf<Key<*>>(SessionFactoryService::class.toKey(qualifier))
-  override val producedKeys = setOf<Key<*>>(SchemaMigratorService::class.toKey(qualifier))
-
+) : AbstractIdleService() {
   override fun startUp() {
     val schemaMigrator = schemaMigratorProvider.get()
     if (environment == Environment.TESTING || environment == Environment.DEVELOPMENT) {

--- a/misk-hibernate/src/main/kotlin/misk/hibernate/SchemaValidatorService.kt
+++ b/misk-hibernate/src/main/kotlin/misk/hibernate/SchemaValidatorService.kt
@@ -1,9 +1,6 @@
 package misk.hibernate
 
 import com.google.common.util.concurrent.AbstractIdleService
-import com.google.inject.Key
-import misk.DependentService
-import misk.inject.toKey
 import misk.jdbc.DataSourceConfig
 import java.util.Collections
 import javax.inject.Provider
@@ -16,14 +13,7 @@ internal class SchemaValidatorService internal constructor(
   private val sessionFactoryServiceProvider: Provider<SessionFactoryService>,
   private val transacterProvider: Provider<Transacter>,
   private val config: DataSourceConfig
-) : AbstractIdleService(), DependentService {
-
-  override val consumedKeys = setOf<Key<*>>(
-      SchemaMigratorService::class.toKey(qualifier),
-      SessionFactoryService::class.toKey(qualifier)
-  )
-  override val producedKeys = setOf<Key<*>>(SchemaValidatorService::class.toKey(qualifier))
-
+) : AbstractIdleService() {
   override fun startUp() {
     synchronized(this) {
       if (validated.contains(qualifier)) {

--- a/misk-hibernate/src/main/kotlin/misk/hibernate/SessionFactoryService.kt
+++ b/misk-hibernate/src/main/kotlin/misk/hibernate/SessionFactoryService.kt
@@ -2,11 +2,7 @@ package misk.hibernate
 
 import com.google.common.base.Stopwatch
 import com.google.common.util.concurrent.AbstractIdleService
-import com.google.inject.Key
-import misk.DependentService
-import misk.inject.toKey
 import misk.jdbc.DataSourceConfig
-import misk.jdbc.DataSourceService
 import misk.logging.getLogger
 import okio.ByteString
 import org.hibernate.SessionFactory
@@ -44,16 +40,12 @@ internal class SessionFactoryService(
   private val hibernateInjectorAccess: HibernateInjectorAccess,
   private val entityClasses: Set<HibernateEntity> = setOf(),
   private val listenerRegistrations: Set<ListenerRegistration> = setOf()
-) : AbstractIdleService(), DependentService, Provider<SessionFactory> {
+) : AbstractIdleService(), Provider<SessionFactory> {
   private var sessionFactory: SessionFactory? = null
-
-  override val consumedKeys = setOf<Key<*>>(DataSourceService::class.toKey(qualifier))
-  override val producedKeys = setOf<Key<*>>(SessionFactoryService::class.toKey(qualifier))
 
   lateinit var hibernateMetadata: Metadata
 
   override fun startUp() {
-
     val stopwatch = Stopwatch.createStarted()
     logger.info("Starting @${qualifier.simpleName} Hibernate")
 

--- a/misk-hibernate/src/main/kotlin/misk/jdbc/DataSourceService.kt
+++ b/misk-hibernate/src/main/kotlin/misk/jdbc/DataSourceService.kt
@@ -2,13 +2,10 @@ package misk.jdbc
 
 import com.google.common.base.Stopwatch
 import com.google.common.util.concurrent.AbstractIdleService
-import com.google.inject.Key
 import com.zaxxer.hikari.HikariConfig
 import com.zaxxer.hikari.HikariDataSource
 import com.zaxxer.hikari.metrics.prometheus.PrometheusMetricsTrackerFactory
-import misk.DependentService
 import misk.environment.Environment
-import misk.inject.toKey
 import misk.metrics.Metrics
 import mu.KotlinLogging
 import javax.inject.Provider
@@ -26,14 +23,11 @@ internal class DataSourceService(
   private val environment: Environment,
   private val dataSourceDecorators: Set<DataSourceDecorator>,
   private val metrics: Metrics? = null
-) : AbstractIdleService(), DependentService, Provider<DataSource> {
+) : AbstractIdleService(), Provider<DataSource> {
   /** The backing connection pool */
   private var hikariDataSource: HikariDataSource? = null
   /** The decorated data source */
   private var dataSource: DataSource? = null
-
-  override val consumedKeys = setOf<Key<*>>(PingDatabaseService::class.toKey(qualifier))
-  override val producedKeys = setOf<Key<*>>(DataSourceService::class.toKey(qualifier))
 
   override fun startUp() {
     val stopwatch = Stopwatch.createStarted()

--- a/misk-hibernate/src/main/kotlin/misk/jdbc/PingDatabaseService.kt
+++ b/misk-hibernate/src/main/kotlin/misk/jdbc/PingDatabaseService.kt
@@ -1,20 +1,15 @@
 package misk.jdbc
 
 import com.google.common.util.concurrent.AbstractIdleService
-import com.google.inject.Key
 import com.zaxxer.hikari.util.DriverDataSource
-import misk.DependentService
 import misk.backoff.ExponentialBackoff
 import misk.backoff.retry
 import misk.environment.Environment
-import misk.inject.toKey
 import misk.logging.getLogger
-import misk.vitess.StartVitessService
 import java.time.Duration
 import java.util.Properties
 import javax.inject.Inject
 import javax.inject.Singleton
-import kotlin.reflect.KClass
 
 private val logger = getLogger<PingDatabaseService>()
 
@@ -24,17 +19,9 @@ private val logger = getLogger<PingDatabaseService>()
  */
 @Singleton
 class PingDatabaseService @Inject constructor(
-  qualifier: KClass<out Annotation>,
   private val config: DataSourceConfig,
   private val environment: Environment
-) : AbstractIdleService(), DependentService {
-
-  // TODO(rhall): depending on Vitess is a hack to simulate Vitess has already been started in the
-  // env. This is to remove flakiness in tests that are not waiting until Vitess is ready.
-  // This should be replaced with an ExternalDependency that manages vitess.
-  override val consumedKeys: Set<Key<*>> = setOf(StartVitessService::class.toKey(qualifier))
-  override val producedKeys: Set<Key<*>> = setOf(PingDatabaseService::class.toKey(qualifier))
-
+) : AbstractIdleService() {
   override fun startUp() {
     val jdbcUrl = this.config.buildJdbcUrl(environment)
     val dataSource = DriverDataSource(

--- a/misk-hibernate/src/main/kotlin/misk/vitess/StartVitessService.kt
+++ b/misk-hibernate/src/main/kotlin/misk/vitess/StartVitessService.kt
@@ -12,16 +12,13 @@ import com.github.dockerjava.netty.NettyDockerCmdExecFactory
 import com.google.common.cache.CacheBuilder
 import com.google.common.cache.CacheLoader
 import com.google.common.util.concurrent.AbstractIdleService
-import com.google.inject.Key
 import com.squareup.moshi.Moshi
 import com.zaxxer.hikari.util.DriverDataSource
-import misk.DependentService
 import misk.backoff.ExponentialBackoff
 import misk.backoff.retry
 import misk.environment.Environment
 import misk.environment.Environment.DEVELOPMENT
 import misk.environment.Environment.TESTING
-import misk.inject.toKey
 import misk.jdbc.DataSourceConfig
 import misk.jdbc.DataSourceType
 import misk.jdbc.uniqueInt
@@ -322,11 +319,7 @@ class StartVitessService(
   private val qualifier: KClass<out Annotation>,
   private val environment: Environment,
   private val config: DataSourceConfig
-) : AbstractIdleService(), DependentService {
-
-  override val consumedKeys: Set<Key<*>> = setOf()
-  override val producedKeys: Set<Key<*>> = setOf(StartVitessService::class.toKey(qualifier))
-
+) : AbstractIdleService() {
   var cluster: DockerVitessCluster? = null
 
   override fun startUp() {

--- a/misk-hibernate/src/test/kotlin/misk/hibernate/SchemaValidatorTest.kt
+++ b/misk-hibernate/src/test/kotlin/misk/hibernate/SchemaValidatorTest.kt
@@ -1,6 +1,5 @@
 package misk.hibernate
 
-import com.google.inject.Key
 import io.opentracing.Tracer
 import misk.MiskTestingServiceModule
 import misk.ServiceModule
@@ -36,10 +35,11 @@ import javax.sql.DataSource
 
 @MiskTest(startService = true)
 class SchemaValidatorTest {
-
   @MiskTestModule
   val module = TestModule()
   val config = MiskConfig.load<RootConfig>("schemavalidation", Environment.TESTING)
+
+  @Inject @ValidationDb lateinit var transacter: Transacter
 
   private lateinit var sessionFactoryService: Provider<SessionFactoryService>
 
@@ -52,8 +52,7 @@ class SchemaValidatorTest {
           DataSourceService(qualifier, config.data_source, Environment.TESTING, emptySet())
 
       val injectorServiceProvider = getProvider(HibernateInjectorAccess::class.java)
-      val sessionFactoryServiceKey =
-          Key.get(SessionFactoryService::class.java, qualifier.java)
+      val sessionFactoryServiceKey = SessionFactoryService::class.toKey(qualifier)
 
       sessionFactoryService = getProvider(sessionFactoryServiceKey)
 
@@ -68,17 +67,6 @@ class SchemaValidatorTest {
 
       val schemaMigratorKey = SchemaMigrator::class.toKey(qualifier)
       val schemaMigratorProvider = getProvider(schemaMigratorKey)
-
-      bind(sessionFactoryServiceKey).toProvider(Provider<SessionFactoryService> {
-        SessionFactoryService(
-            qualifier,
-            config.data_source,
-            dataSourceService,
-            injectorServiceProvider.get(),
-            entitiesProvider.get())
-      }).asSingleton()
-      install(ServiceModule<SessionFactoryService>(qualifier)
-          .dependsOn<DataSourceService>(qualifier))
 
       bind<SessionFactory>().annotatedWith<ValidationDb>().toProvider(sessionFactoryServiceKey)
 
@@ -96,10 +84,12 @@ class SchemaValidatorTest {
 
       bind(schemaMigratorKey).toProvider(object : Provider<SchemaMigrator> {
         @Inject lateinit var resourceLoader: ResourceLoader
-        override fun get(): SchemaMigrator {
-          return SchemaMigrator(qualifier, resourceLoader,
-              transacterProvider, config.data_source)
-        }
+        override fun get(): SchemaMigrator = SchemaMigrator(
+            qualifier,
+            resourceLoader,
+            transacterProvider,
+            config.data_source
+        )
       }).asSingleton()
 
       install(object : HibernateEntityModule(qualifier) {
@@ -112,29 +102,38 @@ class SchemaValidatorTest {
         }
       })
 
+      install(ServiceModule<StartVitessService>(qualifier))
+      bind(keyOf<StartVitessService>(qualifier))
+          .toInstance(StartVitessService(qualifier, Environment.TESTING, config.data_source))
+
       install(ServiceModule<PingDatabaseService>(qualifier)
           .dependsOn<StartVitessService>(qualifier))
       bind(keyOf<PingDatabaseService>(qualifier)).toInstance(
           PingDatabaseService(config.data_source, Environment.TESTING))
 
-      bind(keyOf<DataSourceService>(qualifier)).toInstance(dataSourceService)
       install(ServiceModule<DataSourceService>(qualifier)
           .dependsOn<PingDatabaseService>(qualifier))
+      bind(keyOf<DataSourceService>(qualifier)).toInstance(dataSourceService)
       bind<DataSource>().annotatedWith<ValidationDb>().toProvider(dataSourceService)
+
+      bind(sessionFactoryServiceKey).toProvider(Provider<SessionFactoryService> {
+        SessionFactoryService(
+            qualifier,
+            config.data_source,
+            dataSourceService,
+            injectorServiceProvider.get(),
+            entitiesProvider.get())
+      }).asSingleton()
+      install(ServiceModule<SessionFactoryService>(qualifier)
+          .dependsOn<DataSourceService>(qualifier))
 
       install(ServiceModule<SchemaMigratorService>(qualifier)
           .dependsOn<SessionFactoryService>(qualifier))
       bind(keyOf<SchemaMigratorService>(qualifier)).toProvider(Provider<SchemaMigratorService> {
         SchemaMigratorService(Environment.TESTING, schemaMigratorProvider, config.data_source)
       }).asSingleton()
-
-      install(ServiceModule<StartVitessService>(qualifier))
-      bind(keyOf<StartVitessService>(qualifier)).toInstance(
-          StartVitessService(ValidationDb::class, Environment.TESTING, config.data_source))
     }
   }
-
-  @Inject @ValidationDb lateinit var transacter: Transacter
 
   // TODO (maacosta) Breakup into smaller unit tests.
   private val schemaValidationErrorMessage: String by lazy {
@@ -173,13 +172,15 @@ class SchemaValidatorTest {
 
   @Test
   fun findNullableColumnsInHibernate() {
-    assertThat(schemaValidationErrorMessage).contains("ERROR at schemavalidation.nullable_mismatch_table.tbl5_hibernate_null:\n" +
-        "  Column nullable_mismatch_table.tbl5_hibernate_null is NOT NULL in database but tbl5_hibernate_null is nullable in hibernate")
+    assertThat(schemaValidationErrorMessage).contains(
+        "ERROR at schemavalidation.nullable_mismatch_table.tbl5_hibernate_null:\n" +
+            "  Column nullable_mismatch_table.tbl5_hibernate_null is NOT NULL in database but tbl5_hibernate_null is nullable in hibernate")
   }
 
   @Test
   fun itOkWithNotNullableColumnWithDefaults() {
-    assertThat(schemaValidationErrorMessage).doesNotContain("ERROR at schemavalidation.nullable_mismatch_table.tbl5_hibernate_null_default:")
+    assertThat(schemaValidationErrorMessage).doesNotContain(
+        "ERROR at schemavalidation.nullable_mismatch_table.tbl5_hibernate_null_default:")
   }
 
   @Test
@@ -228,7 +229,7 @@ class SchemaValidatorTest {
   }
 
   @Test
-  fun catchNotReallyUniqueColumnNames(){
+  fun catchNotReallyUniqueColumnNames() {
     assertThat(schemaValidationErrorMessage).contains(
         "Duplicate identifiers: [[tbl6NotReallyUnique, tbl6_not_really_unique]]")
 


### PR DESCRIPTION
Usages of `DependentService` have been removed from`misk-hibernate`.

The `configure` blocks have been reorganized in `HibernateModule` and the testing modules to install services in order of the linear dependency chain they form. This has been done in an attempt to improve readability.