### PR TITLE
Release leases if the cluster weight is 0

### DIFF
--- a/misk-zookeeper/src/main/kotlin/misk/clustering/zookeeper/ZkLease.kt
+++ b/misk-zookeeper/src/main/kotlin/misk/clustering/zookeeper/ZkLease.kt
@@ -2,6 +2,7 @@ package misk.clustering.zookeeper
 
 import misk.clustering.NoMembersAvailableException
 import misk.clustering.lease.Lease
+import misk.clustering.weights.ClusterWeightProvider
 import misk.logging.getLogger
 import org.apache.zookeeper.CreateMode
 import org.apache.zookeeper.KeeperException
@@ -37,6 +38,7 @@ internal class ZkLease(
   ownerName: String,
   private val manager: ZkLeaseManager,
   private val leaseResourceName: String,
+  private val clusterWeight: ClusterWeightProvider,
   override val name: String
 ) : Lease {
 
@@ -203,6 +205,7 @@ internal class ZkLease(
       null
     }
     return desiredLeaseOwner?.name == clusterSnapshot.self.name
+        && clusterWeight.get() > 0
   }
 
   /** @return true if the lease node exists in zk */

--- a/misk-zookeeper/src/test/kotlin/misk/clustering/zookeeper/ZkLeaseTestModule.kt
+++ b/misk-zookeeper/src/test/kotlin/misk/clustering/zookeeper/ZkLeaseTestModule.kt
@@ -3,6 +3,8 @@ package misk.clustering.zookeeper
 import com.google.inject.Provides
 import com.google.inject.Singleton
 import misk.clustering.fake.FakeClusterModule
+import misk.clustering.weights.FakeClusterWeight
+import misk.clustering.weights.FakeClusterWeightModule
 import misk.concurrent.ExplicitReleaseDelayQueue
 import misk.config.AppName
 import misk.inject.KAbstractModule
@@ -17,7 +19,7 @@ internal class ZkLeaseTestModule : KAbstractModule() {
     install(FakeClusterModule())
     install(ZkTestModule(ForZkLease::class))
     install(ZkLeaseManagerModule())
-
+    install(FakeClusterWeightModule())
   }
 
   @Provides @ForZkLease @Singleton

--- a/misk/src/main/kotlin/misk/clustering/weights/ActiveClusterWeight.kt
+++ b/misk/src/main/kotlin/misk/clustering/weights/ActiveClusterWeight.kt
@@ -1,0 +1,22 @@
+package misk.clustering.weights
+
+import misk.inject.KAbstractModule
+
+/**
+ * A static [ClusterWeightProvider] that always returns 100
+ */
+class ActiveClusterWeight : ClusterWeightProvider {
+
+  override fun get(): Int {
+    return 100
+  }
+}
+
+/**
+ * Provides an [ActiveClusterWeight]
+ */
+class ActiveClusterWeightModule : KAbstractModule() {
+  override fun configure() {
+    bind<ClusterWeightProvider>().to<ActiveClusterWeight>()
+  }
+}

--- a/misk/src/main/kotlin/misk/clustering/weights/ClusterWeightProvider.kt
+++ b/misk/src/main/kotlin/misk/clustering/weights/ClusterWeightProvider.kt
@@ -1,0 +1,15 @@
+package misk.clustering.weights
+
+/**
+ * Provides the current weight assigned to the cluster.
+ *
+ * A weight value is between 0 and 100 to indicate how much traffic a cluster should handle.
+ * Typically an active-passive setup has 1 active cluster with 100 and 1 passive cluster with 0.
+ *
+ * If your application does not require dynamic cluster weights, you can use the static
+ * [ActiveClusterWeight].
+ */
+interface ClusterWeightProvider {
+
+  fun get(): Int
+}

--- a/misk/src/main/kotlin/misk/clustering/weights/FakeClusterWeight.kt
+++ b/misk/src/main/kotlin/misk/clustering/weights/FakeClusterWeight.kt
@@ -1,0 +1,30 @@
+package misk.clustering.weights
+
+import misk.inject.KAbstractModule
+
+/**
+ * A [ClusterWeightProvider] for testing
+ */
+class FakeClusterWeight : ClusterWeightProvider {
+
+  private var weight = 100
+
+  override fun get(): Int {
+    return weight
+  }
+
+  fun setClusterWeight(weight : Int) {
+    this.weight = weight
+  }
+}
+
+/**
+ * Provides a [FakeClusterWeight] for testing
+ */
+class FakeClusterWeightModule : KAbstractModule() {
+  override fun configure() {
+    val fake = FakeClusterWeight()
+    bind<FakeClusterWeight>().toInstance(fake)
+    bind<ClusterWeightProvider>().toInstance(fake)
+  }
+}


### PR DESCRIPTION
This allows applications to run in an Active-Passive mode. If the
current weight for a cluster is 0, leases are not acquired or released
if already acquired. This allows an application to only run leased
background tasks in the Active region.

This iteration requires misk users to provide their own implementation
for ClusterWeightProvider. SQ services will use a global ZK impl, which
we could consider contributing as well in the future.