### PR TITLE
Simplify service relationships in HibernateModule

### DIFF
--- a/misk-hibernate/src/main/kotlin/misk/hibernate/HibernateModule.kt
+++ b/misk-hibernate/src/main/kotlin/misk/hibernate/HibernateModule.kt
@@ -65,7 +65,7 @@ class HibernateModule(
       }
     }).asSingleton()
 
-    // Bind PingDataBaseService.
+    // Bind PingDatabaseService.
     bind(keyOf<PingDatabaseService>(qualifier)).toProvider(Provider<PingDatabaseService> {
       PingDatabaseService(config, environmentProvider.get())
     }).asSingleton()
@@ -91,24 +91,6 @@ class HibernateModule(
     }).asSingleton()
     install(ServiceModule<DataSourceService>(qualifier)
         .dependsOn<PingDatabaseService>(qualifier))
-
-    // Bind SessionFactoryService.
-    val entitiesProvider = getProvider(setOfType(HibernateEntity::class).toKey(qualifier))
-    val eventListenersProvider =
-        getProvider(setOfType(ListenerRegistration::class).toKey(qualifier))
-    val hibernateInjectorAccessProvider = getProvider(HibernateInjectorAccess::class.java)
-    val dataSourceProvider = getProvider(keyOf<DataSource>(qualifier))
-
-    bind(keyOf<SessionFactory>(qualifier))
-        .toProvider(keyOf<SessionFactoryService>(qualifier))
-        .asSingleton()
-    bind(keyOf<SessionFactoryService>(qualifier)).toProvider(Provider<SessionFactoryService> {
-      SessionFactoryService(qualifier, config, dataSourceProvider,
-          hibernateInjectorAccessProvider.get(),
-          entitiesProvider.get(), eventListenersProvider.get())
-    }).asSingleton()
-    install(ServiceModule<SessionFactoryService>(qualifier)
-        .dependsOn<DataSourceService>(qualifier))
 
     // Bind SchemaMigratorService.
     val transacterKey = Transacter::class.toKey(qualifier)
@@ -142,8 +124,7 @@ class HibernateModule(
           config
       )
     }).asSingleton()
-    install(ServiceModule<SchemaMigratorService>(qualifier)
-        .dependsOn<SessionFactoryService>(qualifier))
+    install(ServiceModule<SchemaMigratorService>(qualifier))
 
     // Bind SchemaValidatorService.
     val sessionFactoryServiceProvider = getProvider(keyOf<SessionFactoryService>(qualifier))
@@ -157,8 +138,27 @@ class HibernateModule(
           )
         }).asSingleton()
     install(ServiceModule<SchemaValidatorService>(qualifier)
-        .dependsOn<SchemaMigratorService>(qualifier)
-        .dependsOn<SessionFactoryService>(qualifier))
+        .dependsOn<SchemaMigratorService>(qualifier))
+
+    // Bind SessionFactoryService.
+    val entitiesProvider = getProvider(setOfType(HibernateEntity::class).toKey(qualifier))
+    val eventListenersProvider =
+        getProvider(setOfType(ListenerRegistration::class).toKey(qualifier))
+    val hibernateInjectorAccessProvider = getProvider(HibernateInjectorAccess::class.java)
+    val dataSourceProvider = getProvider(keyOf<DataSource>(qualifier))
+
+    bind(keyOf<SessionFactory>(qualifier))
+        .toProvider(keyOf<SessionFactoryService>(qualifier))
+        .asSingleton()
+    bind(keyOf<SessionFactoryService>(qualifier)).toProvider(Provider<SessionFactoryService> {
+      SessionFactoryService(qualifier, config, dataSourceProvider,
+          hibernateInjectorAccessProvider.get(),
+          entitiesProvider.get(), eventListenersProvider.get())
+    }).asSingleton()
+    install(ServiceModule<SessionFactoryService>(qualifier)
+        .enhancedBy<SchemaMigratorService>(qualifier)
+        .enhancedBy<SchemaValidatorService>(qualifier)
+        .dependsOn<DataSourceService>(qualifier))
 
     // Install other modules.
     install(object : HibernateEntityModule(qualifier) {

--- a/misk-hibernate/src/main/kotlin/misk/hibernate/HibernateModule.kt
+++ b/misk-hibernate/src/main/kotlin/misk/hibernate/HibernateModule.kt
@@ -140,7 +140,7 @@ class HibernateModule(
     install(ServiceModule<SchemaValidatorService>(qualifier)
         .dependsOn<SchemaMigratorService>(qualifier))
 
-    // Bind SessionFactoryService.
+    // Bind SessionFactoryService as implementation of TransacterService.
     val entitiesProvider = getProvider(setOfType(HibernateEntity::class).toKey(qualifier))
     val eventListenersProvider =
         getProvider(setOfType(ListenerRegistration::class).toKey(qualifier))
@@ -150,12 +150,13 @@ class HibernateModule(
     bind(keyOf<SessionFactory>(qualifier))
         .toProvider(keyOf<SessionFactoryService>(qualifier))
         .asSingleton()
+    bind(keyOf<TransacterService>(qualifier)).to(keyOf<SessionFactoryService>(qualifier))
     bind(keyOf<SessionFactoryService>(qualifier)).toProvider(Provider<SessionFactoryService> {
       SessionFactoryService(qualifier, config, dataSourceProvider,
           hibernateInjectorAccessProvider.get(),
           entitiesProvider.get(), eventListenersProvider.get())
     }).asSingleton()
-    install(ServiceModule<SessionFactoryService>(qualifier)
+    install(ServiceModule<TransacterService>(qualifier)
         .enhancedBy<SchemaMigratorService>(qualifier)
         .enhancedBy<SchemaValidatorService>(qualifier)
         .dependsOn<DataSourceService>(qualifier))

--- a/misk-hibernate/src/main/kotlin/misk/hibernate/SessionFactoryService.kt
+++ b/misk-hibernate/src/main/kotlin/misk/hibernate/SessionFactoryService.kt
@@ -40,7 +40,7 @@ internal class SessionFactoryService(
   private val hibernateInjectorAccess: HibernateInjectorAccess,
   private val entityClasses: Set<HibernateEntity> = setOf(),
   private val listenerRegistrations: Set<ListenerRegistration> = setOf()
-) : AbstractIdleService(), Provider<SessionFactory> {
+) : AbstractIdleService(), Provider<SessionFactory>, TransacterService {
   private var sessionFactory: SessionFactory? = null
 
   lateinit var hibernateMetadata: Metadata

--- a/misk-hibernate/src/main/kotlin/misk/hibernate/TransacterService.kt
+++ b/misk-hibernate/src/main/kotlin/misk/hibernate/TransacterService.kt
@@ -1,0 +1,18 @@
+package misk.hibernate
+
+import com.google.common.util.concurrent.Service
+
+/**
+ * Marker interface for services that provide database transactors.
+ *
+ * Services that require a database connection should depend on this interface when they are
+ * installed in a module.
+ *
+ * e.g.
+ *
+ * ```
+ * install(ServiceModule<MoviesService>()
+ *     .dependsOn<TransacterService>(Movies::class))
+ * ```
+ **/
+interface TransacterService : Service

--- a/misk-hibernate/src/test/kotlin/misk/hibernate/SchemaMigratorTest.kt
+++ b/misk-hibernate/src/test/kotlin/misk/hibernate/SchemaMigratorTest.kt
@@ -68,6 +68,8 @@ internal class SchemaMigratorTest {
       install(ServiceModule<PingDatabaseService>(Movies::class)
           .dependsOn<StartVitessService>(Movies::class))
 
+      install(ServiceModule<DropTablesService>())
+
       val dataSourceService =
           DataSourceService(Movies::class, config.data_source, defaultEnv, emptySet())
       bind(keyOf<DataSourceService>(Movies::class)).toInstance(dataSourceService)
@@ -85,10 +87,8 @@ internal class SchemaMigratorTest {
       val sessionFactoryKey = keyOf<SessionFactory>(Movies::class)
       val sessionFactoryProvider = getProvider(sessionFactoryKey)
       install(ServiceModule<SessionFactoryService>(Movies::class)
+          .enhancedBy<DropTablesService>()
           .dependsOn<DataSourceService>(Movies::class))
-
-      install(ServiceModule<DropTablesService>()
-          .dependsOn<SessionFactoryService>(Movies::class))
 
       val transacterKey = keyOf<Transacter>(Movies::class)
       bind(transacterKey).toProvider(object : Provider<Transacter> {

--- a/misk-hibernate/src/test/kotlin/misk/hibernate/SchemaMigratorTest.kt
+++ b/misk-hibernate/src/test/kotlin/misk/hibernate/SchemaMigratorTest.kt
@@ -86,7 +86,9 @@ internal class SchemaMigratorTest {
       bind<SessionFactory>().annotatedWith<Movies>().toProvider(sessionFactoryServiceKey)
       val sessionFactoryKey = keyOf<SessionFactory>(Movies::class)
       val sessionFactoryProvider = getProvider(sessionFactoryKey)
-      install(ServiceModule<SessionFactoryService>(Movies::class)
+
+      bind(keyOf<TransacterService>(Movies::class)).to(keyOf<SessionFactoryService>(Movies::class))
+      install(ServiceModule<TransacterService>(Movies::class)
           .enhancedBy<DropTablesService>()
           .dependsOn<DataSourceService>(Movies::class))
 

--- a/misk-hibernate/src/test/kotlin/misk/hibernate/SchemaValidatorTest.kt
+++ b/misk-hibernate/src/test/kotlin/misk/hibernate/SchemaValidatorTest.kt
@@ -46,31 +46,25 @@ class SchemaValidatorTest {
   inner class TestModule : KAbstractModule() {
     override fun configure() {
       install(MiskTestingServiceModule())
+
       val qualifier = ValidationDb::class
 
       val dataSourceService =
           DataSourceService(qualifier, config.data_source, Environment.TESTING, emptySet())
 
       val injectorServiceProvider = getProvider(HibernateInjectorAccess::class.java)
-      val sessionFactoryServiceKey = SessionFactoryService::class.toKey(qualifier)
 
-      sessionFactoryService = getProvider(sessionFactoryServiceKey)
+      sessionFactoryService = getProvider(keyOf<SessionFactoryService>(qualifier))
 
-      val entitiesKey = setOfType(HibernateEntity::class).toKey(qualifier)
-      val entitiesProvider = getProvider(entitiesKey)
+      val entitiesProvider = getProvider(setOfType(HibernateEntity::class).toKey(qualifier))
 
-      val sessionFactoryKey = SessionFactory::class.toKey(qualifier)
-      val sessionFactoryProvider = getProvider(sessionFactoryKey)
+      val sessionFactoryProvider = getProvider(keyOf<SessionFactory>(qualifier))
+      bind<SessionFactory>()
+          .annotatedWith<ValidationDb>()
+          .toProvider(keyOf<SessionFactoryService>(qualifier))
 
-      val transacterKey = Transacter::class.toKey(qualifier)
-      val transacterProvider = getProvider(transacterKey)
-
-      val schemaMigratorKey = SchemaMigrator::class.toKey(qualifier)
-      val schemaMigratorProvider = getProvider(schemaMigratorKey)
-
-      bind<SessionFactory>().annotatedWith<ValidationDb>().toProvider(sessionFactoryServiceKey)
-
-      bind(transacterKey).toProvider(object : Provider<Transacter> {
+      val transacterProvider = getProvider(keyOf<Transacter>(qualifier))
+      bind(keyOf<Transacter>(qualifier)).toProvider(object : Provider<Transacter> {
         @Inject lateinit var queryTracingListener: QueryTracingListener
         @com.google.inject.Inject(optional = true) val tracer: Tracer? = null
         override fun get(): RealTransacter = RealTransacter(
@@ -82,7 +76,8 @@ class SchemaValidatorTest {
         )
       }).asSingleton()
 
-      bind(schemaMigratorKey).toProvider(object : Provider<SchemaMigrator> {
+      val schemaMigratorProvider = getProvider(keyOf<SchemaMigrator>(qualifier))
+      bind(keyOf<SchemaMigrator>(qualifier)).toProvider(object : Provider<SchemaMigrator> {
         @Inject lateinit var resourceLoader: ResourceLoader
         override fun get(): SchemaMigrator = SchemaMigrator(
             qualifier,
@@ -121,7 +116,8 @@ class SchemaValidatorTest {
         SchemaMigratorService(Environment.TESTING, schemaMigratorProvider, config.data_source)
       }).asSingleton()
 
-      bind(sessionFactoryServiceKey).toProvider(Provider<SessionFactoryService> {
+      bind(keyOf<TransacterService>(qualifier)).to(keyOf<SessionFactoryService>(qualifier))
+      bind(keyOf<SessionFactoryService>(qualifier)).toProvider(Provider<SessionFactoryService> {
         SessionFactoryService(
             qualifier,
             config.data_source,
@@ -129,7 +125,7 @@ class SchemaValidatorTest {
             injectorServiceProvider.get(),
             entitiesProvider.get())
       }).asSingleton()
-      install(ServiceModule<SessionFactoryService>(qualifier)
+      install(ServiceModule<TransacterService>(qualifier)
           .enhancedBy<SchemaMigratorService>(qualifier)
           .dependsOn<DataSourceService>(qualifier))
     }

--- a/misk-hibernate/src/test/kotlin/misk/hibernate/SchemaValidatorTest.kt
+++ b/misk-hibernate/src/test/kotlin/misk/hibernate/SchemaValidatorTest.kt
@@ -116,6 +116,11 @@ class SchemaValidatorTest {
       bind(keyOf<DataSourceService>(qualifier)).toInstance(dataSourceService)
       bind<DataSource>().annotatedWith<ValidationDb>().toProvider(dataSourceService)
 
+      install(ServiceModule<SchemaMigratorService>(qualifier))
+      bind(keyOf<SchemaMigratorService>(qualifier)).toProvider(Provider<SchemaMigratorService> {
+        SchemaMigratorService(Environment.TESTING, schemaMigratorProvider, config.data_source)
+      }).asSingleton()
+
       bind(sessionFactoryServiceKey).toProvider(Provider<SessionFactoryService> {
         SessionFactoryService(
             qualifier,
@@ -125,13 +130,8 @@ class SchemaValidatorTest {
             entitiesProvider.get())
       }).asSingleton()
       install(ServiceModule<SessionFactoryService>(qualifier)
+          .enhancedBy<SchemaMigratorService>(qualifier)
           .dependsOn<DataSourceService>(qualifier))
-
-      install(ServiceModule<SchemaMigratorService>(qualifier)
-          .dependsOn<SessionFactoryService>(qualifier))
-      bind(keyOf<SchemaMigratorService>(qualifier)).toProvider(Provider<SchemaMigratorService> {
-        SchemaMigratorService(Environment.TESTING, schemaMigratorProvider, config.data_source)
-      }).asSingleton()
     }
   }
 


### PR DESCRIPTION
Changes the dependency graph declaration (but not the graph itself!) to have `TransactorService` enhanced by `SchemaValidatorService` and `SchemaMigratorService`. Since `SessionFactoryService` is an internal class, I've introduced the public interface `TransactorService` to act as a level of indirection. Services that need a database connection can depend on `TransactorService` and an instance of `SessionFactoryService` will be started for them.

This will allow us to avoid the semantic annoyance of having services directly depend on `SchemaMigratorService` when all they care about is acquiring a connection to the database.

e.g., in tests, `DropTableService` is an enhancement of `TransactorService`.

The following are equivalent:

```kotlin
// Old World
install(ServiceModule<MoviesService>()
    .dependsOn<SchemaMigratorService>(Movies::class))
```

```kotlin
// New World:
// We really want to depend on a SessionFactoryService and have SchemaMigratorService
// start for us. So now we depend on TransacterService instead.
install(ServiceModule<MoviesService>()
    .dependsOn<TransacterService>(Movies::class))
```

With these changes, nothing but internal classes need to care about `SchemaMigratorService` or `SchemaValidatorService`, so both can be demoted to internal classes at a later point.