### PR TITLE
Deprecated `misk.service.ServiceTestingModule`

### DIFF
--- a/misk-testing/src/main/kotlin/misk/service/ServiceTestingModule.kt
+++ b/misk-testing/src/main/kotlin/misk/service/ServiceTestingModule.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package misk.service
 
 import com.google.common.util.concurrent.Service
@@ -12,13 +14,15 @@ import kotlin.reflect.KClass
  * [ServiceTestingModule] provides additional help for testing service, notably allowing existing
  * services to be bound with additional dependencies specifically required for testing. Typically
  * used when a [Service] requires an external service (e.g. zookeeper, etcd, vitess, etc)
- * that is being spun up within the test itself
+ * that is being spun up within the test itself.
+ *
+ * Deprecated by [misk.ServiceModule].
  */
+@Deprecated("Replaced by misk.ServiceModule which allows for full dependency graph specification.")
 class ServiceTestingModule<T : Service> internal constructor(
   private val wrappedServiceKey: Key<T>,
   private val extraDependencies: Set<Key<*>>
 ) : KAbstractModule() {
-
   override fun configure() {
     // Register a wrapper around the service with the service manager. The wrapper delegates
     // to the underlying service for all calls except [DependentService.consumedKeys], which

--- a/misk-testing/src/test/kotlin/misk/service/ServiceTestingModuleTest.kt
+++ b/misk-testing/src/test/kotlin/misk/service/ServiceTestingModuleTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package misk.service
 
 import com.google.common.util.concurrent.AbstractIdleService
@@ -10,12 +12,14 @@ import misk.MiskTestingServiceModule
 import misk.inject.KAbstractModule
 import misk.inject.getInstance
 import misk.inject.keyOf
+import org.junit.Ignore
 import org.junit.jupiter.api.Test
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
 import javax.inject.Inject
 import javax.inject.Singleton
 
+@Ignore("ServiceTestingModule is deprecated.")
 internal class ServiceTestingModuleTest {
   @Test fun serviceTestModuleAddsTestSpecificDependency() {
     val injector = Guice.createInjector(object : KAbstractModule() {


### PR DESCRIPTION
`ServiceTestingModule` appears to have existed to accomodate for
deficiencies in service-dependency declaration at testing sites.
This module no longer needs to exist, as `misk.ServiceModule` provides a
Guice-compatible API which can be used to express full service
dependency graphs.