### PR TITLE
Added marker interface for producer services

### DIFF
--- a/misk-events/src/main/kotlin/misk/events/ProducerService.kt
+++ b/misk-events/src/main/kotlin/misk/events/ProducerService.kt
@@ -1,0 +1,6 @@
+package misk.events
+
+import com.google.common.util.concurrent.Service
+
+/** Marker interface for services that are [Producer]s. **/
+interface ProducerService : Service

--- a/misk/src/main/kotlin/misk/clustering/ClusterService.kt
+++ b/misk/src/main/kotlin/misk/clustering/ClusterService.kt
@@ -2,5 +2,5 @@ package misk.clustering
 
 import com.google.common.util.concurrent.Service
 
-/** Marker interface for the toBeEnhanced that produces a [Cluster]. */
+/** Marker interface for the service that produces a [Cluster]. */
 interface ClusterService : Service


### PR DESCRIPTION
Required for things like a Kafka producer service to be registered with the service graph builder.

This also fixes a copy error in `ClusterService`.