### PR TITLE
Split FormValueParameterExtractorFactory into 3 parts.

### DIFF
--- a/misk/src/main/kotlin/misk/web/extractors/FormAdapter.kt
+++ b/misk/src/main/kotlin/misk/web/extractors/FormAdapter.kt
@@ -1,0 +1,77 @@
+package misk.web.extractors
+
+import misk.exceptions.requireRequest
+import misk.web.FormField
+import kotlin.reflect.KClass
+import kotlin.reflect.KFunction
+import kotlin.reflect.KParameter
+import kotlin.reflect.full.findAnnotation
+import kotlin.reflect.full.primaryConstructor
+
+/**
+ * Binds a Kotlin class to a [FormData]. All fields are supplied to the class constructor which must
+ * be either named directly or annotated [FormField].
+ */
+internal class FormAdapter<T : Any> private constructor(
+  private val constructor: KFunction<T>,
+  private val fields: List<Field>
+) {
+  internal fun fromFormData(formData: FormData): T {
+    val parameterMap = mutableMapOf<KParameter, Any?>()
+    for (field in fields) {
+      val values = formData[field.name]
+      if (values.isEmpty() && field.optional) continue
+      requireRequest(values.isNotEmpty() || field.nullable) {
+        "${field.name} is a required value"
+      }
+      parameterMap[field.kParameter] = field.valuesToParameter(values)
+    }
+    return constructor.callBy(parameterMap)
+  }
+
+  /** Binds a form field to a constructor parameter. */
+  private data class Field(
+    val kParameter: KParameter,
+    val name: String,
+    val optional: Boolean,
+    val nullable: Boolean,
+    val isList: Boolean,
+    val converter: StringConverter?
+  ) {
+    fun valuesToParameter(values: Collection<String>): Any? {
+      if (isList) {
+        return values.map { converter?.invoke(it) }.toList()
+      } else {
+        val first = values.firstOrNull() ?: return null
+        return converter?.invoke(first)
+      }
+    }
+  }
+
+  companion object {
+    /** Returns an adapter for [kClass], or null if it cannot be adapted. */
+    fun <T : Any> create(kClass: KClass<T>): FormAdapter<T>? {
+      val constructor = kClass.primaryConstructor ?: return null
+      val fields = constructor.parameters.map { it.toField() }
+      return FormAdapter(constructor, fields)
+    }
+
+    private fun KParameter.toField(): Field {
+      val annotation = findAnnotation<FormField>()
+      val name = annotation?.name?.toLowerCase()
+          ?: name?.toLowerCase()
+          ?: throw IllegalStateException("cannot introspect parameter name")
+
+      // TODO(jwilson): explode if no converter is found. As is we just replace values with nulls.
+      val isList = type.classifier?.equals(List::class) ?: false
+      return Field(
+          this,
+          name,
+          isOptional,
+          type.isMarkedNullable,
+          isList,
+          converterFor(if (isList) type.arguments.first().type!! else type)
+      )
+    }
+  }
+}

--- a/misk/src/main/kotlin/misk/web/extractors/FormData.kt
+++ b/misk/src/main/kotlin/misk/web/extractors/FormData.kt
@@ -1,0 +1,43 @@
+package misk.web.extractors
+
+import com.google.common.collect.ImmutableMultimap
+import misk.exceptions.requireRequest
+import okio.BufferedSource
+import java.net.URLDecoder
+
+/**
+ * An HTML form like `application/x-www-form-urlencoded`.
+ *
+ * TODO(jwilson): combine with OkHttp's FormBody.
+ */
+internal data class FormData(
+  val map: ImmutableMultimap<String, String>
+) {
+  operator fun get(name: String): Collection<String> = map[name]
+
+  companion object {
+    fun decode(source: BufferedSource): FormData {
+      val result = ImmutableMultimap.builder<String, String>()
+
+      while (!source.exhausted()) {
+        var keyValueEnd = source.indexOf('&'.toByte())
+        if (keyValueEnd == -1L) keyValueEnd = source.buffer.size
+
+        val keyEnd = source.indexOf('='.toByte(), 0, keyValueEnd)
+        requireRequest(keyEnd != 1L) { "invalid form encoding" }
+
+        val key = source.readUtf8(keyEnd).urlDecode().toLowerCase()
+        source.readByte() // Consume '='.
+
+        val value = source.readUtf8(keyValueEnd - keyEnd - 1).urlDecode()
+        result.put(key, value)
+
+        if (!source.exhausted()) source.readByte() // Consume '&'.
+      }
+
+      return FormData(result.build())
+    }
+
+    private fun String.urlDecode(): String = URLDecoder.decode(this, "utf-8")
+  }
+}


### PR DESCRIPTION
FormValueParameterExtractorFactory: glue to move form data into Action parameters
FormData: a model of form data
FormAdapter: glue to turn form data into an instance of a Kotlin class

Previously these were all in FormValueParameterExtractorFactory and that felt awkward.