### PR TITLE
Provision Services as requested by the service graph

### DIFF
--- a/misk/src/main/kotlin/misk/CoordinatedService2.kt
+++ b/misk/src/main/kotlin/misk/CoordinatedService2.kt
@@ -5,6 +5,7 @@ import com.google.common.util.concurrent.MoreExecutors
 import com.google.common.util.concurrent.Service
 import com.google.common.util.concurrent.Service.Listener
 import com.google.common.util.concurrent.Service.State
+import javax.inject.Provider
 
 /**
  * Services in Misk can depend on other services.
@@ -55,7 +56,14 @@ import com.google.common.util.concurrent.Service.State
  * This Service will stall in the `STARTING` state until all upstream services are `RUNNING`.
  * Symmetrically it stalls in the `STOPPING` state until all dependent services are `TERMINATED`.
  */
-internal class CoordinatedService2(val service: Service) : AbstractService() {
+internal class CoordinatedService2(
+    private val serviceProvider : Provider<out Service>
+) : AbstractService() {
+
+  val service : Service by lazy {
+    serviceProvider.get()
+  }
+
   /** Services that start before this. */
   private val directDependsOn = mutableSetOf<CoordinatedService2>()
 

--- a/misk/src/main/kotlin/misk/MiskServiceModule.kt
+++ b/misk/src/main/kotlin/misk/MiskServiceModule.kt
@@ -110,7 +110,7 @@ class MiskCommonServiceModule : KAbstractModule() {
 
     // Support the new ServiceModule API.
     for (entry in serviceEntries) {
-      builder.addService(entry.key, entry.provider)
+      builder.addService(entry.key, injector.getProvider(entry.key))
     }
     for (edge in dependencies) {
       builder.addDependency(dependent = edge.dependent, dependsOn = edge.dependsOn)
@@ -182,7 +182,7 @@ class MiskCommonServiceModule : KAbstractModule() {
 
 internal data class DependencyEdge(val dependent: Key<*>, val dependsOn: Key<*>)
 internal data class EnhancementEdge(val toBeEnhanced: Key<*>, val enhancement: Key<*>)
-internal data class ServiceEntry(val key: Key<out Service>, val provider: Provider<out Service>)
+internal data class ServiceEntry(val key: Key<out Service>)
 
 inline fun <reified T : Service> ServiceModule(qualifier: KClass<out Annotation>? = null) =
     ServiceModule(T::class.toKey(qualifier))
@@ -220,7 +220,7 @@ class ServiceModule(
   val enhancedBy: List<Key<out Service>> = listOf()
 ) : KAbstractModule() {
   override fun configure() {
-    multibind<ServiceEntry>().toInstance(ServiceEntry(key, getProvider(key)))
+    multibind<ServiceEntry>().toInstance(ServiceEntry(key))
 
     for (dependsOnKey in dependsOn) {
       multibind<DependencyEdge>().toInstance(

--- a/misk/src/main/kotlin/misk/MiskServiceModule.kt
+++ b/misk/src/main/kotlin/misk/MiskServiceModule.kt
@@ -110,8 +110,7 @@ class MiskCommonServiceModule : KAbstractModule() {
 
     // Support the new ServiceModule API.
     for (entry in serviceEntries) {
-      val service = injector.getInstance(entry.key)
-      builder.addService(entry.key, service)
+      builder.addService(entry.key, entry.provider)
     }
     for (edge in dependencies) {
       builder.addDependency(dependent = edge.dependent, dependsOn = edge.dependsOn)
@@ -183,7 +182,7 @@ class MiskCommonServiceModule : KAbstractModule() {
 
 internal data class DependencyEdge(val dependent: Key<*>, val dependsOn: Key<*>)
 internal data class EnhancementEdge(val toBeEnhanced: Key<*>, val enhancement: Key<*>)
-internal data class ServiceEntry(val key: Key<out Service>)
+internal data class ServiceEntry(val key: Key<out Service>, val provider: Provider<out Service>)
 
 inline fun <reified T : Service> ServiceModule(qualifier: KClass<out Annotation>? = null) =
     ServiceModule(T::class.toKey(qualifier))
@@ -221,8 +220,7 @@ class ServiceModule(
   val enhancedBy: List<Key<out Service>> = listOf()
 ) : KAbstractModule() {
   override fun configure() {
-    requireBinding(key)
-    multibind<ServiceEntry>().toInstance(ServiceEntry(key))
+    multibind<ServiceEntry>().toInstance(ServiceEntry(key, getProvider(key)))
 
     for (dependsOnKey in dependsOn) {
       multibind<DependencyEdge>().toInstance(

--- a/misk/src/main/kotlin/misk/ServiceGraphBuilder.kt
+++ b/misk/src/main/kotlin/misk/ServiceGraphBuilder.kt
@@ -5,6 +5,7 @@ import com.google.common.util.concurrent.Service
 import com.google.common.util.concurrent.ServiceManager
 import com.google.inject.Key
 import misk.CoordinatedService2.Companion.CycleValidity
+import javax.inject.Provider
 
 /**
  * Builds a graph of [CoordinatedService2]s which defer start up and shut down until their dependent
@@ -22,10 +23,14 @@ class ServiceGraphBuilder {
    * Keys must be unique. If a key is reused, then the original key-service pair will be replaced.
    */
   fun addService(key: Key<*>, service: Service) {
+    addService(key, Provider<Service> { service })
+  }
+
+  fun addService(key: Key<*>, serviceProvider: Provider<out Service>) {
     check(serviceMap[key] == null) {
       "Service $key cannot be registered more than once"
     }
-    serviceMap[key] = CoordinatedService2(service)
+    serviceMap[key] = CoordinatedService2(serviceProvider)
   }
 
   /**

--- a/misk/src/test/kotlin/misk/ServiceGraphBuilderTest.kt
+++ b/misk/src/test/kotlin/misk/ServiceGraphBuilderTest.kt
@@ -3,6 +3,7 @@ package misk
 import com.google.common.util.concurrent.AbstractService
 import com.google.common.util.concurrent.Service
 import com.google.inject.Key
+import com.google.inject.Provider
 import com.google.inject.name.Named
 import com.google.inject.name.Names
 import org.assertj.core.api.Assertions.assertThat
@@ -281,8 +282,12 @@ class ServiceGraphBuilderTest {
     val builder = newBuilderWithServices(target, listOf(keyA))
     val serviceManager = builder.build()
     serviceManager.startAsync()
-    val badEnhancer = CoordinatedService2(AppendingService(target, "bad enhancement"))
-    val badDependency = CoordinatedService2(AppendingService(target, "bad dependency"))
+    val badEnhancer = CoordinatedService2(Provider<Service> {
+      AppendingService(target, "bad enhancement")
+    })
+    val badDependency = CoordinatedService2(Provider<Service> {
+      AppendingService(target, "bad dependency")
+    })
 
     serviceManager.awaitHealthy()
 
@@ -303,8 +308,6 @@ class ServiceGraphBuilderTest {
         |stopping ${keyA.name}
         |""".trimMargin())
   }
-
-
 
   /**
    * Build a service graph with the named services. Configure the graph edges in [block], start the


### PR DESCRIPTION
`CoordinatedService2` now takes a `Provider<Service>` instead of a `Service` in its constructor. 

This allows for the services to be provisioned as requested by the coordinated boot-up order in the service graph.